### PR TITLE
Enable Stats button by checking delayed games for `hasLastPlay`

### DIFF
--- a/frontend/views/pages/cfb/game_thumb.ejs
+++ b/frontend/views/pages/cfb/game_thumb.ejs
@@ -228,7 +228,7 @@ const CONFERENCE_MAP = {
                 <% if (game.status.type.name.includes("STATUS_SCHEDULED")) { %>
                     <a class="btn btn-sm btn-outline-primary" role="button" href="/cfb/game/<%= game.id %>">Preview</a>
                 <% } else { %>
-                    <a class="btn btn-sm btn-outline-primary <%= (game.status.type.name.includes("STATUS_DELAYED") || game.status.type.detail.includes("Cancel") || game.status.type.detail.includes("Postpone") || (game.status.type.name.includes("STATUS_IN_PROGRESS") && !hasLastPlay)) ? "disabled" : "" %>" role="button" href="/cfb/game/<%= game.id %>">Stats</a>
+                    <a class="btn btn-sm btn-outline-primary <%= ((game.status.type.name.includes("STATUS_DELAYED") && !hasLastPlay) || game.status.type.detail.includes("Cancel") || game.status.type.detail.includes("Postpone") || (game.status.type.name.includes("STATUS_IN_PROGRESS") && !hasLastPlay)) ? "disabled" : "" %>" role="button" href="/cfb/game/<%= game.id %>">Stats</a>
                 <% } %>
             </div>
             <div class="text-right">


### PR DESCRIPTION
Add this check when the status is delayed. This has the effect of enabling the **Stats** button when games start and are then delayed. It does not enable the button if the game never started.

Thanks to mother nature, I was able to test this against live data!

<img width="679" alt="Screenshot 2023-09-09 at 2 09 56 PM" src="https://github.com/saiemgilani/game-on-paper-app/assets/1958332/2ae578c2-ebde-492d-a3ec-2d9d31ae6946">

Closes #155 