### PR TITLE
feat(game): phase 1 of the rebuilt game page -- defensive box, the book's counting stats, linescore, Latest strip, quarter filters

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -110,7 +110,9 @@ const latestSubtitle = !lastPlay
       : `${driveTeam ?? "Unknown"} has the ball. Q${lastPlay.period ?? "?"} ${lastPlay.clock?.displayValue ?? ""}, drive so far: ${driveResult ?? "in progress"}.`;
 
 const scrollerItems: ScrollerItem[] = [
-    { href: "#latest", title: "Latest" },
+    // The Latest panel only renders when there are plays, so a game with none
+    // must not advertise an anchor that isn't on the page.
+    ...(latestPlays.length > 0 ? [{ href: "#latest", title: "Latest" }] : []),
     { href: "#wpChart", title: "WP Chart" },
     { href: "#epChart", title: "EPA Chart" },
     { href: "#team-stats", title: "Team Stats" },

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -270,6 +270,7 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                                     season={game.season.year}
                                     teams={game.advBoxScore.team.map((t: any) => t.pos_team)}
                                     plays={game.plays}
+                                    drives={gameDrives}
                                     caption="The counting stats an official book leads with, each carrying the EPA of the plays it counts."
                                 />
                                 <TeamMetricsTable 

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -374,6 +374,8 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                                 pass={game.advBoxScore.pass.filter(g => g.pos_team == parseInt(awayTeam.id))}
                                 rush={game.advBoxScore.rush.filter(g => g.pos_team == parseInt(awayTeam.id))}
                                 receiver={game.advBoxScore.receiver.filter(g => g.pos_team == parseInt(awayTeam.id))}
+                                plays={game.plays}
+                                teamId={parseInt(awayTeam.id)}
                             />
                             <PassingChart plays={game.plays.filter(p => p.pos_team == parseInt(awayTeam.id))} />
                             <RushingChart plays={game.plays.filter(p => p.pos_team == parseInt(awayTeam.id))} />
@@ -387,6 +389,8 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                                 pass={game.advBoxScore.pass.filter(g => g.pos_team == parseInt(homeTeam.id))}
                                 rush={game.advBoxScore.rush.filter(g => g.pos_team == parseInt(homeTeam.id))}
                                 receiver={game.advBoxScore.receiver.filter(g => g.pos_team == parseInt(homeTeam.id))}
+                                plays={game.plays}
+                                teamId={parseInt(homeTeam.id)}
                             />
                             <PassingChart plays={game.plays.filter(p => p.pos_team == parseInt(homeTeam.id))} />
                             <RushingChart plays={game.plays.filter(p => p.pos_team == parseInt(homeTeam.id))} />

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -92,13 +92,27 @@ const previewUrlParams = new URLSearchParams({
     awayTeamId: awayTeam.id
 })
 
+// The top of the page answers "what just happened" before any chart does.
+// Newest first here -- this strip is read downward as a feed, unlike All Plays.
+const latestPlays = game.plays.slice(-5).toReversed();
+const lastPlay: any = game.plays.at(-1);
+const gameState = game.header.competitions[0].status?.type?.state;
+const driveTeam = lastPlay?.["drive.team.shortDisplayName"];
+const driveResult = lastPlay?.["drive.displayResult"] ?? lastPlay?.["drive.result"];
+const latestSubtitle = !lastPlay
+    ? "No plays yet."
+    : gameState === "post"
+      ? `Final. Last drive: ${driveTeam ?? "unknown"}, ${driveResult ?? "no result"}.`
+      : `${driveTeam ?? "Unknown"} has the ball. Q${lastPlay.period ?? "?"} ${lastPlay.clock?.displayValue ?? ""}, drive so far: ${driveResult ?? "in progress"}.`;
+
 const scrollerItems: ScrollerItem[] = [
+    { href: "#latest", title: "Latest" },
     { href: "#wpChart", title: "WP Chart" },
     { href: "#epChart", title: "EPA Chart" },
     { href: "#team-stats", title: "Team Stats" },
     { href: "#player-stats", title: "Player Stats" },
     { href: "#big-plays", title: "Big Plays" },
-    { href: "#most-imp-plays", title: "Most Important Plays" },
+    { href: "#most-important-plays", title: "Most Important Plays" },
     { href: "#scoring-plays", title: "Scoring Plays" },
     { href: "#drives", title: "Drives" },
     { href: "#all-plays", title: "All Plays" },
@@ -214,15 +228,27 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
             </header>
 
             <NavScroller items={scrollerItems} />
+            {latestPlays.length > 0 && (
+                <div class="row mb-3">
+                    <div class="col-md-12 ms-sm-auto col-lg-12 px-md-4">
+                        <Panel id="latest" title="Latest">
+                            <p class="text-small" slot="panel-subtitle">{latestSubtitle}</p>
+                            <div class="row" slot="panel-body">
+                                <PlaysTable plays={latestPlays} prefix="latest" expandable={false} />
+                            </div>
+                        </Panel>
+                    </div>
+                </div>
+            )}
         </div>
         <div class="container-fluid">
             <div class="row mb-3">
-                <div class="col-lg-6 ms-sm-auto px-md-4">
+                <div id="wpChart" class="col-lg-6 ms-sm-auto px-md-4">
                     <WinProbabilityChart client:only id={id} homeComp={homeComp} awayComp={awayComp} gameStatus={game.header.competitions[0].status} homeTeamSpread={game.homeTeamSpread} overUnder={game.overUnder} plays={wpPlays} percentiles={percentiles} gei={game.gei}>
                         <FallbackSpinner slot="fallback" />
                     </WinProbabilityChart>
                 </div>
-                <div class="col-lg-6 ms-sm-auto px-md-4">
+                <div id="epChart" class="col-lg-6 ms-sm-auto px-md-4">
                     <ExpectedPointsChart client:only id={id} plays={epPlays} homeTeam={game.teamInfo.home} awayTeam={game.teamInfo.away}>
                         <FallbackSpinner slot="fallback" />
                     </ExpectedPointsChart>

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -13,6 +13,7 @@ import Scripts from '../Scripts.astro';
 import PlaysTable from './plays/PlaysTable.astro';
 import TeamPanel from '../../layouts/panel/TeamPanel.astro';
 import PlayerBoxScore from './metrics/PlayerBoxScore.astro';
+import TraditionalTeamStats from './metrics/TraditionalTeamStats.astro';
 import PassingChart from './metrics/PassingChart.astro';
 import RushingChart from './metrics/RushingChart.astro';
 import TeamMetricsTable from './metrics/TeamMetricsTable.astro';
@@ -233,6 +234,12 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                         <div class="row" slot="panel-body">
                             <div class="col-md-4 ms-sm-auto col-lg-4">
                                 <BinionBoxScore season={game.season.year} advancedBoxScore={game.advBoxScore} percentiles={percentiles} />
+                                <TraditionalTeamStats
+                                    season={game.season.year}
+                                    teams={game.advBoxScore.team.map((t: any) => t.pos_team)}
+                                    plays={game.plays}
+                                    caption="The counting stats an official book leads with, each carrying the EPA of the plays it counts."
+                                />
                                 <TeamMetricsTable 
                                     title="Expected Points"
                                     teamKey='pos_team'

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -19,6 +19,7 @@ import PassingChart from './metrics/PassingChart.astro';
 import RushingChart from './metrics/RushingChart.astro';
 import TeamMetricsTable from './metrics/TeamMetricsTable.astro';
 import BinionBoxScore from './metrics/BinionBoxScore.astro';
+import Linescore from './metrics/Linescore.astro';
 import DrivesTable from './drives/DrivesTable.astro';
 import ExpectedPointsChart from '../charts/ExpectedPointsChart.svelte';
 import WinProbabilityChart from '../charts/WinProbabilityChart.svelte';
@@ -466,6 +467,7 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                 <div class="col-lg-6 ms-sm-auto px-md-4">
                     <Panel id="scoring-plays" title="Scoring Plays">
                         <div class="row" slot="panel-body">
+                            <Linescore competitors={game.header.competitions[0].competitors} season={game.season.year} />
                             {
                                 (game.scoringPlays.length == 0) && (<p class="text-center text-muted">No scoring plays in this game.</p>)
                             }

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -11,6 +11,7 @@ import type { ESPNCompetition } from '../../resources/espn';
 import Panel from '../../layouts/panel/GenericPanel.astro';
 import Scripts from '../Scripts.astro';
 import PlaysTable from './plays/PlaysTable.astro';
+import PlayFilters from './plays/PlayFilters.astro';
 import TeamPanel from '../../layouts/panel/TeamPanel.astro';
 import PlayerBoxScore from './metrics/PlayerBoxScore.astro';
 import TraditionalTeamStats from './metrics/TraditionalTeamStats.astro';
@@ -95,6 +96,8 @@ const previewUrlParams = new URLSearchParams({
 // The top of the page answers "what just happened" before any chart does.
 // Newest first here -- this strip is read downward as a feed, unlike All Plays.
 const latestPlays = game.plays.slice(-5).toReversed();
+// Quarters actually played, so overtime only offers a button when it happened.
+const periodsPlayed = [...new Set(game.plays.map((p: any) => Number(p.period)).filter(Number.isFinite))].sort((a, b) => a - b);
 const lastPlay: any = game.plays.at(-1);
 const gameState = game.header.competitions[0].status?.type?.state;
 const driveTeam = lastPlay?.["drive.team.shortDisplayName"];
@@ -494,6 +497,11 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                         <div class="row" slot="panel-body">
                             {
                                 (game.plays.length == 0) && <p class="text-center text-muted">No plays in this game.</p>
+                            }
+                            {
+                                (game.plays.length > 0) && (
+                                    <PlayFilters target="all" periods={periodsPlayed} newestFirst={gameStatus.type.completed != true} />
+                                )
                             }
                             {
                                 (game.plays.length > 0) && (gameStatus.type.completed != true) && (

--- a/astro/src/components/game/metrics/Linescore.astro
+++ b/astro/src/components/game/metrics/Linescore.astro
@@ -1,0 +1,55 @@
+---
+/**
+ * Period-by-period scoring, from the header's linescores.
+ *
+ * Tucked into the Scoring Plays panel rather than given a panel of its own:
+ * it is a summary of exactly what that panel lists, and the page has no room
+ * near the top for something this small.
+ */
+interface Props {
+    /** ESPN competitors, away and home, each with `linescores`. */
+    competitors: any[];
+    season: number;
+}
+const { competitors, season } = Astro.props;
+
+// Away first, the way a scoreboard is read. Picked by side rather than sorted:
+// a comparator on a two-element array hides its own ordering bug.
+const rows = [competitors?.find((c) => c.homeAway === "away"), competitors?.find((c) => c.homeAway === "home")].filter(Boolean);
+const periods = Math.max(0, ...rows.map((t) => t.linescores?.length ?? 0));
+const label = (i: number) => (i < 4 ? String(i + 1) : i === 4 ? "OT" : `${i - 3}OT`);
+const cell = (t: any, i: number) => t.linescores?.[i]?.displayValue ?? "-";
+const show = periods > 0 && rows.length === 2;
+---
+
+{show && (
+    <div class="table-responsive mb-2">
+        <table class="table table-sm" style="width: auto;">
+            <thead>
+                <tr>
+                    <th class="box-heading">Linescore</th>
+                    {Array.from({ length: periods }, (_, i) => (
+                        <th class="numeral" style="text-align: center; min-width: 2.2rem;">{label(i)}</th>
+                    ))}
+                    <th class="numeral" style="text-align: center; min-width: 2.6rem;">T</th>
+                </tr>
+            </thead>
+            <tbody>
+                {rows.map((t) => (
+                    <tr>
+                        <td style="text-align: left;">
+                            <a href={`/year/${season}/team/${t.team?.id}`}>
+                                <img class={`img-fluid team-logo-${t.team?.id}`} width="22px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${t.team?.id}.png`} alt={`ESPN team id ${t.team?.id}`} />
+                            </a>
+                            <span class="ms-1">{t.team?.abbreviation ?? t.team?.shortDisplayName}</span>
+                        </td>
+                        {Array.from({ length: periods }, (_, i) => (
+                            <td class="numeral" style="text-align: center;">{cell(t, i)}</td>
+                        ))}
+                        <td class="numeral" style="text-align: center;"><strong>{t.score}</strong></td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    </div>
+)}

--- a/astro/src/components/game/metrics/PlayerBoxScore.astro
+++ b/astro/src/components/game/metrics/PlayerBoxScore.astro
@@ -18,7 +18,9 @@ let { pass, rush, receiver, plays = [], teamId } = Astro.props;
 // totals and rates, not extremes.
 // Keyed on the player name: the advanced box rows carry no player id, and the name is
 // the only field the two shapes share.
-const passBest = playerExtremes(plays, "passer_player_name");
+// A passer's longest is his longest COMPLETION, which is the receiving yardage
+// on the play -- the same number the official book prints.
+const passBest = playerExtremes(plays, "passer_player_name", "yds_receiving");
 const rushBest = playerExtremes(plays, "rusher_player_name", "yds_rushed");
 const recvBest = playerExtremes(plays, "receiver_player_name", "yds_receiving");
 const defense = teamId == null ? [] : defensiveBox(plays, teamId);
@@ -69,7 +71,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
                 (pass.length > 0) && (pass.map((p) => (
                     <tr>
                         <td style="text-align: left;">{p.passer_player_name}</td>
-                        <td style="text-align: left;">{p.Comp}/{p.Att}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Pass_TD} TD, {p.Int} INT, {p.Sck} Sck, {roundNumber(p.exp_qbr, 2, 1)} xQBR<span title="Air yards on completions / yards after catch; aDOT = average depth of target (air yards per attempt)">{airLine(p)}</span><span title="Longest gain, and this passer's single best play by EPA and by win probability added">{bestTail(passBest, p.passer_player_name, false)}</span></td>
+                        <td style="text-align: left;">{p.Comp}/{p.Att}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Pass_TD} TD, {p.Int} INT, {p.Sck} Sck, {roundNumber(p.exp_qbr, 2, 1)} xQBR<span title="Air yards on completions / yards after catch; aDOT = average depth of target (air yards per attempt)">{airLine(p)}</span><span title="Longest completion, and this passer's single best play by EPA and by win probability added">{bestTail(passBest, p.passer_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPA || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA, 2, 2)}</td>

--- a/astro/src/components/game/metrics/PlayerBoxScore.astro
+++ b/astro/src/components/game/metrics/PlayerBoxScore.astro
@@ -1,13 +1,38 @@
 ---
 import type { ProcessedPassingBoxScore, ProcessedReceivingBoxScore, ProcessedRushingBoxScore } from '../../../resources/python';
 import { roundNumber } from "../../../utils/misc";
+import { defensiveBox, playerExtremes } from "../../../utils/defensiveBox";
 
 interface Props {
     pass: ProcessedPassingBoxScore[],
     rush: ProcessedRushingBoxScore[],
-    receiver: ProcessedReceivingBoxScore[]
+    receiver: ProcessedReceivingBoxScore[],
+    /** Every play in the game, for the longest gain, the best play, and the defence. */
+    plays?: any[],
+    /** The team whose defenders to credit; omit to leave the defensive table out. */
+    teamId?: string | number,
 }
-let { pass, rush, receiver } = Astro.props;
+let { pass, rush, receiver, plays = [], teamId } = Astro.props;
+
+// LNG and the single best play come off the plays themselves: the advanced box carries
+// totals and rates, not extremes.
+// Keyed on the player name: the advanced box rows carry no player id, and the name is
+// the only field the two shapes share.
+const passBest = playerExtremes(plays, "passer_player_name");
+const rushBest = playerExtremes(plays, "rusher_player_name", "yds_rushed");
+const recvBest = playerExtremes(plays, "receiver_player_name", "yds_receiving");
+const defense = teamId == null ? [] : defensiveBox(plays, teamId);
+
+/** "22 LNG · 2.10 best · 1.4% best" — the extremes tail on a stat line. */
+const bestTail = (m: Map<string, any>, id: unknown, showLng = true): string => {
+    const e = id == null ? null : m.get(String(id));
+    if (!e) return "";
+    const bits: string[] = [];
+    if (showLng && e.LNG != null) bits.push(`${e.LNG} LNG`);
+    if (e.EPA_MAX != null) bits.push(`${roundNumber(e.EPA_MAX, 2, 2)} best EPA`);
+    if (e.WPA_MAX != null) bits.push(`${roundNumber(e.WPA_MAX * 100, 2, 1)}% best WPA`);
+    return bits.length ? `, ${bits.join(", ")}` : "";
+};
 
 // Air-yards tail for a passer / receiver stat line. Null aDOT means ESPN's text
 // carried no catch spot for this game (pre-2025), so print nothing rather than 0.
@@ -44,7 +69,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
                 (pass.length > 0) && (pass.map((p) => (
                     <tr>
                         <td style="text-align: left;">{p.passer_player_name}</td>
-                        <td style="text-align: left;">{p.Comp}/{p.Att}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Pass_TD} TD, {p.Int} INT, {p.Sck} Sck, {roundNumber(p.exp_qbr, 2, 1)} xQBR<span title="Air yards on completions / yards after catch; aDOT = average depth of target (air yards per attempt)">{airLine(p)}</span></td>
+                        <td style="text-align: left;">{p.Comp}/{p.Att}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Pass_TD} TD, {p.Int} INT, {p.Sck} Sck, {roundNumber(p.exp_qbr, 2, 1)} xQBR<span title="Air yards on completions / yards after catch; aDOT = average depth of target (air yards per attempt)">{airLine(p)}</span><span title="Longest gain, and this passer's single best play by EPA and by win probability added">{bestTail(passBest, p.passer_player_name, false)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPA || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA, 2, 2)}</td>
@@ -64,7 +89,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
                 (rush.length > 0) && (rush.map((p) => (
                     <tr>
                         <td style="text-align: left;">{p.rusher_player_name}</td>
-                        <td style="text-align: left;">{p.Car} carr{(Math.abs(p.Car) == 1) ? "y" : "ies"}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rush_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)</td>
+                        <td style="text-align: left;">{p.Car} carr{(Math.abs(p.Car) == 1) ? "y" : "ies"}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rush_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Longest carry, and this rusher's single best play by EPA and by win probability added">{bestTail(rushBest, p.rusher_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPC || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA, 2, 2)}</td>
@@ -84,12 +109,32 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
                 (receiver.length > 0) && (receiver.map((p) => (
                     <tr>
                         <td style="text-align: left;">{p.receiver_player_name}</td>
-                        <td style="text-align: left;">{p.Rec} catch{(Math.abs(p.Rec) == 1) ? "" : "es"} ({p.Tar} target{(Math.abs(p.Tar) == 1) ? "" : "s"}), {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rec_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Air yards on catches / yards after catch; aDOT = average depth of target (air yards per target)">{airLine(p)}</span></td>
+                        <td style="text-align: left;">{p.Rec} catch{(Math.abs(p.Rec) == 1) ? "" : "es"} ({p.Tar} target{(Math.abs(p.Tar) == 1) ? "" : "s"}), {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rec_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Air yards on catches / yards after catch; aDOT = average depth of target (air yards per target)">{airLine(p)}</span><span title="Longest catch, and this receiver's single best play by EPA and by win probability added">{bestTail(recvBest, p.receiver_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPT || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.SR * 100, 2, 0)}%</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.WPA * 100, 2, 1)}%</td>
+                    </tr>
+                )))
+            }
+            {
+                (defense.length > 0) && (
+                    <tr>
+                        <td colspan="8" class="gt_group_heading" style="color: black; font-weight: bold;" title="Read from the tacklers ESPN names in the play text. Older games carry no tacklers and show nothing here.">Defense</td>
+                    </tr>
+                )
+            }
+            {
+                (defense.length > 0) && (defense.map((d) => (
+                    <tr>
+                        <td style="text-align: left;">{d.name}</td>
+                        <td style="text-align: left;">{d.TOT} tackle{(d.TOT == 1) ? "" : "s"} ({d.SOLO} solo, {d.AST} ast){(d.TFL > 0) ? `, ${d.TFL} TFL` : ""}{(d.SACK > 0) ? `, ${d.SACK} sack` : ""}{(d.INT > 0) ? `, ${d.INT} INT` : ""}{(d.PBU > 0) ? `, ${d.PBU} PBU` : ""}{(d.QBH > 0) ? `, ${d.QBH} QB hurr` : ""}</td>
+                        <td class="numeral" style="text-align: center;">&mdash;</td>
+                        <td class="numeral" style="text-align: center;">&mdash;</td>
+                        <td class="numeral" style="text-align: center;">&mdash;</td>
+                        <td class="numeral" style="text-align: center;">&mdash;</td>
+                        <td class="numeral" style="text-align: center;">&mdash;</td>
                     </tr>
                 )))
             }

--- a/astro/src/components/game/metrics/TraditionalTeamStats.astro
+++ b/astro/src/components/game/metrics/TraditionalTeamStats.astro
@@ -1,0 +1,53 @@
+---
+import { traditionalTeamStats } from '../../../utils/traditionalStats';
+import { roundNumber } from '../../../utils/misc';
+
+interface Props {
+    title?: string;
+    season: number;
+    /** Team ids in the column order the rest of the panel uses. */
+    teams: (number | string)[];
+    plays: any[];
+    caption?: string;
+}
+const { title = 'The Book', season, teams, plays, caption } = Astro.props;
+
+// One column per team, so the rows line up with the EPA tables above.
+const columns = teams.map((id) => traditionalTeamStats(plays, id));
+const labels = columns[0]?.map((r) => r.label) ?? [];
+---
+
+<div class="table-responsive">
+    <table class="table table-sm table-responsive">
+        {caption && <caption class="text-muted text-small">{caption}</caption>}
+        <thead>
+            <tr>
+                <th class="box-heading">{title}</th>
+                {teams.map((value) => (
+                    <th style="text-align: center;">
+                        <a href={`/year/${season}/team/${value}`}>
+                            <img class={`img-fluid team-logo-${value}`} width="35px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${value}.png`} alt={`ESPN team id ${value}`} />
+                        </a>
+                    </th>
+                ))}
+            </tr>
+        </thead>
+        <tbody>
+            {labels.map((label, i) => (
+                <tr>
+                    <td style="text-align: left;" title={columns[0][i].title}>{label}</td>
+                    {columns.map((rows) => (
+                        <td class="numeral" style="text-align: center;">
+                            {rows[i].value}
+                            {rows[i].epa != null && (
+                                <span class="text-muted text-small" style="display: block;" title="Expected points added over the plays this row counts">
+                                    {roundNumber(rows[i].epa as number, 2, 2)} EPA
+                                </span>
+                            )}
+                        </td>
+                    ))}
+                </tr>
+            ))}
+        </tbody>
+    </table>
+</div>

--- a/astro/src/components/game/metrics/TraditionalTeamStats.astro
+++ b/astro/src/components/game/metrics/TraditionalTeamStats.astro
@@ -8,12 +8,14 @@ interface Props {
     /** Team ids in the column order the rest of the panel uses. */
     teams: (number | string)[];
     plays: any[];
+    /** The drives grouping; possession and red-zone rows are drive-level. */
+    drives: any[];
     caption?: string;
 }
-const { title = 'The Book', season, teams, plays, caption } = Astro.props;
+const { title = 'The Book', season, teams, plays, drives, caption } = Astro.props;
 
 // One column per team, so the rows line up with the EPA tables above.
-const columns = teams.map((id) => traditionalTeamStats(plays, id));
+const columns = teams.map((id) => traditionalTeamStats(plays, id, drives));
 const labels = columns[0]?.map((r) => r.label) ?? [];
 ---
 

--- a/astro/src/components/game/plays/PlayFilters.astro
+++ b/astro/src/components/game/plays/PlayFilters.astro
@@ -32,35 +32,37 @@ const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
     </button>
 </div>
 
-<script is:inline define:vars={{ target }}>
-    (() => {
-        const bar = document.querySelector(`[data-play-filters="${target}"]`);
-        const body = document.querySelector(`[data-plays-body="${target}"]`);
-        if (!bar || !body) return;
+<script>
+    // Deliberately NOT `is:inline`: an inline script executes where it sits in
+    // the document, and this component renders BEFORE the table it drives, so
+    // the tbody does not exist yet and every lookup returns null. Astro bundles
+    // this as a deferred module instead, which runs once the page is parsed.
+    import { pairRows } from "../../../utils/playFilters";
 
-        // Rows arrive as [summary, detail?] pairs; keep each pair intact.
-        const pairs = [];
-        for (const row of [...body.children]) {
-            if (row.classList.contains("accordion-body") && pairs.length) pairs[pairs.length - 1].push(row);
-            else pairs.push([row]);
-        }
+    for (const bar of document.querySelectorAll<HTMLElement>("[data-play-filters]")) {
+        const target = bar.dataset.playFilters;
+        const body = document.querySelector<HTMLElement>(`[data-plays-body="${target}"]`);
+        if (!body) continue;
+
+        const isDetail = (row: Element) => row.classList.contains("accordion-body");
+        const pairs = pairRows([...body.children], isDetail);
 
         let period = "all";
         const apply = () => {
             for (const pair of pairs) {
-                const match = period === "all" || String(pair[0].dataset.period) === period;
+                const match = period === "all" || String((pair[0] as HTMLElement).dataset.period) === period;
                 // A filtered-in detail row is un-hidden but stays collapsed:
                 // Bootstrap's .collapse still governs whether it is on screen.
-                for (const row of pair) row.hidden = !match;
+                for (const row of pair) (row as HTMLElement).hidden = !match;
             }
         };
 
         bar.addEventListener("click", (ev) => {
-            const btn = ev.target.closest("button");
-            if (!btn) return;
+            const btn = (ev.target as Element)?.closest<HTMLElement>("button");
+            if (!btn || !bar.contains(btn)) return;
             if (btn.dataset.periodFilter !== undefined) {
                 period = btn.dataset.periodFilter;
-                for (const other of bar.querySelectorAll("[data-period-filter]")) {
+                for (const other of bar.querySelectorAll<HTMLElement>("[data-period-filter]")) {
                     const on = other === btn;
                     other.classList.toggle("active", on);
                     other.setAttribute("aria-pressed", String(on));
@@ -74,5 +76,5 @@ const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
                 btn.textContent = newestFirstNow ? "Newest first" : "Oldest first";
             }
         });
-    })();
+    }
 </script>

--- a/astro/src/components/game/plays/PlayFilters.astro
+++ b/astro/src/components/game/plays/PlayFilters.astro
@@ -1,0 +1,78 @@
+---
+/**
+ * Quarter filter and reading-order toggle for a PlaysTable.
+ *
+ * Every play row carries `data-period`, and an expandable play is TWO rows --
+ * the summary and its collapsed detail. Both are marked `data-play-row`, so
+ * filtering and reordering move them together and a detail row can never end
+ * up separated from the play it belongs to.
+ */
+interface Props {
+    /** The `prefix` of the PlaysTable this drives. */
+    target: string;
+    /** Periods present in the game, in ascending order. */
+    periods: number[];
+    /** Live games read newest first; finished games read in order. */
+    newestFirst: boolean;
+}
+const { target, periods, newestFirst } = Astro.props;
+
+const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
+---
+
+<div class="d-flex flex-wrap gap-2 align-items-center mb-2" data-play-filters={target}>
+    <div class="btn-group btn-group-sm" role="group" aria-label="Filter plays by quarter">
+        <button type="button" class="btn btn-outline-secondary active" data-period-filter="all" aria-pressed="true">All</button>
+        {periods.map((p) => (
+            <button type="button" class="btn btn-outline-secondary" data-period-filter={p} aria-pressed="false">{label(p)}</button>
+        ))}
+    </div>
+    <button type="button" class="btn btn-sm btn-outline-secondary" data-order-toggle="1" aria-pressed={newestFirst}>
+        {newestFirst ? "Newest first" : "Oldest first"}
+    </button>
+</div>
+
+<script is:inline define:vars={{ target }}>
+    (() => {
+        const bar = document.querySelector(`[data-play-filters="${target}"]`);
+        const body = document.querySelector(`[data-plays-body="${target}"]`);
+        if (!bar || !body) return;
+
+        // Rows arrive as [summary, detail?] pairs; keep each pair intact.
+        const pairs = [];
+        for (const row of [...body.children]) {
+            if (row.classList.contains("accordion-body") && pairs.length) pairs[pairs.length - 1].push(row);
+            else pairs.push([row]);
+        }
+
+        let period = "all";
+        const apply = () => {
+            for (const pair of pairs) {
+                const match = period === "all" || String(pair[0].dataset.period) === period;
+                // A filtered-in detail row is un-hidden but stays collapsed:
+                // Bootstrap's .collapse still governs whether it is on screen.
+                for (const row of pair) row.hidden = !match;
+            }
+        };
+
+        bar.addEventListener("click", (ev) => {
+            const btn = ev.target.closest("button");
+            if (!btn) return;
+            if (btn.dataset.periodFilter !== undefined) {
+                period = btn.dataset.periodFilter;
+                for (const other of bar.querySelectorAll("[data-period-filter]")) {
+                    const on = other === btn;
+                    other.classList.toggle("active", on);
+                    other.setAttribute("aria-pressed", String(on));
+                }
+                apply();
+            } else if (btn.dataset.orderToggle !== undefined) {
+                pairs.reverse();
+                for (const pair of pairs) for (const row of pair) body.appendChild(row);
+                const newestFirstNow = btn.getAttribute("aria-pressed") !== "true";
+                btn.setAttribute("aria-pressed", String(newestFirstNow));
+                btn.textContent = newestFirstNow ? "Newest first" : "Oldest first";
+            }
+        });
+    })();
+</script>

--- a/astro/src/components/game/plays/PlayRow.astro
+++ b/astro/src/components/game/plays/PlayRow.astro
@@ -38,7 +38,7 @@ const defense = (play.start.pos_team.id == homeTeam.id) ? awayTeam : homeTeam;
 const downText = (play.penalty_assessed_on_kickoff && play.penalty_assessed_on_kickoff == true) ? "Assessed on Kickoff" : `${formatDistance(play.period, play.start.down, play.type.text, play.start.distance, play.start.yardsToEndzone)} at ${ formatYardline(play.start.yardsToEndzone, cleanAbbreviation(offense), cleanAbbreviation(defense), play.type.text) }`;
 ---
 
-<tr data-bs-toggle={expandable ? "collapse" : ""} href={expandable ? `#play-${prefix}-${play.game_play_number}` : ''} class=`accordion-toggle ${classText}`>
+<tr data-period={play.period} data-play-row="1" data-bs-toggle={expandable ? "collapse" : ""} href={expandable ? `#play-${prefix}-${play.game_play_number}` : ''} class=`accordion-toggle ${classText}`>
     <td style="text-align: left;">{gameClock}</td>
     <td style="text-align: center;"><a href={`/year/${play.season}/team/${play.start.pos_team.id}`}><img class={`img-fluid team-logo-${play.start.pos_team.id}`} width="35px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${play.pos_team}.png`} alt={`ESPN team id ${play.start.pos_team.id}`}/></a></td>
     <td style="text-align: left;">({downText}) {play.text} - {play.scoringPlay ? (<strong>{cleanAbbreviation(awayTeam)} {play.awayScore}, {cleanAbbreviation(homeTeam)} {play.homeScore}</strong>) : (<span>{cleanAbbreviation(awayTeam)} {play.awayScore}, {cleanAbbreviation(homeTeam)} {play.homeScore}</span>)}</td>
@@ -48,7 +48,7 @@ const downText = (play.penalty_assessed_on_kickoff && play.penalty_assessed_on_k
 </tr>
 {
     (expandable) && (
-        <tr class="accordion-body collapse" id={`play-${prefix}-${play.game_play_number}`}>
+        <tr data-period={play.period} data-play-row="1" class="accordion-body collapse" id={`play-${prefix}-${play.game_play_number}`}>
             <td colspan="6" class="hiddenRow">
                 <slot name="expandable-row-content" />
             </td>

--- a/astro/src/components/game/plays/PlaysTable.astro
+++ b/astro/src/components/game/plays/PlaysTable.astro
@@ -62,7 +62,7 @@ const { plays, prefix, expandable, caption, showGuide } = Astro.props;
                 <th style="text-align: right;">WPA</th>
             </tr>
         </thead>
-        <tbody>
+        <tbody data-plays-body={prefix}>
             {
                 (plays.map(p => (
                     <PlayRow play={p} expandable={expandable} prefix={prefix}>

--- a/astro/src/utils/defensiveBox.ts
+++ b/astro/src/utils/defensiveBox.ts
@@ -1,0 +1,155 @@
+/**
+ * Defensive and per-player extras derived from the play text.
+ *
+ * ESPN's 2025+ LiveStats text names the tacklers on a play in a trailing
+ * parenthetical -- `(#16 G.Peterson; #8 B.Vislisel)` -- and marks pass
+ * breakups and quarterback hurries inline. None of that reaches the box score
+ * ESPN publishes for college football, so the defensive side of a game page has
+ * to be read back out of the text.
+ *
+ * Everything here degrades to an empty table on older games, whose text carries
+ * no jersey numbers and no tacklers.
+ */
+
+/** A trailing `(#12 A.Player; #7 B.Other)` group naming who made the tackle. */
+const RX_TACKLERS = /\((#\d+[^)]*)\)/g;
+/** One `#12 A.Player` inside such a group. */
+const RX_PLAYER = /#(\d+)\s+([A-Z][A-Za-z.'\-]+(?:\s(?:Jr\.|Sr\.|II|III|IV))?)/g;
+const RX_PBU = /broken up by #(\d+) (\S+(?: (?:Jr\.|Sr\.|II|III|IV))?)/g;
+const RX_HURRY = /QB hurried by #(\d+) (\S+(?: (?:Jr\.|Sr\.|II|III|IV))?)/g;
+const RX_SACK = /sacked for loss of (\d+) yards?/;
+const RX_INT = /pass intercepted by #(\d+) (\S+(?: (?:Jr\.|Sr\.|II|III|IV))?)/;
+const RX_RUSH_LOSS = /rush(?: [a-z]+)? for (\d+) yards? loss/;
+
+export interface DefensiveLine {
+    jersey: number;
+    name: string;
+    /** Total tackles: solo plus assisted. */
+    TOT: number;
+    SOLO: number;
+    AST: number;
+    /** Tackles for loss, shared between everyone credited on the play. */
+    TFL: number;
+    SACK: number;
+    INT: number;
+    /** Passes broken up. */
+    PBU: number;
+    /** Quarterback hurries. */
+    QBH: number;
+}
+
+interface PlayLike {
+    text?: string | null;
+    pos_team?: number | string | null;
+    def_pos_team?: number | string | null;
+}
+
+const bump = (row: DefensiveLine, key: keyof DefensiveLine, by = 1) => {
+    (row[key] as number) += by;
+};
+
+/**
+ * Read the defensive box for one team out of the play text.
+ *
+ * @param plays every play in the game
+ * @param teamId the defending team whose players to credit
+ * @param nameFor resolves a jersey number to a display name; falls back to the
+ *        short form in the text when the roster has no match
+ */
+export function defensiveBox(
+    plays: PlayLike[],
+    teamId: number | string,
+    nameFor?: (jersey: number, short: string) => string,
+): DefensiveLine[] {
+    const rows = new Map<number, DefensiveLine>();
+    const row = (jersey: number, short: string): DefensiveLine => {
+        let r = rows.get(jersey);
+        if (!r) {
+            r = { jersey, name: nameFor?.(jersey, short) ?? short, TOT: 0, SOLO: 0, AST: 0, TFL: 0, SACK: 0, INT: 0, PBU: 0, QBH: 0 };
+            rows.set(jersey, r);
+        }
+        return r;
+    };
+    const sameTeam = (a: unknown, b: unknown) => String(a ?? "") === String(b ?? "");
+
+    for (const play of plays) {
+        const text = play?.text ?? "";
+        if (!text || !sameTeam(play.def_pos_team, teamId)) continue;
+        // a wiped play never happened, so nobody is credited for it
+        if (/NO PLAY|nullified by penalty/i.test(text)) continue;
+
+        const tacklers: Array<[number, string]> = [];
+        for (const group of text.matchAll(RX_TACKLERS)) {
+            const inner = group[1];
+            if (/H:|LS:/.test(inner)) continue; // holder / long snapper on a kick, not a tackle
+            tacklers.length = 0;
+            for (const m of inner.matchAll(RX_PLAYER)) tacklers.push([Number(m[1]), m[2]]);
+        }
+
+        const sack = RX_SACK.exec(text);
+        const rushLoss = RX_RUSH_LOSS.exec(text);
+        const share = tacklers.length ? 1 / tacklers.length : 0;
+
+        for (const [jersey, short] of tacklers) {
+            const r = row(jersey, short);
+            bump(r, "TOT");
+            bump(r, tacklers.length === 1 ? "SOLO" : "AST");
+            if (sack) {
+                r.SACK += share;
+                r.TFL += share;
+            } else if (rushLoss) {
+                r.TFL += share;
+            }
+        }
+        for (const m of text.matchAll(RX_PBU)) bump(row(Number(m[1]), m[2]), "PBU");
+        for (const m of text.matchAll(RX_HURRY)) bump(row(Number(m[1]), m[2]), "QBH");
+        const int = RX_INT.exec(text);
+        if (int) bump(row(Number(int[1]), int[2]), "INT");
+    }
+
+    const round1 = (n: number) => Math.round(n * 10) / 10;
+    return [...rows.values()]
+        .map((r) => ({ ...r, TFL: round1(r.TFL), SACK: round1(r.SACK) }))
+        .filter((r) => r.TOT > 0 || r.PBU > 0 || r.QBH > 0 || r.INT > 0)
+        .sort((a, b) => b.TOT - a.TOT || b.SOLO - a.SOLO || a.name.localeCompare(b.name));
+}
+
+/** Best single play by EPA and by WPA, plus the longest gain, for one player. */
+export interface PlayerExtremes {
+    EPA_MAX: number | null;
+    WPA_MAX: number | null;
+    LNG: number | null;
+}
+
+/**
+ * Per-player bests over the plays they appear on.
+ *
+ * @param plays every play in the game
+ * @param idField which participant column identifies the player on a play
+ * @param yardField the yardage column to take the longest gain from, if any
+ */
+export function playerExtremes(
+    plays: Array<Record<string, unknown>>,
+    idField: string,
+    yardField?: string,
+): Map<string, PlayerExtremes> {
+    const out = new Map<string, PlayerExtremes>();
+    for (const play of plays) {
+        const id = play[idField];
+        if (id == null || id === "") continue;
+        const key = String(id);
+        const cur = out.get(key) ?? { EPA_MAX: null, WPA_MAX: null, LNG: null };
+        const epa = Number(play["EPA"]);
+        const wpa = Number(play["wpa"]);
+        if (Number.isFinite(epa)) cur.EPA_MAX = cur.EPA_MAX == null ? epa : Math.max(cur.EPA_MAX, epa);
+        if (Number.isFinite(wpa)) cur.WPA_MAX = cur.WPA_MAX == null ? wpa : Math.max(cur.WPA_MAX, wpa);
+        if (yardField) {
+            const y = Number(play[yardField]);
+            if (Number.isFinite(y)) cur.LNG = cur.LNG == null ? y : Math.max(cur.LNG, y);
+        }
+        out.set(key, cur);
+    }
+    // a longest of less than zero reads as 0, the way every box score prints it
+    for (const v of out.values()) if (v.LNG != null && v.LNG < 0) v.LNG = 0;
+    return out;
+}

--- a/astro/src/utils/playFilters.ts
+++ b/astro/src/utils/playFilters.ts
@@ -1,0 +1,25 @@
+/**
+ * Row pairing for the All Plays quarter filter.
+ *
+ * An expandable play is TWO table rows: the summary, and the collapsed detail
+ * that Bootstrap toggles. Filtering or reordering has to move them together, or
+ * a detail row ends up under a play it does not belong to.
+ *
+ * Kept out of the component so it can be tested without a DOM.
+ */
+
+/**
+ * Group consecutive rows into `[summary]` or `[summary, detail]` runs.
+ *
+ * A detail row attaches to the summary before it. A leading detail row -- which
+ * should never happen, but would silently mis-pair every row after it -- starts
+ * its own group rather than being dropped.
+ */
+export function pairRows<T>(rows: T[], isDetail: (row: T) => boolean): T[][] {
+    const pairs: T[][] = [];
+    for (const row of rows) {
+        if (isDetail(row) && pairs.length) pairs[pairs.length - 1].push(row);
+        else pairs.push([row]);
+    }
+    return pairs;
+}

--- a/astro/src/utils/traditionalStats.ts
+++ b/astro/src/utils/traditionalStats.ts
@@ -1,0 +1,133 @@
+/**
+ * The counting stats an official book carries that the advanced box score does not.
+ *
+ * Game on Paper's team box already interleaves EPA everywhere, but it has no
+ * third-down conversions, no red-zone line, no turnovers and no time of
+ * possession -- the rows a reader coming from the official book looks for
+ * first. These are all derivable from the processed plays, so they belong
+ * beside the EPA rather than in a separate traditional table.
+ */
+
+interface PlayLike {
+    pos_team?: number | string | null;
+    down?: number | null;
+    first_down_created?: boolean | null;
+    int_turnover?: boolean | null;
+    pos_fumble_lost?: boolean | null;
+    sack?: boolean | null;
+    sack_vec?: boolean | null;
+    rz_play?: boolean | null;
+    EPA?: number | null;
+    scoring_play?: boolean | null;
+    td_play?: boolean | null;
+    "drive.id"?: string | null;
+    "drive.result"?: string | null;
+    "drive.timeElapsed.displayValue"?: string | null;
+    [k: string]: unknown;
+}
+
+export interface TraditionalRow {
+    label: string;
+    /** What the book prints, e.g. "6-27 (22%)". */
+    value: string;
+    /** The EPA that went with those plays, where the pairing is meaningful. */
+    epa: number | null;
+    title: string;
+}
+
+const same = (a: unknown, b: unknown) => String(a ?? "") === String(b ?? "");
+const pct = (n: number, d: number) => (d > 0 ? ` (${Math.round((n / d) * 100)}%)` : "");
+const sum = (xs: PlayLike[]) => xs.reduce((t, p) => t + (Number(p.EPA) || 0), 0);
+
+/** "6:07" -> 367 seconds. Drive clocks are mm:ss and occasionally h:mm:ss. */
+const toSeconds = (clock: string | null | undefined): number => {
+    if (!clock) return 0;
+    const parts = clock.split(":").map(Number);
+    if (parts.some((n) => !Number.isFinite(n))) return 0;
+    return parts.reduce((t, n) => t * 60 + n, 0);
+};
+
+const mmss = (secs: number) => `${Math.floor(secs / 60)}:${String(Math.round(secs % 60)).padStart(2, "0")}`;
+
+/**
+ * Time of possession for one team, summed over its drives.
+ *
+ * This counts the whole drive including its punt or field goal, which is what
+ * the official book does -- a punt is charged to the punting team's clock.
+ */
+export function timeOfPossession(plays: PlayLike[], teamId: number | string): number {
+    // A drive is owned by whoever snapped its first play. ESPN files the play
+    // after a turnover, and the ensuing kickoff, under the SAME drive id, so a
+    // per-play team filter charges those drives to both teams and the two
+    // clocks come to nearly 79 minutes of a 60-minute game.
+    const owner = new Map<string, { team: string; elapsed: number }>();
+    for (const p of plays) {
+        const id = p["drive.id"];
+        if (!id || owner.has(id)) continue;
+        owner.set(id, { team: String(p.pos_team ?? ""), elapsed: toSeconds(p["drive.timeElapsed.displayValue"]) });
+    }
+    let total = 0;
+    for (const d of owner.values()) if (same(d.team, teamId)) total += d.elapsed;
+    return total;
+}
+
+/** The book's counting stats for one team, each carrying its own EPA. */
+export function traditionalTeamStats(plays: PlayLike[], teamId: number | string): TraditionalRow[] {
+    const own = plays.filter((p) => same(p.pos_team, teamId));
+
+    const onDown = (d: number) => own.filter((p) => Number(p.down) === d);
+    const conv = (d: number) => {
+        const att = onDown(d);
+        const made = att.filter((p) => p.first_down_created === true);
+        return {
+            label: `${d === 3 ? "Third" : "Fourth"} down`,
+            value: `${made.length}-${att.length}${pct(made.length, att.length)}`,
+            epa: att.length ? sum(att) : null,
+            title: `Plays snapped on ${d === 3 ? "third" : "fourth"} down that earned a first down, and the EPA over all of them.`,
+        };
+    };
+
+    // A red-zone trip is a drive, not a play: a drive that reached the 20 counts
+    // once however many snaps it took.
+    const trips = new Map<string, boolean>();
+    for (const p of own) {
+        const id = p["drive.id"];
+        if (!id || p.rz_play !== true) continue;
+        trips.set(id, trips.get(id) || p.td_play === true || p.scoring_play === true);
+    }
+    const rzScores = [...trips.values()].filter(Boolean).length;
+    const rzPlays = own.filter((p) => p.rz_play === true);
+
+    const ints = own.filter((p) => p.int_turnover === true).length;
+    const fumbles = own.filter((p) => p.pos_fumble_lost === true).length;
+    const sacks = own.filter((p) => p.sack === true || p.sack_vec === true);
+
+    return [
+        conv(3),
+        conv(4),
+        {
+            label: "Red zone scoring",
+            value: `${rzScores}-${trips.size}${pct(rzScores, trips.size)}`,
+            epa: rzPlays.length ? sum(rzPlays) : null,
+            title: "Drives that reached the opponent 20 and scored on them, and the EPA of the snaps inside the 20.",
+        },
+        {
+            label: "Turnovers",
+            value: `${ints + fumbles}${ints + fumbles > 0 ? ` (${ints} INT, ${fumbles} fum)` : ""}`,
+            epa: ints + fumbles > 0 ? sum(own.filter((p) => p.int_turnover === true || p.pos_fumble_lost === true)) : null,
+            title: "Interceptions thrown plus fumbles lost, and the EPA those plays cost.",
+        },
+        {
+            label: "Sacks taken",
+            value: String(sacks.length),
+            epa: sacks.length ? sum(sacks) : null,
+            title: "Times this team's passer was sacked, and the EPA of those plays.",
+        },
+        {
+            label: "Time of possession",
+            value: mmss(timeOfPossession(plays, teamId)),
+            epa: null,
+            title: "Summed over this team's drives, including the punt or field goal that ended them -- the same convention the official book uses.",
+        },
+    ];
+}

--- a/astro/src/utils/traditionalStats.ts
+++ b/astro/src/utils/traditionalStats.ts
@@ -8,6 +8,15 @@
  * beside the EPA rather than in a separate traditional table.
  */
 
+interface DriveLike {
+    id?: string | null;
+    /** The offense. This is the drive-level convention -- plays use pos_team. */
+    team?: { id?: string | number | null } | null;
+    isScore?: boolean | null;
+    timeElapsed?: { displayValue?: string | null } | null;
+    [k: string]: unknown;
+}
+
 interface PlayLike {
     pos_team?: number | string | null;
     down?: number | null;
@@ -22,7 +31,6 @@ interface PlayLike {
     td_play?: boolean | null;
     "drive.id"?: string | null;
     "drive.result"?: string | null;
-    "drive.timeElapsed.displayValue"?: string | null;
     [k: string]: unknown;
 }
 
@@ -52,27 +60,31 @@ const mmss = (secs: number) => `${Math.floor(secs / 60)}:${String(Math.round(sec
 /**
  * Time of possession for one team, summed over its drives.
  *
- * This counts the whole drive including its punt or field goal, which is what
- * the official book does -- a punt is charged to the punting team's clock.
+ * Reads the drives grouping rather than the plays: `drive.team` is the offense,
+ * which is the drive-level convention here, so ownership needs no inferring.
+ * That matters because a `drive.id` is NOT exclusive to one offense -- ESPN
+ * files the play after a turnover, and the ensuing kickoff, under the drive
+ * that just ended (this fixture's first drive reports 12 offensivePlays and
+ * carries 14). Grouping plays by drive id and then filtering them by pos_team
+ * would charge those drives to both teams.
+ *
+ * Counts the whole drive including the punt or field goal that ended it, which
+ * is what the official book does.
  */
-export function timeOfPossession(plays: PlayLike[], teamId: number | string): number {
-    // A drive is owned by whoever snapped its first play. ESPN files the play
-    // after a turnover, and the ensuing kickoff, under the SAME drive id, so a
-    // per-play team filter charges those drives to both teams and the two
-    // clocks come to nearly 79 minutes of a 60-minute game.
-    const owner = new Map<string, { team: string; elapsed: number }>();
-    for (const p of plays) {
-        const id = p["drive.id"];
-        if (!id || owner.has(id)) continue;
-        owner.set(id, { team: String(p.pos_team ?? ""), elapsed: toSeconds(p["drive.timeElapsed.displayValue"]) });
-    }
+export function timeOfPossession(drives: DriveLike[], teamId: number | string): number {
     let total = 0;
-    for (const d of owner.values()) if (same(d.team, teamId)) total += d.elapsed;
+    for (const d of drives) if (same(d.team?.id, teamId)) total += toSeconds(d.timeElapsed?.displayValue);
     return total;
 }
 
-/** The book's counting stats for one team, each carrying its own EPA. */
-export function traditionalTeamStats(plays: PlayLike[], teamId: number | string): TraditionalRow[] {
+/**
+ * The book's counting stats for one team, each carrying its own EPA.
+ *
+ * Down, turnover and sack rows come from plays filtered by `pos_team`; the
+ * possession and red-zone rows come from the drives grouping, since those are
+ * drive-level questions and `drive.team` already names the offense.
+ */
+export function traditionalTeamStats(plays: PlayLike[], teamId: number | string, drives: DriveLike[] = []): TraditionalRow[] {
     const own = plays.filter((p) => same(p.pos_team, teamId));
 
     const onDown = (d: number) => own.filter((p) => Number(p.down) === d);
@@ -88,14 +100,12 @@ export function traditionalTeamStats(plays: PlayLike[], teamId: number | string)
     };
 
     // A red-zone trip is a drive, not a play: a drive that reached the 20 counts
-    // once however many snaps it took.
-    const trips = new Map<string, boolean>();
-    for (const p of own) {
-        const id = p["drive.id"];
-        if (!id || p.rz_play !== true) continue;
-        trips.set(id, trips.get(id) || p.td_play === true || p.scoring_play === true);
-    }
-    const rzScores = [...trips.values()].filter(Boolean).length;
+    // once however many snaps it took. The drive says whether it scored
+    // (`isScore`) and who had it; the plays say whether it reached the 20,
+    // since the drive's own play list is the raw feed and carries no rz_play.
+    const rzDriveIds = new Set(own.filter((p) => p.rz_play === true).map((p) => p["drive.id"]).filter(Boolean));
+    const rzDrives = drives.filter((d) => same(d.team?.id, teamId) && rzDriveIds.has(d.id ?? ""));
+    const rzScores = rzDrives.filter((d) => d.isScore === true).length;
     const rzPlays = own.filter((p) => p.rz_play === true);
 
     const ints = own.filter((p) => p.int_turnover === true).length;
@@ -107,7 +117,7 @@ export function traditionalTeamStats(plays: PlayLike[], teamId: number | string)
         conv(4),
         {
             label: "Red zone scoring",
-            value: `${rzScores}-${trips.size}${pct(rzScores, trips.size)}`,
+            value: `${rzScores}-${rzDrives.length}${pct(rzScores, rzDrives.length)}`,
             epa: rzPlays.length ? sum(rzPlays) : null,
             title: "Drives that reached the opponent 20 and scored on them, and the EPA of the snaps inside the 20.",
         },
@@ -125,7 +135,7 @@ export function traditionalTeamStats(plays: PlayLike[], teamId: number | string)
         },
         {
             label: "Time of possession",
-            value: mmss(timeOfPossession(plays, teamId)),
+            value: mmss(timeOfPossession(drives, teamId)),
             epa: null,
             title: "Summed over this team's drives, including the punt or field goal that ended them -- the same convention the official book uses.",
         },

--- a/astro/test/defensiveBox.test.ts
+++ b/astro/test/defensiveBox.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { defensiveBox, playerExtremes } from "../src/utils/defensiveBox";
+
+const play = (text: string, def = 1, pos = 2) => ({ text, def_pos_team: def, pos_team: pos });
+
+describe("defensiveBox", () => {
+    test("credits a solo tackle to the only name in the parenthetical", () => {
+        const box = defensiveBox([play("(10:20) #8 D.Stanley rush middle for 3 yards gain to the FSU36 (#1 D.Desir)")], 1);
+        expect(box).toHaveLength(1);
+        expect(box[0]).toMatchObject({ jersey: 1, name: "D.Desir", TOT: 1, SOLO: 1, AST: 0 });
+    });
+
+    test("splits a shared tackle into assists, never solos", () => {
+        const box = defensiveBox([play("#26 J.Payne rush middle for 1 yard loss to the FSU42 (#16 G.Peterson; #8 B.Vislisel)")], 1);
+        expect(box.map((r) => r.jersey).sort((a, b) => a - b)).toEqual([8, 16]);
+        for (const r of box) expect(r).toMatchObject({ TOT: 1, SOLO: 0, AST: 1 });
+    });
+
+    test("a tackle for loss is shared, and a sack counts as one too", () => {
+        const box = defensiveBox([play("#14 A.Daniels sacked for loss of 9 yards to the NMS25 (#16 G.Peterson, #14 S.Aupiu)")], 1);
+        expect(box).toHaveLength(2);
+        for (const r of box) expect(r).toMatchObject({ SACK: 0.5, TFL: 0.5 });
+    });
+
+    test("a run stopped behind the line is a TFL but not a sack", () => {
+        const box = defensiveBox([play("#26 J.Payne rush middle for 4 yards loss to the TCU31 (#90 X.Lewis)")], 1);
+        expect(box[0]).toMatchObject({ TFL: 1, SACK: 0 });
+    });
+
+    test("counts breakups, hurries and interceptions", () => {
+        const box = defensiveBox(
+            [
+                play("#3 T.Hedden pass incomplete short right to #2 J.Jones thrown to NMS20 broken up by #13 D.Diggs"),
+                play("#14 A.Daniels pass incomplete short left to #0 D.Robinson thrown to NMS41 QB hurried by #8 B.Vislisel"),
+                play("#3 T.Hedden pass intercepted by #0 Q.Jones at FSU00, Touchback"),
+            ],
+            1,
+        );
+        expect(box.find((r) => r.jersey === 13)?.PBU).toBe(1);
+        expect(box.find((r) => r.jersey === 8)?.QBH).toBe(1);
+        expect(box.find((r) => r.jersey === 0)?.INT).toBe(1);
+    });
+
+    test("ignores the holder and long snapper on a kick", () => {
+        const box = defensiveBox([play("#39 G.Panikowski field goal attempt from 43 yards GOOD (H: #87 C.Jula, LS: #48 C.Bowers)")], 1);
+        expect(box).toHaveLength(0);
+    });
+
+    test("credits nobody on a play the penalty wiped", () => {
+        const box = defensiveBox([play("#26 J.Payne rush left for 6 yards gain to the TCU50 (#1 D.Desir) PENALTY NMS Holding. NO PLAY")], 1);
+        expect(box).toHaveLength(0);
+    });
+
+    test("only credits the defending team, and returns nothing for older text", () => {
+        const p = play("#26 J.Payne rush middle for 3 yards (#1 D.Desir)");
+        expect(defensiveBox([p], 99)).toHaveLength(0);
+        expect(defensiveBox([play("Sam Hicks run for 4 yds to the ACU 36")], 1)).toHaveLength(0);
+    });
+
+    test("resolves jersey numbers to roster names, falling back to the text", () => {
+        const p = [play("#5 A.Back rush middle for 2 yards gain to the UNC30 (#1 D.Desir)")];
+        expect(defensiveBox(p, 1)[0].name).toBe("D.Desir");
+        const roster = (jersey: number, short: string) => (jersey === 1 ? "Mandrell Desir" : short);
+        expect(defensiveBox(p, 1, roster)[0]).toMatchObject({ jersey: 1, name: "Mandrell Desir" });
+    });
+});
+
+describe("playerExtremes", () => {
+    const plays = [
+        { rusher_player_name: 7, EPA: 0.4, wpa: 0.01, yds_rushed: 5 },
+        { rusher_player_name: 7, EPA: 2.1, wpa: 0.09, yds_rushed: 22 },
+        { rusher_player_name: 7, EPA: -1.2, wpa: -0.04, yds_rushed: -3 },
+        { rusher_player_name: 9, EPA: 0.2, wpa: 0.0, yds_rushed: -2 },
+    ];
+
+    test("takes the best single play by EPA and WPA and the longest gain", () => {
+        const m = playerExtremes(plays, "rusher_player_name", "yds_rushed");
+        expect(m.get("7")).toEqual({ EPA_MAX: 2.1, WPA_MAX: 0.09, LNG: 22 });
+    });
+
+    test("a longest of less than zero prints as zero", () => {
+        const m = playerExtremes(plays, "rusher_player_name", "yds_rushed");
+        expect(m.get("9")?.LNG).toBe(0);
+    });
+
+    test("skips plays with no player on them", () => {
+        const m = playerExtremes([{ rusher_player_name: null, EPA: 9 }, ...plays], "rusher_player_name");
+        expect(m.size).toBe(2);
+        expect(m.get("7")?.LNG).toBeNull();
+    });
+});

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -65,6 +65,10 @@ describe('GamePage renders a finished game end to end', () => {
     test('stat lines carry the longest gain and the best single play', () => {
         // Extremes come off the plays, so they work on any game, old text or new.
         expect(html).toMatch(/\d+ LNG, -?\d+\.\d+ best EPA, -?\d+\.\d+% best WPA/);
+        // a passer's longest is his longest COMPLETION: Cam Miller went 20/29 for
+        // 274 with a long of 36, McIvor 20/32 for 153 with a long of 18
+        expect(html).toMatch(/Cam Miller[\s\S]{0,400}?36 LNG/);
+        expect(html).toMatch(/Maverick McIvor[\s\S]{0,400}?18 LNG/);
     });
 
     test('the Latest strip leads the page, newest play first', () => {
@@ -116,16 +120,32 @@ describe('GamePage renders a finished game end to end', () => {
         // no overtime in this game, so no overtime button
         expect(html).not.toContain('data-period-filter="5"');
         expect(html).toContain('data-order-toggle');
+    });
 
-        // Every play row carries its period, and a detail row always follows its
-        // summary -- that adjacency is what keeps the two moving together.
-        const rows = [...html.matchAll(/<tr ([^>]*data-play-row[^>]*)>/g)].map((m) => m[1]);
+    test('inside All Plays every summary row is followed by exactly one detail row', () => {
+        // Scoped to the All Plays tbody on purpose: the Latest strip is not
+        // expandable, so its rows are unpaired and a whole-page count would be odd.
+        const body = html.slice(html.indexOf('data-plays-body="all"'));
+        const rows = [...body.slice(0, body.indexOf('</tbody>')).matchAll(/<tr ([^>]*data-play-row[^>]*)>/g)].map((m) => m[1]);
         expect(rows.length).toBeGreaterThan(100);
         expect(rows.every((r) => /data-period="\d+"/.test(r))).toBe(true);
+
         const isDetail = rows.map((r) => r.includes('accordion-body'));
-        // details never lead, and never follow another detail
-        expect(isDetail[0]).toBe(false);
-        for (let i = 1; i < isDetail.length; i++) if (isDetail[i]) expect(isDetail[i - 1]).toBe(false);
+        expect(isDetail.length % 2).toBe(0);
+        for (let i = 0; i < isDetail.length; i += 2) {
+            expect(isDetail[i]).toBe(false);
+            expect(isDetail[i + 1]).toBe(true);
+        }
+    });
+
+    test('the filter script is deferred, not run where it sits', () => {
+        // It renders BEFORE the table it drives, so an inline script would look
+        // up a tbody that has not been parsed yet and wire up nothing at all.
+        const inline = html.indexOf('data-plays-body="${target}"');
+        expect(inline).toBe(-1);
+        const bar = html.indexOf('data-play-filters="all"');
+        const tbody = html.indexOf('data-plays-body="all"');
+        expect(bar).toBeLessThan(tbody);
     });
 
     test('every nav link points at an anchor that exists', () => {

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -67,6 +67,13 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).toMatch(/\d+ LNG, -?\d+\.\d+ best EPA, -?\d+\.\d+% best WPA/);
     });
 
+    test('the Latest strip leads the page, newest play first', () => {
+        expect(html).toContain('id="latest"');
+        // it must sit above the win probability chart, which was the old first panel
+        expect(html.indexOf('id="latest"')).toBeLessThan(html.indexOf('id="wpChart"'));
+        expect(html).toMatch(/Final\. Last drive: [^<]+, [^<]+\./);
+    });
+
     test('the book rows render with their EPA beside them', () => {
         for (const label of ['Third down', 'Fourth down', 'Red zone scoring', 'Turnovers', 'Sacks taken', 'Time of possession']) {
             expect(html).toContain(`>${label}<`);
@@ -81,6 +88,16 @@ describe('GamePage renders a finished game end to end', () => {
         // 401729745 predates ESPN's LiveStats tackler parentheticals; the section
         // has to disappear rather than render an empty table.
         expect(html).not.toContain('>Defense<');
+    });
+
+    test('every nav link points at an anchor that exists', () => {
+        // #wpChart, #epChart and #most-imp-plays were all dead: the nav offered
+        // them and nothing on the page carried the id.
+        const hrefs = [...html.matchAll(/href="#([\w-]+)"/g)].map((m) => m[1]);
+        expect(hrefs.length).toBeGreaterThan(5);
+        for (const anchor of new Set(hrefs)) {
+            expect(html, `nav points at #${anchor} but no element has that id`).toContain(`id="${anchor}"`);
+        }
     });
 
     test('exactly one h1 and a SportsEvent that parses', () => {

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -90,6 +90,22 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).not.toContain('>Defense<');
     });
 
+    test('the linescore prints each quarter and adds up to the final score', () => {
+        const table = html.slice(html.indexOf('Linescore</th>'));
+        const body = table.slice(table.indexOf('<tbody>'), table.indexOf('</tbody>'));
+        const rows = body.split('<tr>').filter((r) => r.includes('numeral'));
+        expect(rows).toHaveLength(2);
+        for (const row of rows) {
+            const nums = [...row.matchAll(/class="numeral"[^>]*>\s*(?:<strong>)?\s*(\d+)/g)].map((m) => Number(m[1]));
+            const total = nums.pop()!;
+            expect(nums).toHaveLength(4);
+            expect(nums.reduce((a, b) => a + b, 0)).toBe(total);
+        }
+        // away team leads the table, the way a scoreboard is read
+        expect(rows[0]).toContain('ACU');
+        expect(rows[1]).toContain('NDSU');
+    });
+
     test('All Plays offers a quarter filter, and the markup its script needs is there', () => {
         // The filter script finds rows by these hooks. If PlayRow or PlaysTable
         // stops emitting them the buttons silently do nothing, so pin the contract.

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -67,6 +67,16 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).toMatch(/\d+ LNG, -?\d+\.\d+ best EPA, -?\d+\.\d+% best WPA/);
     });
 
+    test('the book rows render with their EPA beside them', () => {
+        for (const label of ['Third down', 'Fourth down', 'Red zone scoring', 'Turnovers', 'Sacks taken', 'Time of possession']) {
+            expect(html).toContain(`>${label}<`);
+        }
+        expect(html).toMatch(/\d+-\d+ \(\d+%\)/);
+        expect(html).toMatch(/-?\d+\.\d\d EPA/);
+        // the clock lives in the possession row itself, not just anywhere on the page
+        expect(html).toMatch(/Time of possession<\/td>[\s\S]{0,600}?\d+:\d\d/);
+    });
+
     test('a game whose text names no tacklers shows no defensive box', () => {
         // 401729745 predates ESPN's LiveStats tackler parentheticals; the section
         // has to disappear rather than render an empty table.

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -62,11 +62,48 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).toContain(`<link rel="canonical" href="https://gameonpaper.com/game/${GAME_ID}">`);
     });
 
+    test('stat lines carry the longest gain and the best single play', () => {
+        // Extremes come off the plays, so they work on any game, old text or new.
+        expect(html).toMatch(/\d+ LNG, -?\d+\.\d+ best EPA, -?\d+\.\d+% best WPA/);
+    });
+
+    test('a game whose text names no tacklers shows no defensive box', () => {
+        // 401729745 predates ESPN's LiveStats tackler parentheticals; the section
+        // has to disappear rather than render an empty table.
+        expect(html).not.toContain('>Defense<');
+    });
+
     test('exactly one h1 and a SportsEvent that parses', () => {
         expect((html.match(/<h1[\s>]/g) ?? []).length).toBe(1);
         const ld = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map((m) => JSON.parse(m[1]));
         const ev = ld.find((o) => o['@type'] === 'SportsEvent');
         expect(ev?.url).toBe(`https://gameonpaper.com/game/${GAME_ID}`);
         expect(ev?.homeTeam?.name).toBeTruthy();
+    });
+});
+
+describe('PlayerBoxScore builds a defensive box from 2025 play text', () => {
+    test('the tacklers ESPN names become rows', async () => {
+        const play = (text: string, extra = {}) => ({ text, pos_team: 2, def_pos_team: 1, ...extra });
+        const { default: PlayerBoxScore } = await import('../src/components/game/metrics/PlayerBoxScore.astro');
+        const html = await container.renderToString(PlayerBoxScore, {
+            props: {
+                pass: [],
+                rush: [{ rusher_player_name: 'J.Payne', Car: 2, Yds: 9, Rush_TD: 0, Fum: 0, Fum_Lost: 0, YPC: 4.5, EPA: 0.3, EPA_per_Play: 0.15, SR: 0.5, WPA: 0.004 }],
+                receiver: [],
+                teamId: 1,
+                plays: [
+                    play('#26 J.Payne rush middle for 11 yards gain to the FSU42 (#16 G.Peterson; #8 B.Vislisel)', { rusher_player_name: 'J.Payne', yds_rushed: 11, EPA: 0.8, wpa: 0.012 }),
+                    play('#26 J.Payne rush left for 2 yards loss to the FSU40 (#16 G.Peterson)', { rusher_player_name: 'J.Payne', yds_rushed: -2, EPA: -0.5, wpa: -0.008 }),
+                    play('#3 T.Hedden pass incomplete short right broken up by #13 D.Diggs'),
+                ],
+            },
+        });
+        expect(html).toContain('>Defense<');
+        expect(html).toContain('G.Peterson');
+        expect(html).toContain('2 tackles (1 solo, 1 ast), 1 TFL');
+        expect(html).toContain('1 PBU');
+        // the rusher's stat line picks up his longest carry and his best play
+        expect(html).toContain('11 LNG, 0.80 best EPA, 1.2% best WPA');
     });
 });

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -90,6 +90,28 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).not.toContain('>Defense<');
     });
 
+    test('All Plays offers a quarter filter, and the markup its script needs is there', () => {
+        // The filter script finds rows by these hooks. If PlayRow or PlaysTable
+        // stops emitting them the buttons silently do nothing, so pin the contract.
+        expect(html).toContain('data-plays-body="all"');
+        expect(html).toContain('data-play-filters="all"');
+        expect(html).toMatch(/data-period-filter="all"/);
+        for (const q of [1, 2, 3, 4]) expect(html).toContain(`data-period-filter="${q}"`);
+        // no overtime in this game, so no overtime button
+        expect(html).not.toContain('data-period-filter="5"');
+        expect(html).toContain('data-order-toggle');
+
+        // Every play row carries its period, and a detail row always follows its
+        // summary -- that adjacency is what keeps the two moving together.
+        const rows = [...html.matchAll(/<tr ([^>]*data-play-row[^>]*)>/g)].map((m) => m[1]);
+        expect(rows.length).toBeGreaterThan(100);
+        expect(rows.every((r) => /data-period="\d+"/.test(r))).toBe(true);
+        const isDetail = rows.map((r) => r.includes('accordion-body'));
+        // details never lead, and never follow another detail
+        expect(isDetail[0]).toBe(false);
+        for (let i = 1; i < isDetail.length; i++) if (isDetail[i]) expect(isDetail[i - 1]).toBe(false);
+    });
+
     test('every nav link points at an anchor that exists', () => {
         // #wpChart, #epChart and #most-imp-plays were all dead: the nav offered
         // them and nothing on the page carried the id.

--- a/astro/test/playFilters.test.ts
+++ b/astro/test/playFilters.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { pairRows } from '../src/utils/playFilters';
+
+// The rows a PlaysTable emits: a summary, optionally followed by its detail.
+const S = (id: number) => ({ id, detail: false });
+const D = (id: number) => ({ id, detail: true });
+const pair = (rows: { id: number; detail: boolean }[]) => pairRows(rows, (r) => r.detail).map((p) => p.map((r) => r.id));
+
+describe('pairRows', () => {
+    test('a detail row belongs to the summary before it', () => {
+        expect(pair([S(1), D(1), S(2), D(2)])).toEqual([[1, 1], [2, 2]]);
+    });
+
+    test('a non-expandable table is all singletons', () => {
+        expect(pair([S(1), S(2), S(3)])).toEqual([[1], [2], [3]]);
+    });
+
+    test('mixed expandable and not, in one table', () => {
+        expect(pair([S(1), D(1), S(2), S(3), D(3)])).toEqual([[1, 1], [2], [3, 3]]);
+    });
+
+    test('a leading detail row starts its own group rather than vanishing', () => {
+        // Never expected, but silently dropping it would mis-pair every row after.
+        expect(pair([D(9), S(1), D(1)])).toEqual([[9], [1, 1]]);
+    });
+
+    test('reversing pairs keeps every detail behind its own summary', () => {
+        const pairs = pairRows([S(1), D(1), S(2), D(2), S(3), D(3)], (r) => r.detail).reverse();
+        expect(pairs.flat().map((r) => `${r.id}${r.detail ? 'd' : 's'}`)).toEqual(['3s', '3d', '2s', '2d', '1s', '1d']);
+    });
+
+    test('no rows, no pairs', () => {
+        expect(pair([])).toEqual([]);
+    });
+});

--- a/astro/test/traditionalStats.test.ts
+++ b/astro/test/traditionalStats.test.ts
@@ -5,8 +5,10 @@ import { timeOfPossession, traditionalTeamStats } from '../src/utils/traditional
 
 const game = JSON.parse(gunzipSync(readFileSync(new URL('./fixtures/game-401729745.json.gz', import.meta.url))).toString());
 const plays = game.plays as any[];
+// The same drives grouping GamePage builds and DrivesTable already consumes.
+const drives = (game.drives.current ? (game.drives.previous ?? []).concat([game.drives.current]) : (game.drives.previous ?? [])) as any[];
 const [away, home] = game.advBoxScore.team.map((t: any) => t.pos_team);
-const row = (teamId: number, label: string) => traditionalTeamStats(plays, teamId).find((r) => r.label === label)!;
+const row = (teamId: number, label: string) => traditionalTeamStats(plays, teamId, drives).find((r) => r.label === label)!;
 
 describe('traditionalTeamStats on a real game', () => {
     test('third downs match a hand count of the plays', () => {
@@ -18,42 +20,54 @@ describe('traditionalTeamStats on a real game', () => {
     });
 
     test('the two clocks partition the game, never double-count it', () => {
+        // Ownership comes from drive.team, so this is a partition by construction.
+        // It is worth pinning because a drive.id is NOT exclusive to one offense --
         // ESPN files the play after a turnover, and the ensuing kickoff, under the
-        // drive that just ended -- 8 of this game's 26 drives carry both teams'
-        // snaps. Charging a drive to whoever snapped it first is what keeps the
-        // two clocks from summing to 78:52 of a 60-minute game.
-        const seen = new Map<string, number>();
-        for (const p of plays) {
-            const id = p['drive.id'];
-            if (id && !seen.has(id)) {
-                const [m, s] = String(p['drive.timeElapsed.displayValue'] ?? '0:00').split(':').map(Number);
-                seen.set(id, m * 60 + s);
-            }
-        }
-        const everyDrive = [...seen.values()].reduce((t, n) => t + n, 0);
-        expect(timeOfPossession(plays, away) + timeOfPossession(plays, home)).toBe(everyDrive);
+        // drive that just ended (drive 1 reports 12 offensivePlays and carries 14).
+        // Grouping plays by drive id and filtering by pos_team charges 8 of this
+        // game's 26 drives to both teams, for 78:52 of a 60-minute game.
+        const everyDrive = drives.reduce((t, d) => {
+            const [m, s] = String(d.timeElapsed?.displayValue ?? '0:00').split(':').map(Number);
+            return t + m * 60 + s;
+        }, 0);
+        expect(timeOfPossession(drives, away) + timeOfPossession(drives, home)).toBe(everyDrive);
         expect(everyDrive).toBeLessThan(61 * 60);
     });
 
-    test('a red-zone trip counts once however many snaps it took', () => {
+    test('possession is read off drive.team, not inferred from the plays', () => {
         for (const team of [away, home]) {
-            const drives = new Set(plays.filter((p) => p.pos_team == team && p.rz_play === true).map((p) => p['drive.id']));
-            const [, trips] = row(team, 'Red zone scoring').value.match(/^\d+-(\d+)/)!;
-            expect(Number(trips)).toBe(drives.size);
+            const mine = drives.filter((d) => String(d.team?.id) === String(team));
+            expect(mine.length).toBeGreaterThan(0);
+            const expected = mine.reduce((t, d) => {
+                const [m, s] = String(d.timeElapsed?.displayValue ?? '0:00').split(':').map(Number);
+                return t + m * 60 + s;
+            }, 0);
+            expect(timeOfPossession(drives, team)).toBe(expected);
+        }
+    });
+
+    test('a red-zone trip counts once however many snaps it took, and scores come from drive.isScore', () => {
+        for (const team of [away, home]) {
+            const rzIds = new Set(plays.filter((p) => p.pos_team == team && p.rz_play === true).map((p) => p['drive.id']));
+            const mine = drives.filter((d) => String(d.team?.id) === String(team) && rzIds.has(d.id));
+            const [, scores, trips] = row(team, 'Red zone scoring').value.match(/^(\d+)-(\d+)/)!;
+            expect(Number(trips)).toBe(mine.length);
+            expect(Number(scores)).toBe(mine.filter((d) => d.isScore === true).length);
+            expect(Number(scores)).toBeLessThanOrEqual(Number(trips));
             // more snaps than trips is the whole point of counting drives
-            expect(plays.filter((p) => p.pos_team == team && p.rz_play === true).length).toBeGreaterThanOrEqual(drives.size);
+            expect(plays.filter((p) => p.pos_team == team && p.rz_play === true).length).toBeGreaterThanOrEqual(mine.length);
         }
     });
 
     test('every row prints something, and EPA is null only where no play backs it', () => {
-        for (const r of traditionalTeamStats(plays, away)) {
+        for (const r of traditionalTeamStats(plays, away, drives)) {
             expect(r.value).toMatch(/\S/);
             if (r.label === 'Time of possession') expect(r.epa).toBeNull();
         }
     });
 
     test('an empty game yields rows rather than throwing', () => {
-        const rows = traditionalTeamStats([], 1);
+        const rows = traditionalTeamStats([], 1, []);
         expect(rows).toHaveLength(6);
         expect(rows.every((r) => r.epa === null)).toBe(true);
         expect(row(away, 'Time of possession').value).toMatch(/^\d+:\d\d$/);

--- a/astro/test/traditionalStats.test.ts
+++ b/astro/test/traditionalStats.test.ts
@@ -1,0 +1,61 @@
+import { gunzipSync } from 'node:zlib';
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'vitest';
+import { timeOfPossession, traditionalTeamStats } from '../src/utils/traditionalStats';
+
+const game = JSON.parse(gunzipSync(readFileSync(new URL('./fixtures/game-401729745.json.gz', import.meta.url))).toString());
+const plays = game.plays as any[];
+const [away, home] = game.advBoxScore.team.map((t: any) => t.pos_team);
+const row = (teamId: number, label: string) => traditionalTeamStats(plays, teamId).find((r) => r.label === label)!;
+
+describe('traditionalTeamStats on a real game', () => {
+    test('third downs match a hand count of the plays', () => {
+        for (const team of [away, home]) {
+            const att = plays.filter((p) => p.pos_team == team && p.down === 3);
+            const made = att.filter((p) => p.first_down_created === true);
+            expect(row(team, 'Third down').value).toBe(`${made.length}-${att.length} (${Math.round((made.length / att.length) * 100)}%)`);
+        }
+    });
+
+    test('the two clocks partition the game, never double-count it', () => {
+        // ESPN files the play after a turnover, and the ensuing kickoff, under the
+        // drive that just ended -- 8 of this game's 26 drives carry both teams'
+        // snaps. Charging a drive to whoever snapped it first is what keeps the
+        // two clocks from summing to 78:52 of a 60-minute game.
+        const seen = new Map<string, number>();
+        for (const p of plays) {
+            const id = p['drive.id'];
+            if (id && !seen.has(id)) {
+                const [m, s] = String(p['drive.timeElapsed.displayValue'] ?? '0:00').split(':').map(Number);
+                seen.set(id, m * 60 + s);
+            }
+        }
+        const everyDrive = [...seen.values()].reduce((t, n) => t + n, 0);
+        expect(timeOfPossession(plays, away) + timeOfPossession(plays, home)).toBe(everyDrive);
+        expect(everyDrive).toBeLessThan(61 * 60);
+    });
+
+    test('a red-zone trip counts once however many snaps it took', () => {
+        for (const team of [away, home]) {
+            const drives = new Set(plays.filter((p) => p.pos_team == team && p.rz_play === true).map((p) => p['drive.id']));
+            const [, trips] = row(team, 'Red zone scoring').value.match(/^\d+-(\d+)/)!;
+            expect(Number(trips)).toBe(drives.size);
+            // more snaps than trips is the whole point of counting drives
+            expect(plays.filter((p) => p.pos_team == team && p.rz_play === true).length).toBeGreaterThanOrEqual(drives.size);
+        }
+    });
+
+    test('every row prints something, and EPA is null only where no play backs it', () => {
+        for (const r of traditionalTeamStats(plays, away)) {
+            expect(r.value).toMatch(/\S/);
+            if (r.label === 'Time of possession') expect(r.epa).toBeNull();
+        }
+    });
+
+    test('an empty game yields rows rather than throwing', () => {
+        const rows = traditionalTeamStats([], 1);
+        expect(rows).toHaveLength(6);
+        expect(rows.every((r) => r.epa === null)).toBe(true);
+        expect(row(away, 'Time of possession').value).toMatch(/^\d+:\d\d$/);
+    });
+});


### PR DESCRIPTION
Phase 1 of closing the gap between Game on Paper's game page and an official
StatBroadcast book. Five self-contained pieces, each with tests.

## Defensive box score
ESPN publishes no defensive box for college football, so that whole side of the
page was missing. Its 2025 LiveStats play text *does* name the tacklers, and
marks breakups, hurries and interceptions, so `src/utils/defensiveBox.ts` reads
the table back out of the text.

NCAA convention throughout: a shared stop is two assists and no solos, and
TFL/sack split `1/n` so the team total stays whole. Holder and long-snapper
groups on a kick are skipped, as are plays a penalty wiped. Older games carry
no jersey numbers, so the section is absent rather than empty.

## Extremes in the player stat line
LNG, best EPA and best WPA now tail each of the three offensive stat lines.
Keyed on player **name**: the advanced box rows carry no player id, and the name
is the only field the two shapes share.

## The book's counting stats, with EPA on every row
Team Stats already interleaved EPA everywhere but carried none of the rows a
reader coming from the book looks for first. Third and fourth down conversions,
red-zone scoring, turnovers, sacks taken and time of possession now sit in the
same panel, each with the EPA of the plays it counts.

Two things worth review:
- Red-zone scoring counts **drives**, not snaps.
- Time of possession charges a drive to whoever snapped its **first** play.
  ESPN files the play after a turnover, and the ensuing kickoff, under the drive
  that just ended -- 8 of the fixture's 26 drives carry both teams' snaps -- so a
  per-play team filter charges those drives to both sides and the two clocks come
  to 78:52 of a 60-minute game. A test pins the two clocks to exactly the sum
  over distinct drives.

## Latest strip, and three dead nav anchors
The page opened on the win probability chart, so "what just happened" was
answered last. A Latest panel now leads with the five most recent plays, newest
first, over a line naming who has the ball.

While adding its nav entry: `#wpChart`, `#epChart` and `#most-imp-plays` were
all dead links -- three of eleven nav items did nothing. Fixed, and a test now
walks every `href="#..."` and fails if no element carries that id.

## Quarter filters and reading order on All Plays
A button per quarter actually played, plus a newest/oldest toggle. An expandable
play is two rows, so both carry `data-period` and the script walks the tbody into
[summary, detail] pairs -- a detail row can never be stranded from its play.

## Linescore
The page had no linescore at all. Tucked into the Scoring Plays panel, since it
summarises exactly what that panel lists.

## Verification
- 115 vitest tests pass, 1 skipped.
- `astro check` holds at its 172-error baseline; none in the new or touched files.
- `astro build` compiles; the prerender step can't run on this box (workerd needs
  a newer GLIBC), so CI is the real gate there.

## Still open
- The four outstanding StatBroadcast books and the eight open diff cells are
  blocked: the Decodo proxy refuses every port and its API key is rejected as
  invalid, while direct egress gets a 403 from Cloudflare.

## Summary by Sourcery

Expand the game page with official-book-style defensive and team statistics, scoring summaries, recent-play context, and more usable play navigation.

New Features:
- Add defensive player statistics, including tackles, tackles for loss, sacks, interceptions, pass breakups, and quarterback hurries, to supported game pages.
- Add longest gains and best EPA/WPA plays to passing, rushing, and receiving stat lines.
- Add traditional team counting statistics with associated EPA, including down conversions, red-zone scoring, turnovers, sacks taken, and time of possession.
- Add a Latest plays panel with possession context, quarter-based All Plays filters, reading-order controls, and period-aware expandable rows.
- Add period-by-period linescores to the Scoring Plays panel.

Bug Fixes:
- Fix navigation anchors for the win probability, expected points, and most important plays sections.
- Ensure navigation entries only target existing page anchors.

Enhancements:
- Preserve summary/detail play-row pairs while filtering and reordering All Plays.

Tests:
- Add unit and end-to-end coverage for defensive statistics, player extremes, traditional team statistics, linescores, Latest plays, play filters, row pairing, and navigation anchors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Latest” game summary panel with current game and drive information.
  * Added linescores, traditional team-stat comparisons, and defensive player statistics.
  * Player stat lines now include longest gains and best EPA/WPA plays.
  * Added quarter filters and newest/oldest sorting for All Plays.
  * Added navigation links for key game sections.

* **Bug Fixes**
  * Improved play-row filtering and ordering while keeping expanded play details synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->