### PR TITLE
fix(seo): one ld+json script per object

### DIFF
--- a/astro/src/layouts/GenericPage.astro
+++ b/astro/src/layouts/GenericPage.astro
@@ -22,10 +22,11 @@ interface Props {
 
 const { title, subtitle, slug, breadcrumbs, description, jsonLd, heading } = Astro.props;
 const metaDescription = description || subtitle;
-const structuredData = jsonLdScript([
-    breadcrumbListJsonLd(breadcrumbs),
-    ...(jsonLd ?? []),
-]);
+// One <script> per object: a single tag holding an array is valid JSON-LD, but
+// some validators/extensions read r['@context'] per tag and throw on arrays.
+const structuredData = [breadcrumbListJsonLd(breadcrumbs), ...(jsonLd ?? [])]
+    .map((o) => jsonLdScript([o]))
+    .filter(Boolean);
 
 // Was `https://gameonpaper.com/cfb/${slug}`, but slug already carries its own
 // leading slash, so every canonical and og:url rendered with a doubled slash
@@ -94,7 +95,7 @@ function generateBreadcrumbsListHtml(): string {
         <meta name="twitter:image" content="https://gameonpaper.com/assets/img/social-card.png">
         <meta name="title" content={title}>
         <meta name="medium" content="website">
-        {structuredData && <script type="application/ld+json" set:html={structuredData} />}
+        {structuredData.map((s) => <script type="application/ld+json" set:html={s} />)}
         <script is:inline defer crossorigin="anonymous" data-domain="gameonpaper.com" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>


### PR DESCRIPTION
Follow-up promised in #183. GenericPage emitted BreadcrumbList + Dataset as one array in one `<script>`; valid, but some JSON-LD readers do `r['@context']` per tag and throw (the `undefined is not an object (evaluating 'r["@context"].toLowerCase')` entries in `gop.error_log`). Now one script per object. Verified on a node-22 build: `/year/2025/teams/offensive` → 2 scripts, BreadcrumbList + Dataset, each a bare object.

## Summary by Sourcery

Bug Fixes:
- Emit each JSON-LD object in its own script tag to improve compatibility with readers that expect a top-level object per tag.