### PR TITLE
fix(game): finished-game pages render empty — statusDescription read before declaration

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -66,6 +66,8 @@ const gameStatus = game.header.competitions[0].status;
 // "win probability") -- "Game: X, Y" and "Advanced stats for X vs Y" gave Google
 // nothing to match a query against. Rendered names stay lowercased.
 const hasScore = gameStatus.type.completed == true || gameStatus.type.name.includes("STATUS_IN_PROGRESS") || (gameStatus.type.name.includes("STATUS_DELAYED") && game.plays.length > 0);
+const statusDetail = gameStatus.type.detail;
+const statusDescription = gameStatus.type.description ?? "Scheduled";
 const gameSpec = {
     id, hasScore,
     away: cleanLocation(awayComp.team), home: cleanLocation(homeComp.team),
@@ -80,8 +82,6 @@ const title = gameTitle(gameSpec);
 const subtitle = gameDescription(gameSpec);
 const structuredData = jsonLdScript([sportsEventJsonLd(gameSpec)]);
 
-const statusDetail = gameStatus.type.detail;
-const statusDescription = gameStatus.type.description ?? "Scheduled";
 const isGameInactive = (gameStatus.type.completed == true || statusDescription.includes("Cancel") || statusDescription.includes("Postpone") || statusDescription.includes("Delay"))
 
 const previewUrlParams = new URLSearchParams({


### PR DESCRIPTION
Regression from #181 (`bc44c9a`): `GamePage.astro` read `statusDescription` in `gameSpec` before its `const` — a TDZ ReferenceError in frontmatter that runs mid-stream, so every finished-game page returned a 200 with an empty body since the 22:33 EDT deploy (pregame pages were fine). Fix: declare first. vitest green, node-22 build green; game HTML can't be rendered on the droplet — verify on prod after deploy: `curl -A Googlebot https://gameonpaper.com/game/401856766` non-empty with the new title, one h1, SportsEvent.

## Summary by Sourcery

Bug Fixes:
- Fix finished-game pages rendering empty by ensuring game status descriptions are initialized before generating the game specification. 

Correction: the per-object JSON-LD change mentioned in the commit message did **not** land here (edit failed to apply); it follows in a separate PR.