### PR TITLE
chore(python): pick up the four CFB pipeline fixes from sportsdataverse-py

### DIFF
--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2697,8 +2697,8 @@ wheels = [
 
 [[package]]
 name = "sportsdataverse"
-version = "0.1.3"
-source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#c579acc0074ba27ea1b240a93384f319109d4459" }
+version = "0.1.4"
+source = { git = "https://github.com/sportsdataverse/sportsdataverse-py?branch=main#6216015c8d816cb6e35f6b86c54dd914103896c8" }
 dependencies = [
     { name = "attrs" },
     { name = "beautifulsoup4" },


### PR DESCRIPTION
Bumps the pinned `sportsdataverse` commit from `c579acc0` (0.1.3) to `6216015c` (0.1.4).

The library tracks `main`, but through a locked commit hash — so four merged fixes were not reaching this
app until the lock moved.

| upstream | fix |
|---|---|
| #425 | `text_dupe` no longer deletes the real play sitting in front of a timeout |
| #426 | `rz_play`, `scoring_opp`, `goal_to_go` read yards-to-goal instead of ESPN's absolute `yardLine`, and `goal_to_go` is an equality |
| #428 | power rushing counts 3rd-and-2 and goal-line carries |
| #431 | the rushing decomposition no longer loses half a yard on every carry of 4+ |

## Verified end to end through this venv, on 401864570

| | before | after |
|---|---|---|
| plays in the processed game | 163 | **164** — the deleted play is back |
| snaps really inside the 20 | 24 | 20 of 20 flagged correctly |
| `rz_play` said | 14 | **20** |
| plays ESPN labels `& Goal` | 10 | 10 |
| `goal_to_go` said | **0** | **10** |

## Why it matters here

The Team Stats red-zone rate and scoring-opportunity panels read `rz_play` and the `EPA_success_rz`
family, so they were computing from the wrong end of the field for one team in every game. The Rushing
panel reads the line-yards decomposition, which was short half a yard on every carry of 4 or more.

Lockfile only — no application code changes.

## Summary by Sourcery

Update the locked sportsdataverse dependency so downstream team statistics and rushing metrics use the latest upstream corrections.

Bug Fixes:
- Update the pinned sportsdataverse dependency to incorporate fixes for timeout play retention, red-zone and goal-to-go calculations, power rushing classification, and rushing decomposition accuracy.

Build:
- Refresh the Python lockfile to the newer sportsdataverse commit.