### PR TITLE
feat(ui): floating back-to-top button; restore the expected-points row on play expansion

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -15,3 +15,45 @@ const APP_VERSION = getSecret("APP_VERSION");
   </footer>
   </div>
 </div>
+<!-- Floating back-to-top: shared by the game, pre-game and scoreboard pages via
+     this footer. Hidden until the reader has scrolled a screen's worth, bottom-right
+     so it never covers the play table's left-aligned text; 44px touch target. -->
+<button id="back-to-top" class="btn btn-secondary shadow" type="button" aria-label="Back to top" title="Back to top" hidden>
+  <i class="bi bi-arrow-up" aria-hidden="true"></i>
+</button>
+<style>
+  #back-to-top {
+    position: fixed;
+    right: 1rem;
+    bottom: 1.25rem;
+    z-index: 1030;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    border-radius: 50%;
+    font-size: 1.25rem;
+    line-height: 44px;
+    opacity: 0.85;
+  }
+  #back-to-top:hover, #back-to-top:focus-visible { opacity: 1; }
+  @media print { #back-to-top { display: none; } }
+</style>
+<script is:inline>
+  (function () {
+    var btn = document.getElementById('back-to-top');
+    if (!btn) return;
+    var ticking = false;
+    function update() {
+      btn.hidden = window.scrollY < window.innerHeight;
+      ticking = false;
+    }
+    window.addEventListener('scroll', function () {
+      if (!ticking) { ticking = true; window.requestAnimationFrame(update); }
+    }, { passive: true });
+    btn.addEventListener('click', function () {
+      var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+    });
+    update();
+  })();
+</script>

--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -47,9 +47,11 @@ const APP_VERSION = getSecret("APP_VERSION");
       btn.hidden = window.scrollY < window.innerHeight;
       ticking = false;
     }
-    window.addEventListener('scroll', function () {
+    function schedule() {
       if (!ticking) { ticking = true; window.requestAnimationFrame(update); }
-    }, { passive: true });
+    }
+    window.addEventListener('scroll', schedule, { passive: true });
+    window.addEventListener('resize', schedule, { passive: true }); // the threshold is a viewport height
     btn.addEventListener('click', function () {
       var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });

--- a/astro/src/components/game/plays/ExpandedPlayRow.astro
+++ b/astro/src/components/game/plays/ExpandedPlayRow.astro
@@ -30,6 +30,12 @@ if (play.fourth_down_recommendation) {
     }
 }
 
+// "+0.33" / "-2.15": the Added figure reads as a delta, not a level
+const signed = (n: number | null | undefined): string => {
+    const v = roundNumber(n ?? 0, 2, 2);
+    return Number(v) >= 0 ? `+${v}` : v;
+};
+
 let xpRecommendation: string | null = null;
 if (play.two_pt_recommendation) {
     switch (play.two_pt_recommendation) {
@@ -51,7 +57,11 @@ if (play.two_pt_recommendation) {
 <p style="text-align: center;"><strong>Play Type:</strong> {play.type.text}</p>
 <p style="text-align: center;"><strong>Yards to End Zone (Before to After):</strong> {play.start.yardsToEndzone} to {play.end.yardsToEndzone}</p>
 <p style="text-align: center;"><strong>Started Drive at:</strong> {formatYardline(play.drive_start, cleanAbbreviation(offense), cleanAbbreviation(defense), play.type.text)}</p>
-<!-- <p style="text-align: center;"><strong>ExpPts (After - Before = Added):</strong> {roundNumber(play.expectedPoints.after, 2, 2)} - {roundNumber(play.expectedPoints.before, 2, 2)} = {roundNumber(play.expectedPoints.added, 2, 2)}</p> -->
+<p style="text-align: center;"><strong>Expected Points (Before → After):</strong> {roundNumber(play.expectedPoints.before, 2, 2)} → {roundNumber(play.expectedPoints.after, 2, 2)}, <strong>Added:</strong> {signed(play.expectedPoints.added)}{
+    (Math.abs(play.EP_between ?? 0) >= 0.005) && (
+        <span title="Expected points that changed between the previous play's end and this play's start (a penalty enforced from the prior spot, an untracked administrative change, a data gap). It is part of Added, so Added is not simply After minus Before here."> · incl. {signed(play.EP_between ?? 0)} between plays</span>
+    )
+}</p>
 <p style="text-align: center;"><strong>Score Difference (Before):</strong> {play.start.pos_score_diff} ({roundNumber(play.start.ExpScoreDiff, 2, 2)})</p>
 <p style="text-align: center;"><strong>Score Difference (End):</strong> {play.end.pos_score_diff} ({roundNumber(play.end.ExpScoreDiff, 2, 2)})</p>
 <p style="text-align: center;"><strong>Change of Possession:</strong> {play.change_of_poss || "false"}</p>


### PR DESCRIPTION
## Back to top
A fixed bottom-right button in the shared `Footer.astro`, so it appears on the game, pre-game and scoreboard pages without per-page wiring. Hidden until you have scrolled a screen's worth (rAF-throttled scroll listener), 44px touch target, `bi-arrow-up`, smooth scroll unless `prefers-reduced-motion`, hidden in print. The existing text "Back to top" link in the footer stays.

## Expected points on play expansion
The `ExpPts (After - Before = Added)` line was commented out in 0f35822 ("game: fix typos"). Restored as:

> **Expected Points (Before → After):** 1.38 → 3.31, **Added:** +0.33

and, only when `EP_between` is non-zero:

> · incl. +5.38 between plays

with a tooltip explaining it. That is exactly the case where the old line looked wrong ("3.31 − 1.38 = 7.30"): `Added` folds the expected-points change between the previous play's end and this play's start (penalty enforced from the prior spot, admin gaps), so it is not simply After − Before. Now it says so instead of hiding the row.

Compiles (vite bundles) on Node 22; vitest 71/71. Not screenshot-verified on a device — please eyeball the button position on mobile against the play table.

## Summary by Sourcery

Improve navigation and restore accurate expected-points context in expanded game plays.

New Features:
- Add a shared floating back-to-top button to the footer for game, pre-game, and scoreboard pages.
- Restore expected-points details in expanded play rows, including between-play contributions when applicable.

Enhancements:
- Clarify that the expected-points Added value can include changes between plays rather than equaling the simple After-minus-Before difference.
- Respect reduced-motion preferences when scrolling to the top.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating “Back to top” button to game, pre-game, and scoreboard pages. It appears after scrolling and supports smooth scrolling and reduced-motion preferences.
  * Improved expected-points details in expanded play rows, including clearly labeled Added values and meaningful between-play changes.

* **Accessibility**
  * Provided a large touch target and explanatory tooltip for expected-points changes.
  * The “Back to top” control is hidden when printing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->