### PR TITLE
feat(python): build against sportsdataverse-py main and report the running SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,6 +58,18 @@ jobs:
       - uses: actions/checkout@v7
         with:
           repository: saiemgilani/game-on-paper-app
+      - name: Resolve sportsdataverse-py main
+        id: sdvpy
+        # The image re-resolves sportsdataverse-py main at build time; this SHA is
+        # the cache-buster that makes a new main commit invalidate that layer. A
+        # repository_dispatch from sportsdataverse-py carries it directly.
+        run: |
+          sha="${{ github.event.client_payload.sportsdataverse_py_sha }}"
+          if [ -z "$sha" ]; then
+            sha="$(git ls-remote https://github.com/sportsdataverse/sportsdataverse-py.git refs/heads/main | cut -f1)"
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "sportsdataverse-py main @ $sha"
       - name: Publish Python container to GitHub
         uses: mr-smithers-excellent/docker-build-push@v7.0
         with:
@@ -69,6 +81,7 @@ jobs:
           dockerfile: ./python/Dockerfile
           addLatest: true
           tags: ${{ github.sha }}
+          buildArgs: SDV_PY_MAIN_SHA=${{ steps.sdvpy.outputs.sha }}
       - name: Update SHA for docker compose
         run: |
           DOCKER_COMPOSE_CONTENT="$(cat ./docker-compose.do.yml)"

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -17,10 +17,20 @@ ENV UV_NO_DEV=1
 # only that one: everything else stays pinned by the lock) makes every build a
 # subscription to main. The resolved SHA is written into the image so
 # /healthcheck can report exactly what is running.
-RUN uv lock --upgrade-package sportsdataverse && \
+#
+# SDV_PY_MAIN_SHA is the cache-buster. The re-resolve layer's inputs are only
+# pyproject.toml, uv.lock and the command, so a warm Docker cache would reuse it
+# and keep the old SHA no matter what main did. The workflow resolves main's SHA
+# (git ls-remote) and passes it in; a new value changes the layer and forces the
+# re-resolve. It is informational otherwise -- uv still resolves main itself.
+ARG SDV_PY_MAIN_SHA=unpinned
+RUN echo "requested sportsdataverse-py main @ ${SDV_PY_MAIN_SHA}" && \
+    uv lock --upgrade-package sportsdataverse && \
     uv sync --locked --all-extras --all-groups && \
-    grep -A2 'name = "sportsdataverse"' uv.lock | grep -oE 'sportsdataverse-py\?branch=main#[0-9a-f]+' | sed 's/.*#//' > /code/sdv_py_sha.txt && \
-    echo "sportsdataverse-py @ $(cat /code/sdv_py_sha.txt)"
+    sha="$(grep -A2 'name = "sportsdataverse"' uv.lock | grep -oE 'sportsdataverse-py\?branch=main#[0-9a-f]+' | sed 's/.*#//')" && \
+    echo "$sha" | grep -qE '^[0-9a-f]{40}$' || { echo "could not extract a 40-hex sportsdataverse SHA from uv.lock (got: '$sha')" >&2; exit 1; } && \
+    printf '%s' "$sha" > /code/sdv_py_sha.txt && \
+    echo "sportsdataverse-py @ $sha"
 
 # RUN uv pip uninstall -y xgboost nvidia-nccl-cu12 && \
 #     uv pip install --no-cache-dir --force-reinstall --no-deps xgboost-cpu==2.1.4

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -10,7 +10,17 @@ WORKDIR /code
 ENV PATH="/code/.venv/bin:$PATH"
 COPY pyproject.toml uv.lock ./
 ENV UV_NO_DEV=1
-RUN uv sync --locked --all-extras --all-groups
+# Track sportsdataverse-py MAIN at build time. pyproject says branch=main, but
+# `uv sync --locked` installs the SHA the lock recorded, so the image only ever
+# advanced when someone ran `uv lock --upgrade-package` by hand -- the site sat on
+# v0.1.3 for a day after PR #408 merged. Re-resolving that one package here (and
+# only that one: everything else stays pinned by the lock) makes every build a
+# subscription to main. The resolved SHA is written into the image so
+# /healthcheck can report exactly what is running.
+RUN uv lock --upgrade-package sportsdataverse && \
+    uv sync --locked --all-extras --all-groups && \
+    grep -A2 'name = "sportsdataverse"' uv.lock | grep -oE 'sportsdataverse-py\?branch=main#[0-9a-f]+' | sed 's/.*#//' > /code/sdv_py_sha.txt && \
+    echo "sportsdataverse-py @ $(cat /code/sdv_py_sha.txt)"
 
 # RUN uv pip uninstall -y xgboost nvidia-nccl-cu12 && \
 #     uv pip install --no-cache-dir --force-reinstall --no-deps xgboost-cpu==2.1.4
@@ -28,6 +38,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=pybuilder /code/.venv ./.venv
+COPY --from=pybuilder /code/sdv_py_sha.txt ./sdv_py_sha.txt
 ENV PATH="/code/.venv/bin:$PATH"
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/python/app.py
+++ b/python/app.py
@@ -376,7 +376,22 @@ def process(game_id: int):
 
 @app.route("/healthcheck", methods=["GET"])
 def healthcheck():
-    return jsonify({"status": "ok"})
+    # Report exactly which sportsdataverse-py is running. The image resolves
+    # main at build time (see python/Dockerfile), so the version string alone
+    # cannot distinguish two builds; the SHA the builder recorded can.
+    sha = None
+    try:
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdv_py_sha.txt")) as fh:
+            sha = fh.read().strip() or None
+    except OSError:
+        pass
+    try:
+        from importlib.metadata import version
+
+        sdv_version = version("sportsdataverse")
+    except Exception:
+        sdv_version = None
+    return jsonify({"status": "ok", "sportsdataverse": {"version": sdv_version, "sha": sha}})
 
 
 if __name__ == "__main__":

--- a/python/app.py
+++ b/python/app.py
@@ -381,7 +381,9 @@ def healthcheck():
     # cannot distinguish two builds; the SHA the builder recorded can.
     sha = None
     try:
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdv_py_sha.txt")) as fh:
+        with open(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdv_py_sha.txt")
+        ) as fh:
             sha = fh.read().strip() or None
     except OSError:
         pass
@@ -391,7 +393,9 @@ def healthcheck():
         sdv_version = version("sportsdataverse")
     except Exception:
         sdv_version = None
-    return jsonify({"status": "ok", "sportsdataverse": {"version": sdv_version, "sha": sha}})
+    return jsonify(
+        {"status": "ok", "sportsdataverse": {"version": sdv_version, "sha": sha}}
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
pyproject.toml has said branch=main since #167, but the image installs with
`uv sync --locked`, which pins to the SHA the lock recorded. So "builds against
main" only advanced when someone ran `uv lock --upgrade-package sportsdataverse`
by hand -- and the site served v0.1.3 for a day after sportsdataverse-py #408
merged, showing a mirrored 64 yards to go on a play that ended at the 36.

The Dockerfile now re-resolves that one package at build time and leaves every
other pin in the lock alone, so each image is a subscription to main. The cost is
reproducibility -- two builds of one GOP commit can carry different sdv-py code --
so the builder writes the resolved SHA into the image and /healthcheck reports it
alongside the package version, which is the number the admin panel should show.

A broken sdv-py main fails the build and the previous image keeps serving, which
is the right failure. Rollback is redeploying the previous image tag.

Deploys still only run when GOP itself changes; the companion sportsdataverse-py
workflow dispatches this repo's deploy on every push to its main.

## Summary by Sourcery

Build Python images from the current sportsdataverse-py main revision and report the exact dependency revision running in each image.

New Features:
- Build images against the latest sportsdataverse-py main revision and expose its version and commit SHA through the healthcheck endpoint.

Enhancements:
- Make sportsdataverse-py main updates invalidate the container build cache while preserving other locked dependencies.
- Fail image builds when the sportsdataverse-py revision cannot be resolved or recorded.

Build:
- Pass the resolved sportsdataverse-py main SHA into Docker builds and persist it in the image.

CI:
- Resolve sportsdataverse-py main from repository dispatch payloads or the upstream branch before publishing images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the health check to report the installed package version and build commit identifier when available.
  * Added build metadata to runtime images for improved deployment visibility.
  * This information helps verify the deployed application version and build.

* **Bug Fixes**
  * Health checks now remain reliable when package version or build metadata cannot be read, returning `null` instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->