### PR TITLE
Use <abbr /> for DETMER

### DIFF
--- a/frontend/views/pages/cfb/team.ejs
+++ b/frontend/views/pages/cfb/team.ejs
@@ -8,7 +8,7 @@ function getNumberWithOrdinal(n) {
 }
 
 function injectDetmerSpan() {
-    return `<span title="Stands for 'Downfield Eventful Throwing Metric Encouraging Ripping it'. Built to find the most sicko QB performances. Developed by the Moon Crew Discord & @SickosCommittee on Twitter.">DETMER</span>`;
+    return `<abbr title="Stands for 'Downfield Eventful Throwing Metric Encouraging Ripping it'. Built to find the most sicko QB performances. Developed by the Moon Crew Discord & @SickosCommittee on Twitter.">DETMER</abbr>`;
 }
 
 function roundNumber(value, power10, fixed) {


### PR DESCRIPTION
Underlines and uses a ? cursor on mouseover, making it clearer that you
can hover over it for an explanation. Minor usability thing, and might
be nice to do this for all glossary metrics with pulling the definition
from the terms file.
