### PR TITLE
chore(python): bump sportsdataverse pin to c579acc0 (PR #408)

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2698,7 +2698,7 @@ wheels = [
 [[package]]
 name = "sportsdataverse"
 version = "0.1.3"
-source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#bacd001b1803921f86d14608e7f4f9ec49cb1bab" }
+source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#c579acc0074ba27ea1b240a93384f319109d4459" }
 dependencies = [
     { name = "attrs" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Picks up sportsdataverse-py PR #408 (merged 2026-08-29): the mirrored
end.yardsToEndzone repairs, the home/away wp_after perspective fix, the WP flip
guard, era-aware penalty parsing, and the direct penalty EPA.

Live example on the current TCU @ UNC game (401856766, p42): "J.Payne rush right
for 13 yards ... PENALTY TCU Holding 10 yards from UNC26 to UNC36" was shown as
34 -> 64 yards to go (the mirror), EPA -3.52, WP -10.4%. Against c579acc0 it is
34 -> 36, EPA -1.89, WP -5.4%.

uv lock keeps the pinned SHA even with branch=main; this used
--upgrade-package sportsdataverse.

## Summary by Sourcery

Upgrade the pinned sportsdataverse Python dependency to incorporate corrected play-by-play and game-statistics calculations.

Enhancements:
- Update the Python dependency lockfile to the sportsdataverse revision containing corrected play-by-play yardage, win-probability perspective, penalty parsing, penalty EPA, and WP flip handling.

Build:
- Refresh the Python dependency lockfile while retaining the sportsdataverse commit pin.