### PR TITLE
fix(box): receiving line printed catches as touchdowns

### DIFF
--- a/astro/src/components/game/metrics/PlayerBoxScore.astro
+++ b/astro/src/components/game/metrics/PlayerBoxScore.astro
@@ -79,7 +79,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
                 (receiver.length > 0) && (receiver.map((p) => (
                     <tr>
                         <td style="text-align: left;">{p.receiver_player_name}</td>
-                        <td style="text-align: left;">{p.Rec} catch{(Math.abs(p.Rec) == 1) ? "" : "es"} ({p.Tar} target{(Math.abs(p.Tar) == 1) ? "" : "s"}), {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rec} TD, {p.Fum} Fum ({p.Fum_Lost} lost)</td>
+                        <td style="text-align: left;">{p.Rec} catch{(Math.abs(p.Rec) == 1) ? "" : "es"} ({p.Tar} target{(Math.abs(p.Tar) == 1) ? "" : "s"}), {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rec_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPT || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA, 2, 2)}</td>


### PR DESCRIPTION
The pass-targets stat line read {p.Rec} TD -- the catch count -- so every
receiver showed as many touchdowns as receptions ("4 catches, 4 TD" on a
10-10 game with two rushing scores). The rushing line already used Rush_TD;
this uses Rec_TD, which the box score carries correctly.

## Summary by Sourcery

Bug Fixes:
- Correct receiving touchdown totals in player box scores by displaying receiving touchdowns instead of reception counts.