### PR TITLE
feat(plays): fourth-down and 2PT decision cards in the expanded play row

### DIFF
--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -25,7 +25,6 @@ interface Props {
     recommended?: string | null
     /** Option key the team actually chose, when it can be read off the play. */
     actual?: string | null
-    attribution?: string
     confidenceMeasure?: number | null
 }
 
@@ -35,7 +34,6 @@ const {
     recommended = null,
     actual = null,
     confidenceMeasure = null,
-    attribution = "Based on work by Ben Baldwin (@rbsdm.com on Bluesky) and Jared Lee (@Kazink36 on Github).",
 } = Astro.props;
 
 const withWp = options.filter(o => o.wp != null);
@@ -65,14 +63,14 @@ if (confidenceMeasure) {
 
 <div class="container d-flex justify-content-center mx-auto">
     <div class="p-1 bordered">
-        <div class={`p-2 rounded border`}>
+        <div class="p-2 rounded border">
             <div class="text-center mb-3">
-                <p class="mb-0" title={attribution}><strong>{title}</strong></p>
+                <p class="mb-0"><strong>{title}</strong></p>
                 {recLabel && <p class="mb-0">Bot says: <strong>{recLabel} </strong></p>}
                 {recConfidence && <p class="mb-0">({recConfidence} - diff: {generateMarginalString(Math.abs(confidenceMeasure), 2, 1)}%)</p>}
                 {disagree && actualLabel && <span class="badge bg-danger rounded">Team chose {actualLabel}</span>}
             </div>
-            <div class="container text-center">
+            <div class="container text-center mb-1">
                 <div class="row gap-2">
                 {options.map((o) => {
                     const isRec = o.key == recommended;
@@ -100,6 +98,9 @@ if (confidenceMeasure) {
                     );
                 })}
             </div>
+            </div>
+            <div class="d-flex justify-content-center text-center">
+                <small class="w-75 m-0 text-muted">From GameOnPaper.com<br>Based on work by Ben Baldwin (<a href="https://bsky.app/profile/rbsdm.com">@rbsdm.com</a>) and Jared Lee (<a href="https://github.com/Kazink36">@Kazink36</a>).</small>
             </div>
         </div>
     </div>

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -8,7 +8,7 @@
  * team actually chose is tagged, and a disagreement is called out in the
  * header so it reads at a glance in a screenshot.
  */
-import { roundNumber } from '../../../utils/misc';
+import { generateMarginalString, roundNumber } from '../../../utils/misc';
 
 export interface DecisionOption {
     key: string
@@ -26,6 +26,7 @@ interface Props {
     /** Option key the team actually chose, when it can be read off the play. */
     actual?: string | null
     attribution?: string
+    confidenceMeasure?: number | null
 }
 
 const {
@@ -33,6 +34,7 @@ const {
     options,
     recommended = null,
     actual = null,
+    confidenceMeasure = null,
     attribution = "Based on work by Ben Baldwin (@rbsdm.com on Bluesky) and Jared Lee (@Kazink36 on Github).",
 } = Astro.props;
 
@@ -47,49 +49,64 @@ const delta = (wp: number | null | undefined): string | null => {
     const diff = (wp - bestWp) * 100;
     return Math.abs(diff) < 0.05 ? "best" : `${roundNumber(diff, 2, 1)}`;
 };
+let recConfidence = null;
+if (confidenceMeasure) {
+    if (Math.abs(confidenceMeasure) > 10) {
+        recConfidence = "VERY STRONG"
+    } else if (Math.abs(confidenceMeasure) > 3 && Math.abs(confidenceMeasure) <= 10) {
+        recConfidence = "STRONG"
+    } else if (Math.abs(confidenceMeasure) >= 1 && Math.abs(confidenceMeasure) <= 3) {
+        recConfidence = "MEDIUM"
+    } else if (Math.abs(confidenceMeasure) < 1) {
+        recConfidence = "LOW"
+    }
+}
 ---
 
-<div class={`decision-card ${disagree ? "decision-card--disagree" : ""}`}>
-    <div class="decision-card__header">
-        <span class="decision-card__title" title={attribution}>{title}</span>
-        {recLabel && <span class="decision-card__verdict">Bot says: <strong>{recLabel}</strong></span>}
-        {disagree && actualLabel && <span class="decision-card__flag">Team chose {actualLabel}</span>}
-    </div>
-    <div class="decision-card__tiles">
-        {options.map((o) => {
-            const isRec = o.key == recommended;
-            const isActual = o.key == actual;
-            const d = delta(o.wp);
-            return (
-                <div class={`decision-tile ${isRec ? "decision-tile--rec" : ""} ${isActual ? "decision-tile--actual" : ""}`}>
-                    <div class="decision-tile__label">
-                        {o.label}
-                        {isActual && <span class="decision-tile__tag">chosen</span>}
-                    </div>
-                    <div class="decision-tile__wp">{pct(o.wp)}</div>
-                    <div class="decision-tile__sub">
-                        {d == "best" ? "best option" : d == null ? "" : `${d} vs best`}
-                    </div>
-                    {o.successProb != null && (
-                        <div class="decision-tile__sub decision-tile__success">{o.successLabel ?? "success"} {pct(o.successProb, 0)}</div>
-                    )}
-                </div>
-            );
-        })}
+<div class="container d-flex justify-content-center mx-auto">
+    <div class="p-1 bordered">
+        <div class={`p-2 rounded border`}>
+            <div class="text-center mb-3">
+                <p class="mb-0" title={attribution}><strong>{title}</strong></p>
+                {recLabel && <p class="mb-0">Bot says: <strong>{recLabel} </strong></p>}
+                {recConfidence && <p class="mb-0">({recConfidence} - diff: {generateMarginalString(confidenceMeasure, 2, 1)}%)</p>}
+                {disagree && actualLabel && <span class="badge bg-danger rounded">Team chose {actualLabel}</span>}
+            </div>
+            <div class="container text-center">
+                <div class="row gap-2">
+                {options.map((o) => {
+                    const isRec = o.key == recommended;
+                    const isActual = o.key == actual;
+
+                    let tileClass = ""
+                    if (isActual && isRec) {
+                        tileClass = "decision-tile--agree"
+                    } else if (!isActual && isRec) {
+                        tileClass = "decision-tile--rec"
+                    } else if (isActual && !isRec) {
+                        tileClass = "decision-tile--disagree"
+                    }
+
+                    return (
+                        <div class={`col p-2 rounded border text-center ${tileClass}`}>
+                            <div class="decision-tile__label">
+                                {o.label}
+                            </div>
+                            <div class="decision-tile__wp">{pct(o.wp)}</div>
+                            {o.successProb != null && (
+                                <div class="text-small text-muted"><small>{o.successLabel ?? "success"}: {pct(o.successProb, 0)}</small></div>
+                            )}
+                        </div>
+                    );
+                })}
+            </div>
+            </div>
+        </div>
     </div>
 </div>
-
 <style>
-    .decision-card {
-        border: 1px solid var(--bs-border-color, #dee2e6);
-        border-radius: 0.5rem;
-        padding: 0.6rem 0.75rem;
-        margin: 0.5rem auto;
-        max-width: 34rem;
-        background: var(--bs-body-bg, #fff);
-        text-align: center;
-    }
-    .decision-card--disagree { border-color: #d9534f; }
+    .decision-tile--disagree { border: 2px solid var(--bs-danger) !important; }
+    .decision-tile--agree { border: 2px solid var(--bs-success) !important; }
     .decision-card__header {
         display: flex;
         flex-wrap: wrap;
@@ -100,32 +117,11 @@ const delta = (wp: number | null | undefined): string | null => {
     }
     .decision-card__title { font-weight: 700; }
     .decision-card__verdict { font-size: 0.9rem; }
-    .decision-card__flag {
-        font-size: 0.8rem;
-        color: #fff;
-        background: #d9534f;
-        border-radius: 999px;
-        padding: 0.05rem 0.55rem;
-    }
-    .decision-card__tiles {
-        display: grid;
-        grid-auto-flow: column;
-        grid-auto-columns: 1fr;
-        gap: 0.5rem;
-    }
-    .decision-tile {
-        border: 1px solid var(--bs-border-color, #dee2e6);
-        border-radius: 0.4rem;
-        padding: 0.4rem 0.25rem;
-        opacity: 0.85;
-    }
+
     .decision-tile--rec {
-        border: 2px solid var(--bs-primary, #0d6efd);
-        opacity: 1;
-        font-weight: 600;
+        border: 2px solid var(--bs-primary, #0d6efd) !important;
     }
-    .decision-tile--actual { background: var(--bs-tertiary-bg, #f8f9fa); opacity: 1; }
-    .decision-tile__label { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .decision-tile__label { text-transform: uppercase; }
     .decision-tile__tag {
         display: inline-block;
         margin-left: 0.3rem;
@@ -137,6 +133,6 @@ const delta = (wp: number | null | undefined): string | null => {
         padding: 0 0.35rem;
     }
     .decision-tile__wp { font-size: 1.35rem; font-variant-numeric: tabular-nums; line-height: 1.2; }
-    .decision-tile__sub { font-size: 0.75rem; color: var(--bs-secondary-color, #6c757d); }
-    .decision-tile__success { font-variant-numeric: tabular-nums; }
+    /* .decision-tile__sub { font-size: 0.75rem; color: var(--bs-secondary-color, #6c757d); } */
+    /* .decision-tile__success { font-variant-numeric: tabular-nums; } */
 </style>

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -61,7 +61,7 @@ if (confidenceMeasure) {
 }
 ---
 
-<div class="container d-flex justify-content-center mx-auto">
+<div class="container d-flex justify-content-center mx-auto mb-3">
     <div class="p-1 bordered">
         <div class="p-2 rounded border">
             <div class="text-center mb-3">

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -107,17 +107,6 @@ if (confidenceMeasure) {
 <style>
     .decision-tile--disagree { border: 2px solid var(--bs-danger) !important; }
     .decision-tile--agree { border: 2px solid var(--bs-success) !important; }
-    .decision-card__header {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 0.25rem 0.75rem;
-        align-items: baseline;
-        margin-bottom: 0.5rem;
-    }
-    .decision-card__title { font-weight: 700; }
-    .decision-card__verdict { font-size: 0.9rem; }
-
     .decision-tile--rec {
         border: 2px solid var(--bs-primary, #0d6efd) !important;
     }
@@ -133,6 +122,4 @@ if (confidenceMeasure) {
         padding: 0 0.35rem;
     }
     .decision-tile__wp { font-size: 1.35rem; font-variant-numeric: tabular-nums; line-height: 1.2; }
-    /* .decision-tile__sub { font-size: 0.75rem; color: var(--bs-secondary-color, #6c757d); } */
-    /* .decision-tile__success { font-variant-numeric: tabular-nums; } */
 </style>

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -69,7 +69,7 @@ if (confidenceMeasure) {
             <div class="text-center mb-3">
                 <p class="mb-0" title={attribution}><strong>{title}</strong></p>
                 {recLabel && <p class="mb-0">Bot says: <strong>{recLabel} </strong></p>}
-                {recConfidence && <p class="mb-0">({recConfidence} - diff: {generateMarginalString(confidenceMeasure, 2, 1)}%)</p>}
+                {recConfidence && <p class="mb-0">({recConfidence} - diff: {generateMarginalString(Math.abs(confidenceMeasure), 2, 1)}%)</p>}
                 {disagree && actualLabel && <span class="badge bg-danger rounded">Team chose {actualLabel}</span>}
             </div>
             <div class="container text-center">

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -42,11 +42,6 @@ const recLabel = options.find(o => o.key == recommended)?.label ?? null;
 const actualLabel = options.find(o => o.key == actual)?.label ?? null;
 const disagree = recommended != null && actual != null && recommended != actual;
 const pct = (v: number | null | undefined, d = 1) => v == null ? "—" : `${roundNumber(v * 100, 2, d)}%`;
-const delta = (wp: number | null | undefined): string | null => {
-    if (wp == null || bestWp == null) return null;
-    const diff = (wp - bestWp) * 100;
-    return Math.abs(diff) < 0.05 ? "best" : `${roundNumber(diff, 2, 1)}`;
-};
 let recConfidence = null;
 if (confidenceMeasure) {
     if (Math.abs(confidenceMeasure) > 10) {

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -61,8 +61,8 @@ if (confidenceMeasure) {
         <div class="p-2 rounded border">
             <div class="text-center mb-3">
                 <p class="mb-0"><strong>{title}</strong></p>
-                {recLabel && <p class="mb-0">Bot says: <strong>{recLabel} </strong></p>}
-                {recConfidence && <p class="mb-0">({recConfidence} - diff: {generateMarginalString(Math.abs(confidenceMeasure), 2, 1)}%)</p>}
+                {recLabel && <p class="mb-0"><strong>{recLabel}</strong></p>}
+                {confidenceMeasure && recConfidence && <p class="mb-0">({recConfidence} - diff: {generateMarginalString(Math.abs(confidenceMeasure), 2, 1)}%)</p>}
                 {disagree && actualLabel && <span class="badge bg-danger rounded">Team chose {actualLabel}</span>}
             </div>
             <div class="container text-center mb-1">

--- a/astro/src/components/game/plays/DecisionCard.astro
+++ b/astro/src/components/game/plays/DecisionCard.astro
@@ -1,0 +1,142 @@
+---
+/**
+ * Fourth-down / two-point decision card for the expanded play row.
+ *
+ * One tile per option (Go / FG / Punt, or 2PT / XP) showing the model's
+ * expected win probability, the gap to the best option, and the option's
+ * success probability. The recommended tile is outlined; the option the
+ * team actually chose is tagged, and a disagreement is called out in the
+ * header so it reads at a glance in a screenshot.
+ */
+import { roundNumber } from '../../../utils/misc';
+
+export interface DecisionOption {
+    key: string
+    label: string
+    wp?: number | null
+    /** Model probability the option succeeds (first down / FG make / 2PT conversion). */
+    successProb?: number | null
+    successLabel?: string
+}
+
+interface Props {
+    title: string
+    options: DecisionOption[]
+    recommended?: string | null
+    /** Option key the team actually chose, when it can be read off the play. */
+    actual?: string | null
+    attribution?: string
+}
+
+const {
+    title,
+    options,
+    recommended = null,
+    actual = null,
+    attribution = "Based on work by Ben Baldwin (@rbsdm.com on Bluesky) and Jared Lee (@Kazink36 on Github).",
+} = Astro.props;
+
+const withWp = options.filter(o => o.wp != null);
+const bestWp = withWp.length ? Math.max(...withWp.map(o => o.wp as number)) : null;
+const recLabel = options.find(o => o.key == recommended)?.label ?? null;
+const actualLabel = options.find(o => o.key == actual)?.label ?? null;
+const disagree = recommended != null && actual != null && recommended != actual;
+const pct = (v: number | null | undefined, d = 1) => v == null ? "—" : `${roundNumber(v * 100, 2, d)}%`;
+const delta = (wp: number | null | undefined): string | null => {
+    if (wp == null || bestWp == null) return null;
+    const diff = (wp - bestWp) * 100;
+    return Math.abs(diff) < 0.05 ? "best" : `${roundNumber(diff, 2, 1)}`;
+};
+---
+
+<div class={`decision-card ${disagree ? "decision-card--disagree" : ""}`}>
+    <div class="decision-card__header">
+        <span class="decision-card__title" title={attribution}>{title}</span>
+        {recLabel && <span class="decision-card__verdict">Bot says: <strong>{recLabel}</strong></span>}
+        {disagree && actualLabel && <span class="decision-card__flag">Team chose {actualLabel}</span>}
+    </div>
+    <div class="decision-card__tiles">
+        {options.map((o) => {
+            const isRec = o.key == recommended;
+            const isActual = o.key == actual;
+            const d = delta(o.wp);
+            return (
+                <div class={`decision-tile ${isRec ? "decision-tile--rec" : ""} ${isActual ? "decision-tile--actual" : ""}`}>
+                    <div class="decision-tile__label">
+                        {o.label}
+                        {isActual && <span class="decision-tile__tag">chosen</span>}
+                    </div>
+                    <div class="decision-tile__wp">{pct(o.wp)}</div>
+                    <div class="decision-tile__sub">
+                        {d == "best" ? "best option" : d == null ? "" : `${d} vs best`}
+                    </div>
+                    {o.successProb != null && (
+                        <div class="decision-tile__sub decision-tile__success">{o.successLabel ?? "success"} {pct(o.successProb, 0)}</div>
+                    )}
+                </div>
+            );
+        })}
+    </div>
+</div>
+
+<style>
+    .decision-card {
+        border: 1px solid var(--bs-border-color, #dee2e6);
+        border-radius: 0.5rem;
+        padding: 0.6rem 0.75rem;
+        margin: 0.5rem auto;
+        max-width: 34rem;
+        background: var(--bs-body-bg, #fff);
+        text-align: center;
+    }
+    .decision-card--disagree { border-color: #d9534f; }
+    .decision-card__header {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.25rem 0.75rem;
+        align-items: baseline;
+        margin-bottom: 0.5rem;
+    }
+    .decision-card__title { font-weight: 700; }
+    .decision-card__verdict { font-size: 0.9rem; }
+    .decision-card__flag {
+        font-size: 0.8rem;
+        color: #fff;
+        background: #d9534f;
+        border-radius: 999px;
+        padding: 0.05rem 0.55rem;
+    }
+    .decision-card__tiles {
+        display: grid;
+        grid-auto-flow: column;
+        grid-auto-columns: 1fr;
+        gap: 0.5rem;
+    }
+    .decision-tile {
+        border: 1px solid var(--bs-border-color, #dee2e6);
+        border-radius: 0.4rem;
+        padding: 0.4rem 0.25rem;
+        opacity: 0.85;
+    }
+    .decision-tile--rec {
+        border: 2px solid var(--bs-primary, #0d6efd);
+        opacity: 1;
+        font-weight: 600;
+    }
+    .decision-tile--actual { background: var(--bs-tertiary-bg, #f8f9fa); opacity: 1; }
+    .decision-tile__label { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .decision-tile__tag {
+        display: inline-block;
+        margin-left: 0.3rem;
+        font-size: 0.65rem;
+        text-transform: none;
+        letter-spacing: 0;
+        border: 1px solid currentColor;
+        border-radius: 999px;
+        padding: 0 0.35rem;
+    }
+    .decision-tile__wp { font-size: 1.35rem; font-variant-numeric: tabular-nums; line-height: 1.2; }
+    .decision-tile__sub { font-size: 0.75rem; color: var(--bs-secondary-color, #6c757d); }
+    .decision-tile__success { font-variant-numeric: tabular-nums; }
+</style>

--- a/astro/src/components/game/plays/ExpandedPlayRow.astro
+++ b/astro/src/components/game/plays/ExpandedPlayRow.astro
@@ -13,39 +13,6 @@ const awayTeam = { id: play.awayTeamId, location: play.awayTeamName, abbreviatio
 const offense = (play.start.pos_team.id == homeTeam.id) ? homeTeam : awayTeam;
 const defense = (play.start.pos_team.id == homeTeam.id) ? awayTeam : homeTeam;
 
-let goRecommendation: string | null = null;
-if (play.fourth_down_recommendation) {
-    switch (play.fourth_down_recommendation) {
-        case "go":
-            goRecommendation = "Go"
-            break;
-        case "field_goal":
-            goRecommendation = "Field Goal";
-            break;
-        case "punt":
-            goRecommendation = "Punt";
-            break;
-        default:
-            goRecommendation = null;
-            break;
-    }
-}
-
-let xpRecommendation: string | null = null;
-if (play.two_pt_recommendation) {
-    switch (play.two_pt_recommendation) {
-        case "kick_xp":
-            xpRecommendation = "XP"
-            break;
-        case "go_for_2":
-            xpRecommendation = "2PT";
-            break;
-        default:
-            xpRecommendation = null;
-            break;
-    }
-}
-
 // What the offense actually did, read off the play flags (null when ambiguous,
 // e.g. a penalty-only row).
 const fourthDownActual: string | null =
@@ -57,8 +24,9 @@ const tryActual: string | null =
     play.two_point_conv_result != null ? "go_for_2"
     : play.extra_point_result != null ? "kick_xp"
     : null;
-const showFourthDown = play.start.down == 4 && !!goRecommendation;
-const showTry = !!xpRecommendation;
+const showFourthDown = play.start.down == 4 && !!play.fourth_down_recommendation;
+const showTry = !!play.two_pt_recommendation;
+
 
 ---
 <div class="row p-1">
@@ -91,9 +59,10 @@ const showTry = !!xpRecommendation;
                         title="Fourth Down Bot"
                         recommended={play.fourth_down_recommendation}
                         actual={fourthDownActual}
+                        confidenceMeasure={play.go_boost}
                         options={[
                             { key: "go", label: "Go", wp: play.go_wp, successProb: play.first_down_prob, successLabel: "convert" },
-                            { key: "field_goal", label: "Field Goal", wp: play.fg_wp, successProb: play.fg_make_prob, successLabel: "make" },
+                            { key: "field_goal", label: "FG", wp: play.fg_wp, successProb: play.fg_make_prob, successLabel: "make" },
                             { key: "punt", label: "Punt", wp: play.punt_wp },
                         ]}
                     />
@@ -103,6 +72,7 @@ const showTry = !!xpRecommendation;
                         title="2PT Bot"
                         recommended={play.two_pt_recommendation}
                         actual={tryActual}
+                        confidenceMeasure={play.two_pt_wp_diff}
                         options={[
                             { key: "go_for_2", label: "Go for 2", wp: play.two_pt_wp, successProb: play.prob_2pt, successLabel: "convert" },
                             { key: "kick_xp", label: "Kick XP", wp: play.xp_wp },

--- a/astro/src/components/game/plays/ExpandedPlayRow.astro
+++ b/astro/src/components/game/plays/ExpandedPlayRow.astro
@@ -1,6 +1,7 @@
 ---
 import type { ProcessedPlay } from '../../../resources/python';
 import { formatYardline, roundNumber, cleanAbbreviation, toTitleCase } from '../../../utils/misc';
+import DecisionCard from './DecisionCard.astro';
 
 interface Props {
     play: ProcessedPlay
@@ -45,6 +46,20 @@ if (play.two_pt_recommendation) {
     }
 }
 
+// What the offense actually did, read off the play flags (null when ambiguous,
+// e.g. a penalty-only row).
+const fourthDownActual: string | null =
+    play.punt ? "punt"
+    : play.fg_attempt ? "field_goal"
+    : (play.pass || play.rush || play.sack_vec) ? "go"
+    : null;
+const tryActual: string | null =
+    play.two_point_conv_result != null ? "go_for_2"
+    : play.extra_point_result != null ? "kick_xp"
+    : null;
+const showFourthDown = play.start.down == 4 && !!goRecommendation;
+const showTry = !!xpRecommendation;
+
 ---
 <div class="row p-1">
 <div class="ms-sm-auto col-lg-6">
@@ -55,14 +70,6 @@ if (play.two_pt_recommendation) {
 <p style="text-align: center;"><strong>Score Difference (Before):</strong> {play.start.pos_score_diff} ({roundNumber(play.start.ExpScoreDiff, 2, 2)})</p>
 <p style="text-align: center;"><strong>Score Difference (End):</strong> {play.end.pos_score_diff} ({roundNumber(play.end.ExpScoreDiff, 2, 2)})</p>
 <p style="text-align: center;"><strong>Change of Possession:</strong> {play.change_of_poss || "false"}</p>
-{
-    (play.start.down == 4) && (goRecommendation) && (
-        <p class="mb-0" style="text-align: center;">
-            <strong title="Based on work by Ben Baldwin (@rbsdm.com on Bluesky) and Jared Lee (@Kazink36 on Github).">Fourth Down Bot says:</strong> <span>{goRecommendation}</span>
-        </p>
-        <p class="mb-3" style="text-align: center;"><strong>Expected WP:</strong> Go {roundNumber((play.go_wp || 0) * 100, 2, 1)}% / FG {roundNumber((play.fg_wp || 0) * 100, 2, 1)}% / Punt {roundNumber((play.punt_wp || 0) * 100, 2, 1)}%</p>
-    )
-}
 </div>
 <div class="ms-sm-auto col-lg-6">
 <p style="text-align: center;"><strong>Score:</strong> {cleanAbbreviation(awayTeam)} {play.awayScore}, {cleanAbbreviation(homeTeam)} {play.homeScore}</p>
@@ -72,15 +79,37 @@ if (play.two_pt_recommendation) {
 <p style="text-align: center;"><strong>Away Score:</strong> {play.start.awayScore} ({play.awayScore}) <strong>Home Score:</strong> {play.start.homeScore} ({play.homeScore})</p>
 <p style="text-align: center;"><strong>Pos Team Timeouts:</strong> {play.end.posTeamTimeouts} <strong>Defense Timeouts:</strong> {play.end.defPosTeamTimeouts}</p>
 
+</div>
+</div>
+
 {
-    (xpRecommendation) && (
-        <p class="mb-0" style="text-align: center;">
-            <strong title="Based on work by Ben Baldwin (@rbsdm.com on Bluesky) and Jared Lee (@Kazink36 on Github).">2PT Bot says:</strong> <span>{xpRecommendation}</span>
-        </p>
-        <p class="mb-3" style="text-align: center;"><strong>Expected WP:</strong> 2PT {roundNumber((play.two_pt_wp || 0) * 100, 2, 1)}% / XP {roundNumber((play.xp_wp || 0) * 100, 2, 1)}%</p>
+    (showFourthDown || showTry) && (
+        <div class="row p-1">
+            <div class="col-12">
+                {showFourthDown && (
+                    <DecisionCard
+                        title="Fourth Down Bot"
+                        recommended={play.fourth_down_recommendation}
+                        actual={fourthDownActual}
+                        options={[
+                            { key: "go", label: "Go", wp: play.go_wp, successProb: play.first_down_prob, successLabel: "convert" },
+                            { key: "field_goal", label: "Field Goal", wp: play.fg_wp, successProb: play.fg_make_prob, successLabel: "make" },
+                            { key: "punt", label: "Punt", wp: play.punt_wp },
+                        ]}
+                    />
+                )}
+                {showTry && (
+                    <DecisionCard
+                        title="2PT Bot"
+                        recommended={play.two_pt_recommendation}
+                        actual={tryActual}
+                        options={[
+                            { key: "go_for_2", label: "Go for 2", wp: play.two_pt_wp, successProb: play.prob_2pt, successLabel: "convert" },
+                            { key: "kick_xp", label: "Kick XP", wp: play.xp_wp },
+                        ]}
+                    />
+                )}
+            </div>
+        </div>
     )
 }
-
-</div>
-</div>
-

--- a/astro/src/components/game/plays/ExpandedPlayRow.astro
+++ b/astro/src/components/game/plays/ExpandedPlayRow.astro
@@ -72,7 +72,7 @@ const showTry = !!play.two_pt_recommendation;
                         title="2PT Bot"
                         recommended={play.two_pt_recommendation}
                         actual={tryActual}
-                        confidenceMeasure={play.two_pt_wp_diff}
+                        confidenceMeasure={(play.two_pt_wp_diff || 0) * 100}
                         options={[
                             { key: "go_for_2", label: "Go for 2", wp: play.two_pt_wp, successProb: play.prob_2pt, successLabel: "convert" },
                             { key: "kick_xp", label: "Kick XP", wp: play.xp_wp },


### PR DESCRIPTION
## Summary
- New `DecisionCard.astro` replaces the two "Fourth Down Bot says / 2PT Bot says" text lines in `ExpandedPlayRow.astro`.
- One tile per option showing **expected WP**, **Δ vs best**, and the option's **success probability** (`first_down_prob`, `fg_make_prob`, `prob_2pt`).
- Recommended tile outlined; the option the team actually took (read off `punt` / `fg_attempt` / pass-rush-sack flags, `two_point_conv_result` / `extra_point_result`) is tagged **chosen**; a disagreement turns the card border red with a "Team chose X" pill.
- Full-width row under the existing two columns; scoped CSS on Bootstrap vars, no new deps. Attribution kept on the title tooltip.

All fields already ship in the play payload (`go_wp`, `fg_wp`, `punt_wp`, `*_wp_diff`, `two_pt_wp`, `xp_wp`, …).

Note: #175 also touches `ExpandedPlayRow.astro` (expected-points line); this PR only removes the two bot blocks and appends a row, so the merge should be clean either order.

## Test plan
- [x] `npx astro check` — no new errors (11 pre-existing before and after)
- [ ] Expand a 4th-down play on a 2024+ game: card renders, recommended tile outlined, chosen tile tagged
- [ ] Expand a TD play: 2PT card renders with XP / 2PT tiles
- [ ] Non-4th-down, non-TD play: no card row

## Summary by Sourcery

Add visual decision cards to expanded play rows for evaluating fourth-down and two-point decisions.

New Features:
- Add decision cards for fourth-down and two-point choices, showing expected win probability, option deltas, and success probabilities.
- Indicate the model-recommended option and the team’s actual choice, highlighting disagreements.

Enhancements:
- Replace the expanded play row’s fourth-down and two-point bot text with a compact, reusable card presentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added decision cards for fourth-down and two-point attempts.
  * Displays recommended and actual choices, expected win probability, success probability, and recommendation confidence.
  * Highlights the recommended option and calls out disagreements between the recommendation and the team’s decision.
  * Decision cards now appear in expanded play details when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->