### PR TITLE
fix(ci): forward telemetry/admin secrets to the Worker and python compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,9 +17,14 @@ jobs:
         with:
           repository: saiemgilani/game-on-paper-app
       - uses: cloudflare/wrangler-action@v4
-        env: 
+        env:
           PYTHON_HTTP_TOKEN: ${{ secrets.PYTHON_HTTP_TOKEN }}
           SDV_AUTH_TOKEN: ${{ secrets.SDV_AUTH_TOKEN }}
+          PYTHON_HTTP_URL: ${{ secrets.PYTHON_HTTP_URL }}
+          ADMIN_USER: ${{ secrets.ADMIN_USER }}
+          ADMIN_PASS: ${{ secrets.ADMIN_PASS }}
+          GOP_INGEST_KEY: ${{ secrets.GOP_INGEST_KEY }}
+          TELEMETRY_ENABLED: ${{ secrets.TELEMETRY_ENABLED }}
           APP_VERSION: ${{ github.sha }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -28,6 +33,11 @@ jobs:
           secrets: |
             PYTHON_HTTP_TOKEN
             SDV_AUTH_TOKEN
+            PYTHON_HTTP_URL
+            ADMIN_USER
+            ADMIN_PASS
+            GOP_INGEST_KEY
+            TELEMETRY_ENABLED
           vars: |
             APP_VERSION
           preCommands: |
@@ -86,7 +96,7 @@ jobs:
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ secrets.GH_USERNAME }} --password-stdin
             docker compose pull
             docker stop $(docker ps -a -q) || true
-            PYTHON_HTTP_TOKEN=${{ secrets.PYTHON_HTTP_TOKEN }} docker compose -f docker-compose.yml up -d --pull always
+            PYTHON_HTTP_TOKEN=${{ secrets.PYTHON_HTTP_TOKEN }} GOP_PG_DSN='${{ secrets.GOP_PG_DSN }}' GOP_PG_DSN_RO='${{ secrets.GOP_PG_DSN_RO }}' GOP_INGEST_KEY='${{ secrets.GOP_INGEST_KEY }}' TELEMETRY_ENABLED='${{ secrets.TELEMETRY_ENABLED }}' docker compose -f docker-compose.yml up -d --pull always
             docker system prune --force
           ENDSSH
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,6 @@ jobs:
         env:
           PYTHON_HTTP_TOKEN: ${{ secrets.PYTHON_HTTP_TOKEN }}
           SDV_AUTH_TOKEN: ${{ secrets.SDV_AUTH_TOKEN }}
-          PYTHON_HTTP_URL: ${{ secrets.PYTHON_HTTP_URL }}
           ADMIN_USER: ${{ secrets.ADMIN_USER }}
           ADMIN_PASS: ${{ secrets.ADMIN_PASS }}
           GOP_INGEST_KEY: ${{ secrets.GOP_INGEST_KEY }}
@@ -30,10 +29,12 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: "./astro"
+          # PYTHON_HTTP_URL is intentionally NOT pushed as a secret: it already
+          # exists as a plaintext var in wrangler.jsonc and a same-name secret
+          # would collide with that binding.
           secrets: |
             PYTHON_HTTP_TOKEN
             SDV_AUTH_TOKEN
-            PYTHON_HTTP_URL
             ADMIN_USER
             ADMIN_PASS
             GOP_INGEST_KEY
@@ -86,17 +87,35 @@ jobs:
           SSH_HOST: ${{ secrets.API_HOST }}
           SSH_USER: ${{ secrets.API_USERNAME }}
           SSH_PORT: ${{ secrets.PORT }}
+          PYTHON_HTTP_TOKEN: ${{ secrets.PYTHON_HTTP_TOKEN }}
+          GOP_PG_DSN: ${{ secrets.GOP_PG_DSN }}
+          GOP_PG_DSN_RO: ${{ secrets.GOP_PG_DSN_RO }}
+          GOP_INGEST_KEY: ${{ secrets.GOP_INGEST_KEY }}
+          TELEMETRY_ENABLED: ${{ secrets.TELEMETRY_ENABLED }}
         run: |
+          # Build the compose env file on the runner from real env vars (never
+          # interpolate secret values into shell source: an apostrophe/newline
+          # in a DSN would break the remote script after containers stopped).
+          {
+            printf 'PYTHON_HTTP_TOKEN=%s\n' "$PYTHON_HTTP_TOKEN"
+            printf 'GOP_PG_DSN=%s\n' "$GOP_PG_DSN"
+            printf 'GOP_PG_DSN_RO=%s\n' "$GOP_PG_DSN_RO"
+            printf 'GOP_INGEST_KEY=%s\n' "$GOP_INGEST_KEY"
+            printf 'TELEMETRY_ENABLED=%s\n' "$TELEMETRY_ENABLED"
+          } > deploy.env
+
           sftp -i ~/.ssh/deploy_key -P $SSH_PORT $SSH_USER@$SSH_HOST bash << 'ENDSSH'
             put docker-compose.do.yml docker-compose.yml
+            put deploy.env .env
           ENDSSH
 
           ssh -i ~/.ssh/deploy_key -p $SSH_PORT $SSH_USER@$SSH_HOST bash << 'ENDSSH'
             set -e
+            chmod 600 .env
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ secrets.GH_USERNAME }} --password-stdin
             docker compose pull
             docker stop $(docker ps -a -q) || true
-            PYTHON_HTTP_TOKEN=${{ secrets.PYTHON_HTTP_TOKEN }} GOP_PG_DSN='${{ secrets.GOP_PG_DSN }}' GOP_PG_DSN_RO='${{ secrets.GOP_PG_DSN_RO }}' GOP_INGEST_KEY='${{ secrets.GOP_INGEST_KEY }}' TELEMETRY_ENABLED='${{ secrets.TELEMETRY_ENABLED }}' docker compose -f docker-compose.yml up -d --pull always
+            docker compose -f docker-compose.yml up -d --pull always
             docker system prune --force
           ENDSSH
 

--- a/astro/wrangler.jsonc
+++ b/astro/wrangler.jsonc
@@ -13,7 +13,7 @@
 		"SEASON_MODE": "offseason"
 	},
 	"secrets": {
-		"required": ["PYTHON_HTTP_TOKEN", "SDV_AUTH_TOKEN"]
+		"required": ["PYTHON_HTTP_TOKEN", "SDV_AUTH_TOKEN", "ADMIN_USER", "ADMIN_PASS", "GOP_INGEST_KEY"]
 	},
 	"main": "./src/worker.ts",
 	"assets": {

--- a/docker-compose.do.yml
+++ b/docker-compose.do.yml
@@ -2,7 +2,7 @@ services:
   python:
     image: ghcr.io/saiemgilani/saiemgilani/game-on-paper-python-api:REPLACE_ME
     environment:
-      - PYTHON_HTTP_TOKEN
+      - PYTHON_HTTP_TOKEN=${PYTHON_HTTP_TOKEN:-}
       - GOP_PG_DSN=${GOP_PG_DSN:-}
       - GOP_PG_DSN_RO=${GOP_PG_DSN_RO:-}
       - GOP_INGEST_KEY=${GOP_INGEST_KEY:-}


### PR DESCRIPTION
## Why /admin is locked and telemetry is silent

Troubleshooting after #165 merged: the GitHub Actions secrets **were** set in July (`ADMIN_USER`, `ADMIN_PASS`, `GOP_INGEST_KEY`, `PYTHON_HTTP_URL`, `TELEMETRY_ENABLED` all exist on the repo) — but `deploy.yml` never forwarded them:

- **deploy-web** only pushed `PYTHON_HTTP_TOKEN` + `SDV_AUTH_TOKEN` to the Worker. Every `getSecret()` for the five telemetry/admin names returned undefined → `/admin` fail-closed to 401 for everyone (confirmed live: `gameonpaper.com/admin` returns 401 with the gop-admin realm), middleware ingest emit disabled, admin API proxy had no key.
- **deploy-api** only exported `PYTHON_HTTP_TOKEN` before `docker compose up`, so `${GOP_PG_DSN:-}` etc. interpolated to empty → python writer fail-open disabled, `/gop/*` endpoints reject everything (no key configured).

## Fix

- deploy-web: push all five Worker secrets via wrangler-action's `secrets:` block.
- deploy-api: export `GOP_PG_DSN`, `GOP_PG_DSN_RO`, `GOP_INGEST_KEY`, `TELEMETRY_ENABLED` inline before `docker compose up` (single-quoted; DSNs carry special characters).

## Owner step — done 2026-08-23

`GOP_PG_DSN` / `GOP_PG_DSN_RO` were added as Actions secrets on 2026-08-23 (18:45Z), so the full pipeline — admin login, astro ingest, python buffering, and Postgres writes — activates on merge. Review round 2 (7a049f7): PYTHON_HTTP_URL dropped from the secrets push (already a wrangler.jsonc var; same-name secret would collide) and compose secrets now travel as a printf-built .env over sftp instead of being interpolated into shell source.

## Summary by Sourcery

Forward admin, telemetry, and database configuration through web and API deployments to restore authenticated admin access and enable telemetry processing.

Bug Fixes:
- Forward admin and telemetry credentials to the Worker so admin authentication, telemetry ingestion, and the admin API proxy can operate in deployed environments.
- Pass PostgreSQL and telemetry configuration through the API deployment so the Python service can authenticate requests and write telemetry when the required database secrets are configured.

Enhancements:
- Make deployment environment propagation reliable for compose services, including credentials and database connection strings containing special characters.

Deployment:
- Update web and API deployments to provision the required Worker secrets and remote compose environment configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deployment**
  * Improved deployment configuration to support database connectivity, ingestion services, telemetry controls, and administrative access.
  * Enhanced secure handling of runtime configuration across web and API deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
