### PR TITLE
feat(cache): purge rendered game pages by tag; key the API-layer cache on the deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,10 @@ jobs:
           ADMIN_PASS: ${{ secrets.ADMIN_PASS }}
           GOP_INGEST_KEY: ${{ secrets.GOP_INGEST_KEY }}
           TELEMETRY_ENABLED: ${{ secrets.TELEMETRY_ENABLED }}
-          APP_VERSION: ${{ github.sha }}
+          # sha alone is NOT unique per deploy: repository_dispatch (sdv-py main moved)
+          # re-deploys the same repo sha with a new parser. run_id makes every deploy
+          # bust the API-layer cacheKey in resources/python.ts.
+          APP_VERSION: ${{ github.sha }}-${{ github.run_id }}
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/purge-game-cache.yml
+++ b/.github/workflows/purge-game-cache.yml
@@ -1,61 +1,53 @@
-# Purge a game's cached render so a parser fix in sportsdataverse-py reaches the
-# page. Two layers hold a completed game for up to a year:
-#   1. the Astro page, in Workers Caching -- which NO zone-level purge reaches;
-#      only the Worker itself can purge it, via /admin/api/purge-game;
-#   2. the worker's fetch of <PYTHON_HTTP_URL>/cfb/<id>/process, which lives in
-#      the zone cache (cf.cacheEverything) and is purged by URL. That call needs
-#      "Zone -> Cache Purge" on CLOUDFLARE_API_TOKEN; it is reported, not fatal.
+# Purge rendered game pages from Workers Caching after a parser fix. No zone-level
+# purge reaches Workers Caching; only the Worker can purge itself, so this calls
+# /admin/api/purge-game, from the API host because GitHub runners get a
+# Cloudflare bot challenge on /admin/*. The API-layer response cache is keyed on
+# APP_VERSION and is therefore already invalidated by the deploy that carried
+# the fix -- only the rendered pages need clearing.
+#
+#   tags=game-completed (default)   every final game page
+#   game_ids=401856766,...          specific games (also resets their regression mark)
 name: purge-game-cache
 
 on:
   workflow_dispatch:
     inputs:
+      tags:
+        description: "cache tags to purge (comma-separated); default clears every final game"
+        required: false
+        default: "game-completed"
       game_ids:
-        description: "ESPN game ids, comma-separated"
-        required: true
+        description: "ESPN game ids, comma-separated (optional)"
+        required: false
+        default: ""
 
 jobs:
   purge:
     runs-on: ubuntu-latest
     steps:
-      # GitHub runners get a Cloudflare bot challenge (cf-mitigated: challenge) on
-      # /admin/*, so the call is made from the API host the deploy already SSHes into.
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -p ${{ secrets.PORT }} ${{ secrets.API_HOST }} >> ~/.ssh/known_hosts
-      - name: Purge the Astro pages (Workers Caching, in-worker, via the API host)
+      - name: Purge via the API host
         env:
           SSH_HOST: ${{ secrets.API_HOST }}
           SSH_USER: ${{ secrets.API_USERNAME }}
           SSH_PORT: ${{ secrets.PORT }}
           ADMIN_USER: ${{ secrets.ADMIN_USER }}
           ADMIN_PASS: ${{ secrets.ADMIN_PASS }}
+          TAGS: ${{ inputs.tags }}
           GAME_IDS: ${{ inputs.game_ids }}
         run: |
           set -euo pipefail
-          ids=$(echo "$GAME_IDS" | tr -d ' ')
+          tags=$(echo "$TAGS" | tr -d ' '); ids=$(echo "$GAME_IDS" | tr -d ' ')
+          url="https://gameonpaper.com/admin/api/purge-game?tags=$tags&ids=$ids"
           # credentials travel on stdin, never on the remote command line
           resp=$(printf '%s\n%s\n' "$ADMIN_USER" "$ADMIN_PASS" | ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
-            "read -r u; read -r p; curl -sS -w '\n%{http_code}' -u \"\$u:\$p\" -A gop-purge-workflow 'https://gameonpaper.com/admin/api/purge-game?ids=$ids'")
+            "read -r u; read -r p; curl -sS -w '\n%{http_code}' -u \"\$u:\$p\" -A gop-purge-workflow '$url'")
           code=$(echo "$resp" | tail -1); body=$(echo "$resp" | sed '$d')
           if [ "$code" != "200" ]; then echo "::error::purge endpoint returned HTTP $code"; echo "$body" | head -c 400; echo; exit 1; fi
           echo "$body" | jq -c .
           echo "$body" | jq -e '.ok' >/dev/null
-
-      - name: Purge the cached API responses (zone cache, by URL)
-        env:
-          CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          API_URL: ${{ secrets.PYTHON_HTTP_URL }}
-          GAME_IDS: ${{ inputs.game_ids }}
-        run: |
-          set -uo pipefail
-          zone=$(curl -sS -H "Authorization: Bearer $CF_TOKEN" \
-            "https://api.cloudflare.com/client/v4/zones?name=gameonpaper.com" | jq -r '.result[0].id')
-          files=$(echo "$GAME_IDS" | tr -d ' ' | tr ',' '\n' | grep . | sed "s#^#${API_URL%/}/cfb/#; s#\$#/process#" | jq -R . | jq -s .)
-          resp=$(curl -sS -X POST -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
-            "https://api.cloudflare.com/client/v4/zones/$zone/purge_cache" --data "{\"files\": $files}")
-          echo "$resp" | jq -c '{success, errors}'
-          echo "$resp" | jq -e '.success' >/dev/null || echo "::warning::API-layer purge failed: CLOUDFLARE_API_TOKEN needs Zone -> Cache Purge. The page purge above still applied; the API layer expires on its own TTL."

--- a/.github/workflows/purge-game-cache.yml
+++ b/.github/workflows/purge-game-cache.yml
@@ -43,10 +43,13 @@ jobs:
         run: |
           set -euo pipefail
           tags=$(echo "$TAGS" | tr -d ' '); ids=$(echo "$GAME_IDS" | tr -d ' ')
-          url="https://gameonpaper.com/admin/api/purge-game?tags=$tags&ids=$ids"
-          # credentials travel on stdin, never on the remote command line
-          resp=$(printf '%s\n%s\n' "$ADMIN_USER" "$ADMIN_PASS" | ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
-            "read -r u; read -r p; curl -sS -w '\n%{http_code}' -u \"\$u:\$p\" -A gop-purge-workflow '$url'")
+          # empty inputs = the classic "clear every final game"; ids alone stay targeted
+          if [ -z "$tags" ] && [ -z "$ids" ]; then tags=game-completed; fi
+          url="https://gameonpaper.com/admin/api/purge-game"
+          # credentials AND inputs travel on stdin, never on the remote command line;
+          # curl --data-urlencode keeps workflow inputs data, not shell source
+          resp=$(printf '%s\n%s\n%s\n%s\n' "$ADMIN_USER" "$ADMIN_PASS" "$tags" "$ids" | ssh -i ~/.ssh/deploy_key -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" \
+            "read -r u; read -r p; read -r tags; read -r ids; curl -sS -w '\n%{http_code}' -u \"\$u:\$p\" -A gop-purge-workflow --get --data-urlencode \"tags=\$tags\" --data-urlencode \"ids=\$ids\" '$url'")
           code=$(echo "$resp" | tail -1); body=$(echo "$resp" | sed '$d')
           if [ "$code" != "200" ]; then echo "::error::purge endpoint returned HTTP $code"; echo "$body" | head -c 400; echo; exit 1; fi
           echo "$body" | jq -c .

--- a/astro/src/pages/admin/api/purge-game.ts
+++ b/astro/src/pages/admin/api/purge-game.ts
@@ -3,21 +3,46 @@ import { env } from 'cloudflare:workers';
 
 export const prerender = false;
 
-// Purge cached game pages from inside the Worker. Workers Caching is scoped to
-// the Worker: no zone-level purge (dashboard, API, Terraform) reaches it, only
+// Purge cached pages from inside the Worker. Workers Caching is scoped to the
+// Worker: no zone-level purge (dashboard, API, Terraform) reaches it, only
 // ctx.cache.purge -- which Astro exposes as cache.invalidate. Behind /admin
-// basic auth. `?ids=401856766,401864570` (also accepts a JSON body {ids: []}).
+// basic auth.
+//   ?tags=game-completed          every final game page (after a parser fix)
+//   ?ids=401856766,401864570      specific games (also resets their regression mark)
+// Both may be combined. The API-layer response cache is keyed on APP_VERSION,
+// so a deploy already invalidates it; this only has to clear the rendered pages.
+const KNOWN_TAGS = new Set(['game-completed', 'game-in-progress', 'game-scheduled-today',
+    'game-scheduled-future', 'scoreboard', 'matchup', 'favorites-enabled']);
+
 export const GET: APIRoute = async (context) => purge(context);
 export const POST: APIRoute = async (context) => purge(context);
 
 async function purge(context: Parameters<APIRoute>[0]): Promise<Response> {
-    let ids: string[] = (context.url.searchParams.get('ids') ?? '').split(',');
+    const q = context.url.searchParams;
+    let ids = (q.get('ids') ?? '').split(',');
+    let tags = (q.get('tags') ?? '').split(',');
     if (context.request.method === 'POST') {
-        try { ids = ids.concat(((await context.request.json()) as { ids?: unknown[] })?.ids?.map(String) ?? []); } catch { /* no body */ }
+        try {
+            const body = (await context.request.json()) as { ids?: unknown[]; tags?: unknown[] };
+            ids = ids.concat(body?.ids?.map(String) ?? []);
+            tags = tags.concat(body?.tags?.map(String) ?? []);
+        } catch { /* no body */ }
     }
     ids = [...new Set(ids.map((s) => s.trim()).filter((s) => /^\d{6,12}$/.test(s)))];
-    if (ids.length === 0) return Response.json({ ok: false, error: 'no valid game ids' }, { status: 400 });
+    const badTags = tags.map((s) => s.trim()).filter((s) => s && !KNOWN_TAGS.has(s));
+    tags = [...new Set(tags.map((s) => s.trim()).filter((s) => KNOWN_TAGS.has(s)))];
+    if (badTags.length) return Response.json({ ok: false, error: `unknown tags: ${badTags.join(',')}`, known: [...KNOWN_TAGS] }, { status: 400 });
+    if (ids.length === 0 && tags.length === 0) return Response.json({ ok: false, error: 'give ?ids= and/or ?tags=' }, { status: 400 });
+
     const results: Record<string, string> = {};
+    if (tags.length) {
+        try {
+            await context.cache.invalidate({ tags });
+            for (const t of tags) results[`tag:${t}`] = 'purged';
+        } catch (e: any) {
+            for (const t of tags) results[`tag:${t}`] = `error: ${e?.message ?? e}`;
+        }
+    }
     for (const id of ids) {
         try {
             await context.cache.invalidate({ path: `/game/${id}` });

--- a/astro/src/pages/admin/api/purge-game.ts
+++ b/astro/src/pages/admin/api/purge-game.ts
@@ -12,7 +12,10 @@ export const prerender = false;
 // Both may be combined. The API-layer response cache is keyed on APP_VERSION,
 // so a deploy already invalidates it; this only has to clear the rendered pages.
 const KNOWN_TAGS = new Set(['game-completed', 'game-in-progress', 'game-scheduled-today',
-    'game-scheduled-future', 'scoreboard', 'matchup', 'favorites-enabled']);
+    'game-scheduled-future', 'scoreboard', 'matchup', 'favorites-enabled',
+    // week/schedule + chart pages (see the tags: lists in utils/config.ts and pages/)
+    'week-complete', 'week-in-progress', 'week-scheduled-current-week',
+    'week-scheduled-current-season', 'chart']);
 
 export const GET: APIRoute = async (context) => purge(context);
 export const POST: APIRoute = async (context) => purge(context);

--- a/astro/src/resources/python.ts
+++ b/astro/src/resources/python.ts
@@ -824,6 +824,7 @@ export interface ProcessedGame {
 
 const PYTHON_HTTP_URL = getSecret("PYTHON_HTTP_URL") || 'http://python:5000';
 const PYTHON_HTTP_TOKEN = getSecret("PYTHON_HTTP_TOKEN");
+const APP_VERSION = getSecret("APP_VERSION") || "dev";
 
 export async function retrieveProcessedGame(gameId: string | number, cacheTTL: number): Promise<ProcessedGame> {
     const processed: ProcessedGame = await processPlays(gameId, cacheTTL);
@@ -924,7 +925,15 @@ async function processPlays(gameId: string | number, cacheTTL: number): Promise<
             "Authorization": `Bearer ${encodedToken}`,
             "Referer": "gameonpaper.com" 
         },
-        cf: { cacheEverything: true, cacheTtlByStatus: { "200-299": cacheTTL, 404: 1, "500-599": 0 } }
+        cf: {
+            cacheEverything: true,
+            cacheTtlByStatus: { "200-299": cacheTTL, 404: 1, "500-599": 0 },
+            // A completed game's API response is cached for a year. Keying it on the
+            // deployed version means a deploy (a parser fix in sportsdataverse-py
+            // rides in with every build) invalidates it without any zone purge; the
+            // page-side tag purge then re-renders from a fresh API response.
+            cacheKey: `${PYTHON_HTTP_URL}/cfb/${gameId}/process?v=${APP_VERSION}`,
+        }
     })
     const content = await req.text();
 


### PR DESCRIPTION
Follow-up to #174 per review: purge by **tag**, not URL/zone.

## What
- `/admin/api/purge-game?tags=game-completed` → `cache.invalidate({ tags })` inside the Worker (the only thing that reaches Workers Caching). Tags are allowlisted to the ones the pages set (`game-completed`, `game-in-progress`, `game-scheduled-today`, `game-scheduled-future`, `scoreboard`, `matchup`, `favorites-enabled`). `?ids=` remains for targeted purges and still resets the regression guard's mark.
- `purge-game-cache.yml`: `tags` input (default `game-completed`), `game_ids` optional; the zone-purge step is gone, so **no Cloudflare token permission is needed**.

## The catch that made tag purge insufficient on its own
A final game's page re-renders from the worker's cached fetch of `/cfb/<id>/process` (`cf.cacheEverything`, one-year TTL, no tag). That fetch's `cf.cacheKey` now includes `APP_VERSION` (= deploy SHA), so every deploy invalidates the API layer for free; after a parser fix the sequence is simply *deploy → run the workflow* (or `curl -u … 'https://gameonpaper.com/admin/api/purge-game?tags=game-completed'`).

vitest 71/71; compiles on Node 22.

## Summary by Sourcery

Enable reliable post-deployment cache refreshes by combining tag-based rendered-page purges with deployment-versioned API caching.

New Features:
- Add tag-based invalidation for rendered game and related pages, with optional targeted game purges and validation of supported tags.

Bug Fixes:
- Ensure every deployment invalidates cached processed-game API responses, including redeployments using the same source commit.

Enhancements:
- Simplify cache-purge operations by removing the Cloudflare zone-level purge and relying on deploy-versioned API caching plus Worker-side page invalidation.

CI:
- Update the manual purge workflow to accept tags and optional game IDs while removing the requirement for Cloudflare cache-purge permissions.

Deployment:
- Include the deployment run identifier in APP_VERSION so each deployment receives a unique API cache key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for clearing cached game pages by cache tag or game ID.
  - Added validation for supported cache tags, with clear errors for invalid values.
  - Game cache purge requests can now target multiple cache categories at once.

- **Bug Fixes**
  - Improved cache invalidation so updated deployments use fresh API responses instead of outdated cached data.
  - Simplified cache clearing by removing redundant API-response purge handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->