### PR TITLE
fix(meta): game cards declare the square size ESPN actually serves

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -161,14 +161,14 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
         <meta property="og:title" content={title}>
         <meta property="og:description" content={`Advanced stats for ${subtitle}`}>
         <meta property="og:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${id}.png?templateId=espn.com.share.1`}>
-        <meta property="og:image:width" content="1200">
-        <meta property="og:image:height" content="630">
+        <meta property="og:image:width" content="400">
+        <meta property="og:image:height" content="400">
         <meta property="og:type" content="website">
         <meta name="twitter:site" content="@gameonpaper">
         <meta name="twitter:url" content={canonicalUrl}>
         <meta name="twitter:title" content={title}>
         <meta name="twitter:description" content={subtitle}>
-        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:card" content="summary">
         <meta name="twitter:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${id}.png?templateId=espn.com.share.1`}>
         <meta name="title" content={title}>
         <meta name="medium" content="website">

--- a/astro/src/components/game/PreGamePage.astro
+++ b/astro/src/components/game/PreGamePage.astro
@@ -117,14 +117,14 @@ const matchupHistory = await retrieveMatchupHistory(homeTeam.id, awayTeam.id, 5)
         <meta property="og:title" content={title}>
         <meta property="og:description" content={`Advanced stats for ${subtitle}`}>
         <meta property="og:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${game.id}.png?templateId=espn.com.share.1`}>
-        <meta property="og:image:width" content="1200">
-        <meta property="og:image:height" content="630">
+        <meta property="og:image:width" content="400">
+        <meta property="og:image:height" content="400">
         <meta property="og:type" content="website">
         <meta name="twitter:site" content="@gameonpaper">
         <meta name="twitter:url" content={`https://gameonpaper.com/cfb/game/${game.id}`}>
         <meta name="twitter:title" content={title}>
         <meta name="twitter:description" content={subtitle}>
-        <meta name="twitter:card" content="summary_large_image">
+        <meta name="twitter:card" content="summary">
         <meta name="twitter:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${game.id}.png?templateId=espn.com.share.1`}>
         <meta name="title" content={title}>
         <meta name="medium" content="website">


### PR DESCRIPTION
## The problem

Game pages advertised `og:image` as **1200×630** and requested a `summary_large_image` card. ESPN's stitcher art is **400×400**.

Verified across eight games — in-progress, not-yet-started, and completed from a prior season — all 400×400. And `espn.com.share.1` is the only template that resolves; `share.2`, `espn.com.1` and `share.wide.1` all 404, so there is no wide variant to switch to.

The result on X is a wide card frame handed a square image: pillarboxed, with the declared dimensions lying about the asset.

This is a follow-up to #169, which set these pages to `summary_large_image` on the strength of the `og:image:width` tag rather than probing the actual image. The tag was wrong.

## The change

Declare what is actually served, and let the frame match it:

- `og:image:width`/`height` **1200×630 → 400×400** on `GamePage.astro` and `PreGamePage.astro`
- `twitter:card` **`summary_large_image` → `summary`**, so a square image sits in a square frame instead of being padded into a wide one

## Trade-off

This makes game-link cards **smaller**. That is the deliberate choice: a small card showing the art correctly beats a large one showing it wrong. A wide game card needs art that is genuinely wide — a per-game generated image — which is separate work worth doing properly.

## Not touched

`SchedulePage.astro`, `GenericPage.astro` and `glossary.astro` keep `summary_large_image`. They point at `social-card.png`, which really is 1200×630, so the wide card is correct there.

## Summary by Sourcery

Bug Fixes:
- Correct game-page social metadata to declare the 400×400 images actually served and use square Twitter cards, preventing incorrectly padded wide previews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated social sharing previews for game and pre-game pages to use square images and compact Twitter cards.
  * Improved consistency of preview appearance across supported social platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->