### PR TITLE
Update python section to prepare for 0.0.36.2.46

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
   build-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: saiemgilani/game-on-paper-app
       - name: Publish Node container to GitHub
@@ -31,7 +31,7 @@ jobs:
   build-python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: saiemgilani/game-on-paper-app
       - name: Publish Python container to GitHub
@@ -47,7 +47,7 @@ jobs:
   build-redis:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: saiemgilani/game-on-paper-app
       - name: Publish Redis container to GitHub
@@ -77,7 +77,7 @@ jobs:
       - build-python
       - build-redis
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: saiemgilani/game-on-paper-app
       - name: Push updated docker-compose override file
@@ -90,7 +90,7 @@ jobs:
           localPath: "./docker-compose.do.yml"
           remotePath: "./docker-compose.yml"
       - name: Deploy package to DigitalOcean
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1
         env:
           GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12 AS base
+FROM python:3.14 AS base
 
 WORKDIR /root/src
 
@@ -14,6 +14,5 @@ WORKDIR /code
 COPY --from=pybuilder /root/.local /root/.local
 
 COPY . ./
-
 
 CMD python app.py

--- a/python/app.py
+++ b/python/app.py
@@ -5,7 +5,6 @@ from flask_logs import LogSetup
 from sportsdataverse.cfb.cfb_pbp import CFBPlayProcess
 import os
 import logging
-import pandas as pd
 import json
 
 app = Flask(__name__)
@@ -14,6 +13,7 @@ app.config["LOG_LEVEL"] = os.environ.get("LOG_LEVEL", "INFO")
 
 logs = LogSetup()
 logs.init_app(app)
+
 
 @app.after_request
 def after_request(response):
@@ -24,15 +24,16 @@ def after_request(response):
         dt.now(tz=tz.utc).strftime("%d/%b/%Y:%H:%M:%S.%f")[:-3],
         request.method,
         request.path,
-        response.status
+        response.status,
     )
     return response
 
-@app.route('/cfb/process', methods=['POST'])
+
+@app.route("/cfb/process", methods=["POST"])
 def process():
     try:
-        gameId = request.get_json(force=True)['gameId']
-        processed_data = CFBPlayProcess(gameId = gameId)
+        gameId = request.get_json(force=True)["gameId"]
+        processed_data = CFBPlayProcess(gameId=gameId)
         pbp = processed_data.espn_cfb_pbp()
         processed_data.run_processing_pipeline()
         tmp_json = processed_data.plays_json.to_json(orient="records")
@@ -40,135 +41,167 @@ def process():
 
         box = processed_data.create_box_score()
         bad_cols = [
-            'start.distance', 'start.yardLine', 'start.team.id', 'start.down', 'start.yardsToEndzone', 'start.posTeamTimeouts', 'start.defTeamTimeouts',
-            'start.shortDownDistanceText', 'start.possessionText', 'start.downDistanceText', 'start.pos_team_timeouts', 'start.def_pos_team_timeouts',
-            'clock.displayValue',
-            'type.id', 'type.text', 'type.abbreviation',
-            'end.distance', 'end.yardLine', 'end.team.id','end.down', 'end.yardsToEndzone', 'end.posTeamTimeouts','end.defTeamTimeouts',
-            'end.shortDownDistanceText', 'end.possessionText', 'end.downDistanceText', 'end.pos_team_timeouts', 'end.def_pos_team_timeouts',
-            'expectedPoints.before', 'expectedPoints.after', 'expectedPoints.added',
-            'winProbability.before', 'winProbability.after', 'winProbability.added',
-            'scoringType.displayName', 'scoringType.name', 'scoringType.abbreviation'
+            "start.distance",
+            "start.yardLine",
+            "start.team.id",
+            "start.down",
+            "start.yardsToEndzone",
+            "start.posTeamTimeouts",
+            "start.defTeamTimeouts",
+            "start.shortDownDistanceText",
+            "start.possessionText",
+            "start.downDistanceText",
+            "start.pos_team_timeouts",
+            "start.def_pos_team_timeouts",
+            "clock.displayValue",
+            "type.id",
+            "type.text",
+            "type.abbreviation",
+            "end.distance",
+            "end.yardLine",
+            "end.team.id",
+            "end.down",
+            "end.yardsToEndzone",
+            "end.posTeamTimeouts",
+            "end.defTeamTimeouts",
+            "end.shortDownDistanceText",
+            "end.possessionText",
+            "end.downDistanceText",
+            "end.pos_team_timeouts",
+            "end.def_pos_team_timeouts",
+            "expectedPoints.before",
+            "expectedPoints.after",
+            "expectedPoints.added",
+            "winProbability.before",
+            "winProbability.after",
+            "winProbability.added",
+            "scoringType.displayName",
+            "scoringType.name",
+            "scoringType.abbreviation",
         ]
         # clean records back into ESPN format
         for record in jsonified_df:
             record["clock"] = {
-                "displayValue" : record["clock.displayValue"],
-                "minutes" : record["clock.minutes"],
-                "seconds" : record["clock.seconds"]
+                "displayValue": record["clock.displayValue"],
+                "minutes": record["clock.minutes"],
+                "seconds": record["clock.seconds"],
             }
 
             record["type"] = {
-                "id" : record["type.id"],
-                "text" : record["type.text"],
-                "abbreviation" : record["type.abbreviation"],
+                "id": record["type.id"],
+                "text": record["type.text"],
+                "abbreviation": record["type.abbreviation"],
             }
             record["modelInputs"] = {
-                "start" : {
-                    "down" : record["start.down"],
-                    "distance" : record["start.distance"],
-                    "yardsToEndzone" : record["start.yardsToEndzone"],
+                "start": {
+                    "down": record["start.down"],
+                    "distance": record["start.distance"],
+                    "yardsToEndzone": record["start.yardsToEndzone"],
                     "TimeSecsRem": record["start.TimeSecsRem"],
-                    "adj_TimeSecsRem" : record["start.adj_TimeSecsRem"],
-                    "pos_score_diff" : record["pos_score_diff_start"],
-                    "posTeamTimeouts" : record["start.posTeamTimeouts"],
-                    "defTeamTimeouts" : record["start.defPosTeamTimeouts"],
-                    "ExpScoreDiff" : record["start.ExpScoreDiff"],
-                    "ExpScoreDiff_Time_Ratio" : record["start.ExpScoreDiff_Time_Ratio"],
-                    "spread_time" : record['start.spread_time'],
-                    "pos_team_receives_2H_kickoff": record["start.pos_team_receives_2H_kickoff"],
+                    "adj_TimeSecsRem": record["start.adj_TimeSecsRem"],
+                    "pos_score_diff": record["pos_score_diff_start"],
+                    "posTeamTimeouts": record["start.posTeamTimeouts"],
+                    "defTeamTimeouts": record["start.defPosTeamTimeouts"],
+                    "ExpScoreDiff": record["start.ExpScoreDiff"],
+                    "ExpScoreDiff_Time_Ratio": record["start.ExpScoreDiff_Time_Ratio"],
+                    "spread_time": record["start.spread_time"],
+                    "pos_team_receives_2H_kickoff": record[
+                        "start.pos_team_receives_2H_kickoff"
+                    ],
                     "is_home": record["start.is_home"],
-                    "period": record["period"]
+                    "period": record["period"],
                 },
-                "end" : {
-                    "down" : record["end.down"],
-                    "distance" : record["end.distance"],
-                    "yardsToEndzone" : record["end.yardsToEndzone"],
+                "end": {
+                    "down": record["end.down"],
+                    "distance": record["end.distance"],
+                    "yardsToEndzone": record["end.yardsToEndzone"],
                     "TimeSecsRem": record["end.TimeSecsRem"],
-                    "adj_TimeSecsRem" : record["end.adj_TimeSecsRem"],
-                    "posTeamTimeouts" : record["end.posTeamTimeouts"],
-                    "defTeamTimeouts" : record["end.defPosTeamTimeouts"],
-                    "pos_score_diff" : record["pos_score_diff_end"],
-                    "ExpScoreDiff" : record["end.ExpScoreDiff"],
-                    "ExpScoreDiff_Time_Ratio" : record["end.ExpScoreDiff_Time_Ratio"],
-                    "spread_time" : record['end.spread_time'],
-                    "pos_team_receives_2H_kickoff": record["end.pos_team_receives_2H_kickoff"],
+                    "adj_TimeSecsRem": record["end.adj_TimeSecsRem"],
+                    "posTeamTimeouts": record["end.posTeamTimeouts"],
+                    "defTeamTimeouts": record["end.defPosTeamTimeouts"],
+                    "pos_score_diff": record["pos_score_diff_end"],
+                    "ExpScoreDiff": record["end.ExpScoreDiff"],
+                    "ExpScoreDiff_Time_Ratio": record["end.ExpScoreDiff_Time_Ratio"],
+                    "spread_time": record["end.spread_time"],
+                    "pos_team_receives_2H_kickoff": record[
+                        "end.pos_team_receives_2H_kickoff"
+                    ],
                     "is_home": record["end.is_home"],
-                    "period": record["period"]
-                }
+                    "period": record["period"],
+                },
             }
 
             record["expectedPoints"] = {
-                "before" : record["EP_start"],
-                "after" : record["EP_end"],
-                "added" : record["EPA"]
+                "before": record["EP_start"],
+                "after": record["EP_end"],
+                "added": record["EPA"],
             }
 
             record["winProbability"] = {
-                "before" : record["wp_before"],
-                "after" : record["wp_after"],
-                "added" : record["wpa"]
+                "before": record["wp_before"],
+                "after": record["wp_after"],
+                "added": record["wpa"],
             }
 
             record["start"] = {
-                "team" : {
-                    "id" : record["start.team.id"],
+                "team": {
+                    "id": record["start.team.id"],
                 },
                 "pos_team": {
-                    "id" : record["start.pos_team.id"],
-                    "name" : record["start.pos_team.name"]
+                    "id": record["start.pos_team.id"],
+                    "name": record["start.pos_team.name"],
                 },
                 "def_pos_team": {
-                    "id" : record["start.def_pos_team.id"],
-                    "name" : record["start.def_pos_team.name"],
+                    "id": record["start.def_pos_team.id"],
+                    "name": record["start.def_pos_team.name"],
                 },
-                "distance" : record["start.distance"],
-                "yardLine" : record["start.yardLine"],
-                "down" : record["start.down"],
-                "yardsToEndzone" : record["start.yardsToEndzone"],
-                "homeScore" : record["start.homeScore"],
-                "awayScore" : record["start.awayScore"],
-                "pos_team_score" : record["start.pos_team_score"],
-                "def_pos_team_score" : record["start.def_pos_team_score"],
-                "pos_score_diff" : record["pos_score_diff_start"],
-                "posTeamTimeouts" : record["start.posTeamTimeouts"],
-                "defTeamTimeouts" : record["start.defPosTeamTimeouts"],
-                "ExpScoreDiff" : record["start.ExpScoreDiff"],
-                "ExpScoreDiff_Time_Ratio" : record["start.ExpScoreDiff_Time_Ratio"],
-                "shortDownDistanceText" : record["start.shortDownDistanceText"],
-                "possessionText" : record["start.possessionText"],
-                "downDistanceText" : record["start.downDistanceText"],
-                "posTeamSpread" : record["start.pos_team_spread"]
+                "distance": record["start.distance"],
+                "yardLine": record["start.yardLine"],
+                "down": record["start.down"],
+                "yardsToEndzone": record["start.yardsToEndzone"],
+                "homeScore": record["start.homeScore"],
+                "awayScore": record["start.awayScore"],
+                "pos_team_score": record["start.pos_team_score"],
+                "def_pos_team_score": record["start.def_pos_team_score"],
+                "pos_score_diff": record["pos_score_diff_start"],
+                "posTeamTimeouts": record["start.posTeamTimeouts"],
+                "defTeamTimeouts": record["start.defPosTeamTimeouts"],
+                "ExpScoreDiff": record["start.ExpScoreDiff"],
+                "ExpScoreDiff_Time_Ratio": record["start.ExpScoreDiff_Time_Ratio"],
+                "shortDownDistanceText": record["start.shortDownDistanceText"],
+                "possessionText": record["start.possessionText"],
+                "downDistanceText": record["start.downDistanceText"],
+                "posTeamSpread": record["start.pos_team_spread"],
             }
 
             record["end"] = {
-                "team" : {
-                    "id" : record["end.team.id"],
+                "team": {
+                    "id": record["end.team.id"],
                 },
                 "pos_team": {
-                    "id" : record["end.pos_team.id"],
-                    "name" : record["end.pos_team.name"],
+                    "id": record["end.pos_team.id"],
+                    "name": record["end.pos_team.name"],
                 },
                 "def_pos_team": {
-                    "id" : record["end.def_pos_team.id"],
-                    "name" : record["end.def_pos_team.name"],
+                    "id": record["end.def_pos_team.id"],
+                    "name": record["end.def_pos_team.name"],
                 },
-                "distance" : record["end.distance"],
-                "yardLine" : record["end.yardLine"],
-                "down" : record["end.down"],
-                "yardsToEndzone" : record["end.yardsToEndzone"],
-                "homeScore" : record["end.homeScore"],
-                "awayScore" : record["end.awayScore"],
-                "pos_team_score" : record["end.pos_team_score"],
-                "def_pos_team_score" : record["end.def_pos_team_score"],
-                "pos_score_diff" : record["pos_score_diff_end"],
-                "posTeamTimeouts" : record["end.posTeamTimeouts"],
-                "defPosTeamTimeouts" : record["end.defPosTeamTimeouts"],
-                "ExpScoreDiff" : record["end.ExpScoreDiff"],
-                "ExpScoreDiff_Time_Ratio" : record["end.ExpScoreDiff_Time_Ratio"],
-                "shortDownDistanceText" : record.get("end.shortDownDistanceText"),
-                "possessionText" : record.get("end.possessionText"),
-                "downDistanceText" : record.get("end.downDistanceText")
+                "distance": record["end.distance"],
+                "yardLine": record["end.yardLine"],
+                "down": record["end.down"],
+                "yardsToEndzone": record["end.yardsToEndzone"],
+                "homeScore": record["end.homeScore"],
+                "awayScore": record["end.awayScore"],
+                "pos_team_score": record["end.pos_team_score"],
+                "def_pos_team_score": record["end.def_pos_team_score"],
+                "pos_score_diff": record["pos_score_diff_end"],
+                "posTeamTimeouts": record["end.posTeamTimeouts"],
+                "defPosTeamTimeouts": record["end.defPosTeamTimeouts"],
+                "ExpScoreDiff": record["end.ExpScoreDiff"],
+                "ExpScoreDiff_Time_Ratio": record["end.ExpScoreDiff_Time_Ratio"],
+                "shortDownDistanceText": record.get("end.shortDownDistanceText"),
+                "possessionText": record.get("end.possessionText"),
+                "downDistanceText": record.get("end.downDistanceText"),
             }
 
             # record["players"] = {
@@ -198,50 +231,58 @@ def process():
 
         result = {
             "id": gameId,
-            "count" : len(jsonified_df),
-            "plays" : jsonified_df,
-            "box_score" : box,
-            "homeTeamId": pbp['header']['competitions'][0]['competitors'][0]['team']['id'],
-            "awayTeamId": pbp['header']['competitions'][0]['competitors'][1]['team']['id'],
-            "drives" : pbp['drives'],
-            "scoringPlays" : np.array(pbp['scoringPlays']).tolist(),
-            "winprobability" : np.array(pbp['winprobability']).tolist(),
-            "boxScore" : pbp['boxscore'],
-            "homeTeamSpread" : np.array(pbp['homeTeamSpread']).tolist(),
-            "overUnder" : np.array(pbp['overUnder']).tolist(),
-            "header" : pbp['header'],
-            "broadcasts" : np.array(pbp['broadcasts']).tolist(),
-            "videos" : np.array(pbp['videos']).tolist(),
-            "standings" : pbp['standings'],
-            "pickcenter" : np.array(pbp['pickcenter']).tolist(),
-            "espnWinProbability" : np.array(pbp['espnWP']).tolist(),
-            "gameInfo" : np.array(pbp['gameInfo']).tolist(),
-            "season" : np.array(pbp['season']).tolist()
+            "count": len(jsonified_df),
+            "plays": jsonified_df,
+            "box_score": box,
+            "homeTeamId": pbp["header"]["competitions"][0]["competitors"][0]["team"][
+                "id"
+            ],
+            "awayTeamId": pbp["header"]["competitions"][0]["competitors"][1]["team"][
+                "id"
+            ],
+            "drives": pbp["drives"],
+            "scoringPlays": np.array(pbp["scoringPlays"]).tolist(),
+            "winprobability": np.array(pbp["winprobability"]).tolist(),
+            "boxScore": pbp["boxscore"],
+            "homeTeamSpread": np.array(pbp["homeTeamSpread"]).tolist(),
+            "overUnder": np.array(pbp["overUnder"]).tolist(),
+            "header": pbp["header"],
+            "broadcasts": np.array(pbp["broadcasts"]).tolist(),
+            "videos": np.array(pbp["videos"]).tolist(),
+            "standings": pbp["standings"],
+            "pickcenter": np.array(pbp["pickcenter"]).tolist(),
+            "espnWinProbability": np.array(pbp["espnWP"]).tolist(),
+            "gameInfo": np.array(pbp["gameInfo"]).tolist(),
+            "season": np.array(pbp["season"]).tolist(),
         }
         # logging.getLogger("root").info(result)
         return jsonify(result), 200
     except KeyError as e:
-        logging.getLogger("root").error("Error while processing PBP on Python side, threw 404: %r (%s)" % (e, e))
-        return jsonify({
-            "status" : "bad",
-            "message" : "ESPN payload is malformed. Data not available."
-        }), 404
+        logging.getLogger("root").error(
+            "Error while processing PBP on Python side, threw 404: %r (%s)" % (e, e)
+        )
+        return jsonify(
+            {
+                "status": "bad",
+                "message": "ESPN payload is malformed. Data not available.",
+            }
+        ), 404
     except Exception as e:
-        logging.getLogger("root").error("Error while processing PBP on Python side, threw 500: %r (%s)" % (e, e))
+        logging.getLogger("root").error(
+            "Error while processing PBP on Python side, threw 500: %r (%s)" % (e, e)
+        )
         import traceback
+
         traceback.print_tb(e.__traceback__)
-        return jsonify({
-            "status" : "bad",
-            "message" : "Unknown error occurred, check logs."
-        }), 500
+        return jsonify(
+            {"status": "bad", "message": "Unknown error occurred, check logs."}
+        ), 500
 
 
-@app.route('/healthcheck', methods=['GET'])
+@app.route("/healthcheck", methods=["GET"])
 def healthcheck():
-    return jsonify({
-        "status": "ok"
-    })
+    return jsonify({"status": "ok"})
 
-if __name__ == '__main__':
-    app.run(port=7000, debug=False, host='0.0.0.0')
 
+if __name__ == "__main__":
+    app.run(port=7000, debug=False, host="0.0.0.0")

--- a/python/flask_logs.py
+++ b/python/flask_logs.py
@@ -25,7 +25,11 @@ class LogSetup(object):
                 app_log_file_name = app.config["APP_LOG_NAME"]
                 access_log_file_name = app.config["WWW_LOG_NAME"]
             except KeyError as e:
-                exit(code="{} is a required parameter for log_type '{}'".format(e, log_type))
+                exit(
+                    code="{} is a required parameter for log_type '{}'".format(
+                        e, log_type
+                    )
+                )
             app_log = "/".join([log_directory, app_log_file_name])
             www_log = "/".join([log_directory, access_log_file_name])
 
@@ -49,7 +53,11 @@ class LogSetup(object):
         }
         std_logger = {
             "loggers": {
-                "": {"level": logging_level, "handlers": ["default"], "propagate": True},
+                "": {
+                    "level": logging_level,
+                    "handlers": ["default"],
+                    "propagate": True,
+                },
                 "app.access": {
                     "level": logging_level,
                     "handlers": ["access_logs"],

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.1.3
-sportsdataverse==0.0.36.2.44
-setuptools
-xgboost<=3.0
-Werkzeug==2.3.7
+Flask==3.1.2
+Werkzeug==3.1.5
+xgboost<3
+numpy>=2.0.2
+sportsdataverse==0.0.36.2.46


### PR DESCRIPTION
Also formatted it all with ruff and bumped gh actions.

## Summary by Sourcery

Update the Python play-by-play processing service, its runtime environment, and deployment workflow to use newer dependencies and standardized formatting.

Enhancements:
- Reformat Python Flask app and logging setup modules to comply with Ruff style and improve consistency in JSON responses and logging configuration.
- Remove unused imports and modernize string quoting and route definitions in the Flask app.

Build:
- Upgrade the Python Docker image to use Python 3.14 for the Flask service.

CI:
- Bump GitHub Actions workflow to use actions/checkout@v6 and appleboy/ssh-action@v1 in the deployment pipeline.

Chores:
- Refresh Python dependencies, including upgrading Flask and Werkzeug, tightening xgboost constraints, adding numpy, and updating sportsdataverse to version 0.0.36.2.46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependencies including Flask, Werkzeug, numpy, and sportsdataverse to latest versions.
  * Upgraded Python base image to version 3.14.
  * Updated CI/CD pipeline actions to latest versions for improved stability and security.

* **Style**
  * Applied code formatting improvements throughout the Python codebase for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->