### PR TITLE
ci(deploy-api): queue deploys, free disk before pulling, fail on unhealthy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,13 @@ jobs:
 
   deploy-api:
     runs-on: ubuntu-latest
+    # Two merges minutes apart ran this job twice in parallel on 2026-08-31: run A
+    # pulled its image, run B overwrote docker-compose.yml on the host, run A's
+    # down+up then pulled B's image into a full disk and the API stayed down.
+    # Queue deploys to the host; never cancel one mid-compose.
+    concurrency:
+      group: deploy-api-host
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v7
         with:
@@ -129,15 +136,41 @@ jobs:
             set -e
             chmod 600 .env
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ secrets.GH_USERNAME }} --password-stdin
-            docker compose pull
+            echo "disk before: $(df -h / | tail -1)"
+            # Free space BEFORE pulling, touching nothing that is running: stopped
+            # containers, build cache, and images no container references. The old
+            # trailing `system prune` (no -a) kept every previous deploy's tagged
+            # image, which is how the disk filled on 2026-08-31.
+            docker container prune -f
+            docker image prune -af
+            docker builder prune -af
+            # Pull with the old container still serving. If this fails (disk,
+            # registry, network) `set -e` stops here and nothing goes down.
+            docker compose -f docker-compose.yml pull
             # `docker stop` leaves the stopped container in place, so the next
             # `up` collides with its name ("container name is already in use").
             # `compose down` stops AND removes what compose owns, which is also
             # narrower than stopping every container on the host.
             docker compose -f docker-compose.yml down --remove-orphans || true
-            docker compose -f docker-compose.yml up -d --pull always
+            # No --pull always: the image is already local, and a second pull
+            # could race a compose file rewritten by a later run.
+            docker compose -f docker-compose.yml up -d
             docker compose -f docker-compose.yml ps
-            docker system prune --force
+            # Fail the run if the new container never becomes healthy (compose
+            # healthcheck: 20s start + 60s interval), instead of a green deploy
+            # in front of a red API.
+            cid=$(docker compose -f docker-compose.yml ps -q python)
+            for i in $(seq 1 36); do
+              st=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$cid" 2>/dev/null || echo missing)
+              echo "health: $st"
+              [ "$st" = healthy ] && break
+              case "$st" in exited|dead|missing) docker compose -f docker-compose.yml logs --tail 50; exit 1 ;; esac
+              [ $i -eq 36 ] && { echo "API not healthy after 180s"; docker compose -f docker-compose.yml logs --tail 50; exit 1; }
+              sleep 5
+            done
+            # The previous image is unreferenced now; drop it too.
+            docker image prune -af
+            echo "disk after: $(df -h / | tail -1)"
           ENDSSH
 
       # - name: Check that API is live


### PR DESCRIPTION
Follow-up to tonight's outage (asked for in the #184 thread).

**What happened:** two merges (#181 at 02:14:56Z, #182 at 02:15:21Z) ran `deploy-api` **in parallel** — there was no concurrency group. Run A pulled its image; run B overwrote `docker-compose.yml` on the host; run A's `down` + `up --pull always` then pulled B's image into a **full disk** (`failed to extract layer … .venv`) and the API stayed down. The disk was full because the trailing `docker system prune --force` (no `-a`) never removed previous deploys' *tagged* images.

**Changes (remote script + job):**
- `concurrency: { group: deploy-api-host, cancel-in-progress: false }` — deploys to the host queue; none is cancelled mid-compose.
- Before pulling: `docker container prune -f`, `docker image prune -af`, `docker builder prune -af` — frees old images/containers/cache; the running container and its image are untouched.
- `docker compose pull` **first**, old container still serving; a pull failure aborts under `set -e` before `down`.
- `up -d` without `--pull always` (image already local; avoids racing a rewritten compose file).
- Health wait on the compose healthcheck (up to 180 s); an unhealthy/exited container fails the run with logs.
- Prune the now-unreferenced previous image afterwards; `df -h` before/after in the log.

**Not zero-downtime in the strict sense:** `down` → `up -d` still restarts the container (a few seconds), same as today. True blue/green needs a second service + proxy; not attempted here.

Verification: YAML parses; the script is only exercised by a real deploy — merging deploys the same app code, so watch the run's `disk before/after` and `health:` lines.

## Summary by Sourcery

Harden API deployments against concurrent runs, disk exhaustion, failed image pulls, and unhealthy rollouts.

Bug Fixes:
- Prevent API deploys from leaving the service down when image pulls fail or the newly started container is unhealthy.
- Prevent disk exhaustion during deployment by reclaiming unused Docker containers, images, and build cache before pulling.

Enhancements:
- Queue deployments to the host and preserve the currently running container until the replacement image has been pulled successfully.
- Add deployment health checks with failure logs and disk usage reporting before and after deployment.

CI:
- Serialize deploy-api workflow runs without cancelling an in-progress deployment.

Deployment:
- Rework the API deployment sequence to pull before restarting, avoid redundant pulls during startup, and remove obsolete images after the rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Deployments to the API host are now queued to prevent overlapping releases from conflicting.
  * Existing API services remain available while new versions are downloaded.
  * Deployments now verify service health after startup and report failures with diagnostic logs.
  * Automated cleanup helps free disk space before and after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->