### PR TITLE
feat(seo): game pages — titles, SportsEvent JSON-LD, h1, pregame canonical

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -26,6 +26,7 @@ import { CURRENT_YEAR, LAST_YEAR, SESSION_FAVORITES_DEFAULT } from '../../utils/
 import Footer from '../Footer.astro';
 import "bootstrap-icons/font/bootstrap-icons.css";
 import FallbackSpinner from '../FallbackSpinner.astro';
+import { gameDescription, gameTitle, jsonLdScript, sportsEventJsonLd } from '../../utils/seo';
 
 interface Props {
    id: string | number
@@ -61,14 +62,22 @@ const gameNote = game.header?.gameNote ?? "";
 const isChampEvent = isChampionshipEvent(gameNote);
 const gameStatus = game.header.competitions[0].status;
 
-let title = "";
-let subtitle = "";
-if (gameStatus.type.completed == true || gameStatus.type.name.includes("STATUS_IN_PROGRESS") || (gameStatus.type.name.includes("STATUS_DELAYED") && game.plays.length > 0)) {
-    title = `Game: ${cleanLocation(awayComp.team)} ${awayComp.score}, ${cleanLocation(homeComp.team)} ${homeComp.score} | Game on Paper`
-} else {
-    title = `Game: ${cleanLocation(awayComp.team)} vs ${cleanLocation(homeComp.team)} | Game on Paper`
-}
-subtitle = `${cleanLocation(awayComp.team)} vs ${cleanLocation(homeComp.team)}`;
+// Title/description/JSON-LD say what the page is (final, week, "EPA per play",
+// "win probability") -- "Game: X, Y" and "Advanced stats for X vs Y" gave Google
+// nothing to match a query against. Rendered names stay lowercased.
+const hasScore = gameStatus.type.completed == true || gameStatus.type.name.includes("STATUS_IN_PROGRESS") || (gameStatus.type.name.includes("STATUS_DELAYED") && game.plays.length > 0);
+const gameSpec = {
+    id, hasScore,
+    away: cleanLocation(awayComp.team), home: cleanLocation(homeComp.team),
+    awayName: awayComp.team.displayName, homeName: homeComp.team.displayName,
+    awayId: awayTeam.id, homeId: homeTeam.id,
+    awayScore: awayComp.score, homeScore: homeComp.score,
+    date: game.header.competitions[0].date, season: game.season.year, week: game.header.week,
+    note: game.header?.gameNote, neutralSite: game.header.competitions[0].neutralSite,
+};
+const title = gameTitle(gameSpec);
+const subtitle = gameDescription(gameSpec);
+const structuredData = jsonLdScript([sportsEventJsonLd(gameSpec)]);
 
 const statusDetail = gameStatus.type.detail;
 const statusDescription = gameStatus.type.description ?? "Scheduled";
@@ -153,12 +162,12 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
         <meta name="referrer" content="origin-when-cross-origin">
         <link rel="canonical" href={canonicalUrl}>
         <title>{title}</title>
-        <meta name="description" content={`Advanced stats for ${subtitle}`}>
+        <meta name="description" content={subtitle}>
 
         <meta property="og:site_name" content="GameOnPaper.com">
         <meta property="og:url" content={canonicalUrl}>
         <meta property="og:title" content={title}>
-        <meta property="og:description" content={`Advanced stats for ${subtitle}`}>
+        <meta property="og:description" content={subtitle}>
         <meta property="og:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${id}.png?templateId=espn.com.share.1`}>
         <meta property="og:image:width" content="400">
         <meta property="og:image:height" content="400">
@@ -171,6 +180,7 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
         <meta name="twitter:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${id}.png?templateId=espn.com.share.1`}>
         <meta name="title" content={title}>
         <meta name="medium" content="website">
+        <script type="application/ld+json" set:html={structuredData} />
         <script defer is:inline crossorigin="anonymous" data-domain="gameonpaper.com" src="https://plausible.io/js/script.js"></script>
         <DarkModeLogos teamIds={[game.teamInfo.home.id, game.teamInfo.away.id]} />
     </head>
@@ -183,7 +193,7 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                     </div>
                     <div class="col-8 text-center">
                         <div>
-                            <h2 class="mb-0">{`${cleanLocation(awayTeam)} ${awayComp.score} @ ${cleanLocation(homeTeam)} ${homeComp.score}`}</h2>
+                            <h1 class="h2 mb-0">{`${cleanLocation(awayTeam)} ${awayComp.score} @ ${cleanLocation(homeTeam)} ${homeComp.score}`}</h1>
                             {
                                 (gameNote != "") && <p class={`text-small mt-0 mb-3 ${isChampEvent ? "championship-text" : "text-primary"}`}><strong>{gameNote}</strong></p>
                             }

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -74,6 +74,7 @@ const gameSpec = {
     awayScore: awayComp.score, homeScore: homeComp.score,
     date: game.header.competitions[0].date, season: game.season.year, week: game.header.week,
     note: game.header?.gameNote, neutralSite: game.header.competitions[0].neutralSite,
+    statusDescription,
 };
 const title = gameTitle(gameSpec);
 const subtitle = gameDescription(gameSpec);

--- a/astro/src/components/game/PreGamePage.astro
+++ b/astro/src/components/game/PreGamePage.astro
@@ -12,6 +12,7 @@ import MatchupView from './MatchupView.astro';
 import WatchButton from './WatchButton.astro';
 import Footer from '../Footer.astro';
 import "bootstrap-icons/font/bootstrap-icons.css";
+import { gameDescription, gameTitle, jsonLdScript, sportsEventJsonLd } from '../../utils/seo';
 
 interface Props {
     id: string | number
@@ -29,8 +30,21 @@ const awayTeam = awayComp.team;
 const gameNote = espnGame.gamepackageJSON.header.gameNote ?? "";
 const isChampEvent = isChampionshipEvent(gameNote);
 
-let title = `Game: ${cleanLocation(awayComp.team)} vs ${cleanLocation(homeComp.team)} | Game on Paper`;
-let subtitle = `${cleanLocation(awayComp.team)} vs ${cleanLocation(homeComp.team)}`;
+const header = espnGame.gamepackageJSON.header;
+const gameSpec = {
+    id, hasScore: false,
+    away: cleanLocation(awayComp.team), home: cleanLocation(homeComp.team),
+    awayName: awayComp.team.displayName, homeName: homeComp.team.displayName,
+    awayId: awayTeam.id, homeId: homeTeam.id,
+    date: game.date, season: header.season.year, week: header.week,
+    note: gameNote, neutralSite: game.neutralSite,
+};
+const title = gameTitle(gameSpec);
+const subtitle = gameDescription(gameSpec);
+const structuredData = jsonLdScript([sportsEventJsonLd(gameSpec)]);
+// Canonical is /game/<id>, the served path; /cfb/game/<id> is Disallowed in
+// robots.txt, so the old value told Google the authoritative URL was one it may not crawl.
+const canonicalUrl = new URL(`/game/${id}`, "https://gameonpaper.com").href;
 const statusDescription = game.status.type.description ?? "Scheduled";
 const metricYear = espnGame.gamepackageJSON.header.season.year == CURRENT_YEAR ? LAST_YEAR : espnGame.gamepackageJSON.header.season.year;
 
@@ -108,26 +122,27 @@ const matchupHistory = await retrieveMatchupHistory(homeTeam.id, awayTeam.id, 5)
         <meta http-equiv="x-ua-compatible" content="IE=edge,chrome=1">
         <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
         <meta name="referrer" content="origin-when-cross-origin">
-        <link rel="canonical" href={`https://gameonpaper.com/cfb/game/${game.id}`}>
+        <link rel="canonical" href={canonicalUrl}>
         <title>{title}</title>
-        <meta name="description" content={`Advanced stats for ${subtitle}`}>
+        <meta name="description" content={subtitle}>
 
         <meta property="og:site_name" content="GameOnPaper.com">
-        <meta property="og:url" content={`https://gameonpaper.com/cfb/game/${game.id}`}>
+        <meta property="og:url" content={canonicalUrl}>
         <meta property="og:title" content={title}>
-        <meta property="og:description" content={`Advanced stats for ${subtitle}`}>
+        <meta property="og:description" content={subtitle}>
         <meta property="og:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${game.id}.png?templateId=espn.com.share.1`}>
         <meta property="og:image:width" content="400">
         <meta property="og:image:height" content="400">
         <meta property="og:type" content="website">
         <meta name="twitter:site" content="@gameonpaper">
-        <meta name="twitter:url" content={`https://gameonpaper.com/cfb/game/${game.id}`}>
+        <meta name="twitter:url" content={canonicalUrl}>
         <meta name="twitter:title" content={title}>
         <meta name="twitter:description" content={subtitle}>
         <meta name="twitter:card" content="summary">
         <meta name="twitter:image" content={`https://s.espncdn.com/stitcher/sports/football/college-football/events/${game.id}.png?templateId=espn.com.share.1`}>
         <meta name="title" content={title}>
         <meta name="medium" content="website">
+        <script type="application/ld+json" set:html={structuredData} />
         <script defer is:inline crossorigin="anonymous" data-domain="gameonpaper.com" src="https://plausible.io/js/script.js"></script>
         <DarkModeLogos teamIds={[homeTeam.id, awayTeam.id]} />
     </head>
@@ -140,7 +155,7 @@ const matchupHistory = await retrieveMatchupHistory(homeTeam.id, awayTeam.id, 5)
                     </div>
                     <div class="col-8 text-center">
                         <div>
-                            <h2 class="mb-0">{`${cleanLocation(awayTeam)} @ ${cleanLocation(homeTeam)}`}</h2>
+                            <h1 class="h2 mb-0">{`${cleanLocation(awayTeam)} @ ${cleanLocation(homeTeam)}`}</h1>
                             {
                                 (gameNote != "") && <p class={`text-small mt-0 mb-3 ${isChampEvent ? "championship-text" : "text-primary"}`}><strong>{gameNote}</strong></p>
                             }

--- a/astro/src/components/game/PreGamePage.astro
+++ b/astro/src/components/game/PreGamePage.astro
@@ -30,6 +30,7 @@ const awayTeam = awayComp.team;
 const gameNote = espnGame.gamepackageJSON.header.gameNote ?? "";
 const isChampEvent = isChampionshipEvent(gameNote);
 
+const statusDescription = game.status.type.description ?? "Scheduled";
 const header = espnGame.gamepackageJSON.header;
 const gameSpec = {
     id, hasScore: false,
@@ -38,6 +39,7 @@ const gameSpec = {
     awayId: awayTeam.id, homeId: homeTeam.id,
     date: game.date, season: header.season.year, week: header.week,
     note: gameNote, neutralSite: game.neutralSite,
+    statusDescription,
 };
 const title = gameTitle(gameSpec);
 const subtitle = gameDescription(gameSpec);
@@ -45,7 +47,6 @@ const structuredData = jsonLdScript([sportsEventJsonLd(gameSpec)]);
 // Canonical is /game/<id>, the served path; /cfb/game/<id> is Disallowed in
 // robots.txt, so the old value told Google the authoritative URL was one it may not crawl.
 const canonicalUrl = new URL(`/game/${id}`, "https://gameonpaper.com").href;
-const statusDescription = game.status.type.description ?? "Scheduled";
 const metricYear = espnGame.gamepackageJSON.header.season.year == CURRENT_YEAR ? LAST_YEAR : espnGame.gamepackageJSON.header.season.year;
 
 let homeTeamSeason: SDVTeamSeasonInformation = {

--- a/astro/src/utils/seo.ts
+++ b/astro/src/utils/seo.ts
@@ -73,6 +73,81 @@ export function datasetJsonLd(spec: DatasetSpec) {
     };
 }
 
+export interface GameSpec {
+    id: string | number;
+    /** rendered (lowercased) names, as the site shows them */
+    away: string;
+    home: string;
+    /** schema.org names -- the real display names, never the lowercased slug */
+    awayName?: string;
+    homeName?: string;
+    awayId?: string | number;
+    homeId?: string | number;
+    awayScore?: string | number;
+    homeScore?: string | number;
+    /** ISO kickoff */
+    date: string;
+    season: number;
+    week?: number;
+    /** ESPN gameNote, e.g. "Peach Bowl" -- replaces "Week N" when present */
+    note?: string;
+    neutralSite?: boolean;
+    /** final or in progress: scores are meaningful */
+    hasScore: boolean;
+}
+
+/** "Week 3 2025" or "Peach Bowl 2025" -- what the page is about beyond the two teams. */
+export function gameContext(g: Pick<GameSpec, 'season' | 'week' | 'note'>): string {
+    const label = g.note?.trim() || (g.week ? `Week ${g.week}` : '');
+    return label ? `${label} ${g.season}` : `${g.season}`;
+}
+
+export function gameTitle(g: GameSpec): string {
+    const matchup = g.hasScore ? `${g.away} ${g.awayScore}, ${g.home} ${g.homeScore}` : `${g.away} vs ${g.home}`;
+    const what = g.hasScore ? 'EPA & advanced box score' : 'preview: win probability & EPA matchup';
+    return `${matchup} | ${gameContext(g)} ${what} | Game on Paper`;
+}
+
+export function gameDescription(g: GameSpec): string {
+    const when = new Date(g.date);
+    const day = isNaN(when.getTime()) ? '' : ` on ${when.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'America/New_York' })}`;
+    if (g.hasScore) {
+        return `${g.away} ${g.awayScore}, ${g.home} ${g.homeScore}${day}: college football advanced box score with EPA per play, success rate, explosiveness, win probability chart, drives and every play.`;
+    }
+    return `${g.away} vs ${g.home}${day}: college football matchup preview with win probability, EPA per play, success rate and explosiveness for both teams, plus series history.`;
+}
+
+/** A game as a SportsEvent -- the only schema.org type Google shows sports rich results for. */
+export function sportsEventJsonLd(g: GameSpec) {
+    const team = (name: string | undefined, fallback: string, id: string | number | undefined) => ({
+        '@type': 'SportsTeam',
+        name: name || fallback,
+        sport: 'American football',
+        ...(id != null ? { url: new URL(`/team/${id}`, ORIGIN).href } : {}),
+    });
+    const url = new URL(`/game/${g.id}`, ORIGIN).href;
+    const home = team(g.homeName, g.home, g.homeId);
+    const away = team(g.awayName, g.away, g.awayId);
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'SportsEvent',
+        '@id': url,
+        url,
+        name: `${away.name} at ${home.name}`,
+        description: gameDescription(g),
+        sport: 'American football',
+        startDate: g.date,
+        eventStatus: 'https://schema.org/EventScheduled',
+        eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+        ...(g.neutralSite ? {} : { location: { '@type': 'Place', name: `${home.name} home field` } }),
+        homeTeam: home,
+        awayTeam: away,
+        competitor: [away, home],
+        organizer: { '@type': 'SportsOrganization', name: 'NCAA' },
+        ...(g.hasScore ? { subjectOf: { '@type': 'Dataset', name: `${away.name} ${g.awayScore}, ${home.name} ${g.homeScore} advanced box score`, url, keywords: ['college football', 'EPA per play', 'success rate', 'win probability'] } } : {}),
+    };
+}
+
 export function websiteJsonLd() {
     return {
         '@context': 'https://schema.org',

--- a/astro/src/utils/seo.ts
+++ b/astro/src/utils/seo.ts
@@ -94,12 +94,27 @@ export interface GameSpec {
     neutralSite?: boolean;
     /** final or in progress: scores are meaningful */
     hasScore: boolean;
+    /** ESPN status description ("Final", "Postponed", "Canceled") */
+    statusDescription?: string;
+}
+
+/**
+ * schema.org EventStatusType has no "completed" or "in progress" value -- a played
+ * game is still EventScheduled. Only cancellations and postponements differ.
+ */
+export function eventStatus(statusDescription?: string): string {
+    const s = (statusDescription ?? '').toLowerCase();
+    if (s.includes('cancel')) return 'https://schema.org/EventCancelled';
+    if (s.includes('postpone')) return 'https://schema.org/EventPostponed';
+    return 'https://schema.org/EventScheduled';
 }
 
 /** "Week 3 2025" or "Peach Bowl 2025" -- what the page is about beyond the two teams. */
 export function gameContext(g: Pick<GameSpec, 'season' | 'week' | 'note'>): string {
     const label = g.note?.trim() || (g.week ? `Week ${g.week}` : '');
-    return label ? `${label} ${g.season}` : `${g.season}`;
+    if (!label) return `${g.season}`;
+    // an ESPN note can already carry the year ("2025 CFP Semifinal"); don't say it twice
+    return label.includes(`${g.season}`) ? label : `${label} ${g.season}`;
 }
 
 export function gameTitle(g: GameSpec): string {
@@ -137,7 +152,7 @@ export function sportsEventJsonLd(g: GameSpec) {
         description: gameDescription(g),
         sport: 'American football',
         startDate: g.date,
-        eventStatus: 'https://schema.org/EventScheduled',
+        eventStatus: eventStatus(g.statusDescription),
         eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
         ...(g.neutralSite ? {} : { location: { '@type': 'Place', name: `${home.name} home field` } }),
         homeTeam: home,

--- a/astro/test/seo.test.ts
+++ b/astro/test/seo.test.ts
@@ -116,6 +116,7 @@ describe('game copy + SportsEvent', () => {
         expect(gameTitle(pre)).toBe('north carolina vs tcu | Week 1 2025 preview: win probability & EPA matchup | Game on Paper');
         expect(gameContext({ season: 2024, week: 17, note: 'Peach Bowl' })).toBe('Peach Bowl 2024');
         expect(gameContext({ season: 2024 })).toBe('2024');
+        expect(gameContext({ season: 2024, week: 17, note: '2024 CFP Semifinal' })).toBe('2024 CFP Semifinal');
     });
 
     test('SportsEvent uses real display names, team urls and the served game url', () => {
@@ -128,6 +129,10 @@ describe('game copy + SportsEvent', () => {
         expect(ld.subjectOf?.['@type']).toBe('Dataset');
         expect(sportsEventJsonLd(pre).subjectOf).toBeUndefined();
         expect(sportsEventJsonLd({ ...final, neutralSite: true }).location).toBeUndefined();
+        // schema.org has no completed/in-progress status; only cancel/postpone differ
+        expect(sportsEventJsonLd({ ...final, statusDescription: 'Final' }).eventStatus).toBe('https://schema.org/EventScheduled');
+        expect(sportsEventJsonLd({ ...pre, statusDescription: 'Postponed' }).eventStatus).toBe('https://schema.org/EventPostponed');
+        expect(sportsEventJsonLd({ ...pre, statusDescription: 'Canceled' }).eventStatus).toBe('https://schema.org/EventCancelled');
     });
 });
 

--- a/astro/test/seo.test.ts
+++ b/astro/test/seo.test.ts
@@ -9,6 +9,10 @@ import {
     definedTermSetJsonLd,
     jsonLdScript,
     websiteJsonLd,
+    gameContext,
+    gameDescription,
+    gameTitle,
+    sportsEventJsonLd,
 } from '../src/utils/seo';
 
 describe('leaderboard copy', () => {
@@ -92,6 +96,38 @@ describe('json-ld builders', () => {
 
     test('website ld names the site', () => {
         expect(websiteJsonLd().url).toBe('https://gameonpaper.com');
+    });
+});
+
+describe('game copy + SportsEvent', () => {
+    const final = { id: 401856766, hasScore: true, away: 'north carolina', home: 'tcu', awayName: 'North Carolina Tar Heels', homeName: 'TCU Horned Frogs', awayId: 153, homeId: 2628, awayScore: '15', homeScore: '10', date: '2025-09-02T00:00Z', season: 2025, week: 1 };
+    const pre = { ...final, hasScore: false, awayScore: undefined, homeScore: undefined };
+
+    test('final title carries score, week and the metric words; rendered names stay lowercase', () => {
+        const t = gameTitle(final);
+        expect(t).toBe('north carolina 15, tcu 10 | Week 1 2025 EPA & advanced box score | Game on Paper');
+        expect(gameDescription(final)).toContain('EPA per play');
+        expect(gameDescription(final)).toContain('win probability');
+        expect(gameDescription(final)).toContain('Sep 1, 2025');
+        expect(t).not.toContain('Tar Heels');
+    });
+
+    test('preview title says preview; bowl note replaces the week', () => {
+        expect(gameTitle(pre)).toBe('north carolina vs tcu | Week 1 2025 preview: win probability & EPA matchup | Game on Paper');
+        expect(gameContext({ season: 2024, week: 17, note: 'Peach Bowl' })).toBe('Peach Bowl 2024');
+        expect(gameContext({ season: 2024 })).toBe('2024');
+    });
+
+    test('SportsEvent uses real display names, team urls and the served game url', () => {
+        const ld = sportsEventJsonLd(final);
+        expect(ld['@type']).toBe('SportsEvent');
+        expect(ld.url).toBe('https://gameonpaper.com/game/401856766');
+        expect(ld.homeTeam.name).toBe('TCU Horned Frogs');
+        expect(ld.awayTeam.url).toBe('https://gameonpaper.com/team/153');
+        expect(ld.startDate).toBe('2025-09-02T00:00Z');
+        expect(ld.subjectOf?.['@type']).toBe('Dataset');
+        expect(sportsEventJsonLd(pre).subjectOf).toBeUndefined();
+        expect(sportsEventJsonLd({ ...final, neutralSite: true }).location).toBeUndefined();
     });
 });
 


### PR DESCRIPTION
## Why
Game pages are ~99% of the site's URLs and, as of tonight's prod probe, served `<title>Game: North Carolina 15, TCU 10</title>`, description "Advanced stats for North Carolina vs TCU", **no h1 and no structured data**. Pregame pages also still canonicalised to `/cfb/game/{id}` — a URL `robots.txt` Disallows.

## What
- `utils/seo.ts`: `gameTitle` / `gameDescription` / `gameContext` / `sportsEventJsonLd` — pure builders, unit-tested.
  - Final: `north carolina 15, tcu 10 | Week 1 2025 EPA & advanced box score | Game on Paper`; bowl games use the ESPN `gameNote` ("Peach Bowl 2024") instead of "Week N".
  - Preview: `… | Week 1 2025 preview: win probability & EPA matchup | Game on Paper`.
  - Descriptions carry the kickoff date and the metric terms.
- `GamePage.astro` / `PreGamePage.astro`: wire the builders, emit `SportsEvent` JSON-LD (SportsTeam home/away with `/team/{id}` urls, kickoff, `Dataset` subjectOf once there's a score), header `h2` → `h1 class="h2"` (same node, same look).
- `PreGamePage.astro`: canonical/og:url/twitter:url → `/game/{id}`.

## Constraints
- Rendered team names stay lowercased as on the site; only the JSON-LD uses `displayName`.
- No new visible elements — the only DOM change is the header tag (`h2`→`h1.h2`, identical styling).

## Verification
- `npx vitest run`: 86 passed, 1 skipped.
- `astro build` (node 22) green.
- Game pages can't be rendered on the droplet (Python API token isn't on disk), so the HTML was not probed locally — **after deploy, `curl -A Googlebot https://gameonpaper.com/game/401856766`** and check title, one `<h1>`, `SportsEvent` in `application/ld+json`, and a pregame canonical of `/game/{id}`. I'll do that once it's merged.

## Not in this PR
Glossary definition copy (next PR). Game-page weight (4.7 MB HTML) — separate render-path change.

## Summary by Sourcery

Improve game-page search visibility with descriptive metadata, SportsEvent structured data, accessible headings, and corrected pregame canonical URLs.

New Features:
- Add SEO-focused titles and descriptions for completed games and previews, including scores, dates, competition context, and football analytics terminology.
- Add SportsEvent JSON-LD for game pages with team metadata, game URLs, kickoff details, event status, and completed-game datasets.

Bug Fixes:
- Correct pregame canonical, Open Graph, and Twitter URLs to use the crawlable /game/{id} route instead of /cfb/game/{id}.

Enhancements:
- Expose game headings as styled h1 elements without changing their visual presentation.
- Centralize game SEO content and structured-data generation in reusable, unit-tested builders.

Tests:
- Add unit coverage for game titles, descriptions, context labels, SportsEvent metadata, event statuses, and dataset inclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer game-page titles and descriptions for completed games and previews.
  * Added structured SportsEvent metadata for improved search presentation.
  * Updated game-page canonical and social URLs to use the `/game/<id>` path.
  * Improved page heading semantics for accessibility and discoverability.

* **Tests**
  * Added coverage for game titles, descriptions, context, and structured metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->