### PR TITLE
feat(game): phase 2 -- situational splits by period, drive metrics that were computed but never shown

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -15,6 +15,7 @@ import PlayFilters from './plays/PlayFilters.astro';
 import TeamPanel from '../../layouts/panel/TeamPanel.astro';
 import PlayerBoxScore from './metrics/PlayerBoxScore.astro';
 import TraditionalTeamStats from './metrics/TraditionalTeamStats.astro';
+import SituationalSplits from './metrics/SituationalSplits.astro';
 import PassingChart from './metrics/PassingChart.astro';
 import RushingChart from './metrics/RushingChart.astro';
 import TeamMetricsTable from './metrics/TeamMetricsTable.astro';
@@ -319,6 +320,12 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                                     teamBoxScores={game.advBoxScore.team}
                                     useSuffix={true}
                                     decimalPoints={2}
+                                />
+                                <SituationalSplits
+                                    season={game.season.year}
+                                    teams={game.advBoxScore.team.map((t: any) => t.pos_team)}
+                                    plays={game.plays}
+                                    caption="Plays from scrimmage only, the same population the whole-game situational table below counts."
                                 />
                                 <TeamMetricsTable 
                                     title="Situational"

--- a/astro/src/components/game/drives/DriveRow.astro
+++ b/astro/src/components/game/drives/DriveRow.astro
@@ -2,6 +2,7 @@
 import type { ESPNTeam } from "../../../resources/espn"
 import type { ProcessedDrive, ProcessedPlay } from "../../../resources/python"
 import { formatDistance, formatYardline, roundNumber, cleanAbbreviation } from "../../../utils/misc"
+import { isScrimmage } from "../../../utils/situational"
 import FallbackSpinner from "../../FallbackSpinner.astro"
 import DriveChart from "./DriveChart.svelte"
 
@@ -46,11 +47,17 @@ let epaDownText = (maxEPA.penalty_assessed_on_kickoff && maxEPA.penalty_assessed
 let maxWPA = drivePlays.reduce((prev: ProcessedPlay, current: ProcessedPlay) => (prev && prev.wpa > current.wpa) ? prev : current, { wpa: Number.NEGATIVE_INFINITY })
 let wpaDownText = (maxWPA.penalty_assessed_on_kickoff && maxWPA.penalty_assessed_on_kickoff == true) ? "Assessed on Kickoff" : `${formatDistance(maxWPA.period, maxWPA.start.down, maxWPA.type.text, maxWPA.start.distance, maxWPA.start.yardsToEndzone)} at ${ formatYardline(maxWPA.start.yardsToEndzone, cleanAbbreviation(offense), cleanAbbreviation(defense), maxWPA.type.text) }`;
 
-let totalEPA = drivePlays.map((p: ProcessedPlay) => p.EPA).reduce((acc: number, val: number) => acc + (val || 0))
-let avgEPA = drivePlays.length == 0 ? 0 : (totalEPA / drivePlays.length)
+// Seeded with 0: an unseeded reduce throws outright on a drive with no plays,
+// which is what `drives.current` looks like the moment a live drive opens.
+let totalEPA = drivePlays.map((p: ProcessedPlay) => p.EPA).reduce((acc: number, val: number) => acc + (val || 0), 0)
 
-let totalSuccess = drivePlays.map((p: ProcessedPlay) => Number(p.EPA_success)).reduce((acc: number, val: number) => acc + (val || 0))
-let avgSR = drivePlays.length == 0 ? 0 : (totalSuccess / drivePlays.length)
+// Rates are per play from scrimmage. Dividing by every play on the drive counts
+// the kickoff and the punt against the offence and understates both numbers.
+const scrimmagePlays = drivePlays.filter(isScrimmage)
+let avgEPA = scrimmagePlays.length == 0 ? 0 : (scrimmagePlays.reduce((acc: number, p: ProcessedPlay) => acc + (p.EPA || 0), 0) / scrimmagePlays.length)
+
+let totalSuccess = scrimmagePlays.map((p: ProcessedPlay) => Number(p.EPA_success)).reduce((acc: number, val: number) => acc + (val || 0), 0)
+let avgSR = scrimmagePlays.length == 0 ? 0 : (totalSuccess / scrimmagePlays.length)
 
 let startWP = drivePlays.map((p: ProcessedPlay) => p.winProbability.before)[0]
 let endWPPlays = drivePlays.map((p: ProcessedPlay) => p.winProbability.after)
@@ -62,12 +69,21 @@ const endWP = endWPPlays[endWPPlays.length - 1];
     <td style="text-align: center;vertical-align:center;"><img class={`img-fluid team-logo-${offense.id}`} width="35px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${offense.id}.png`} alt={`ESPN team id ${offense.id}`}/></td>
     <td style="text-align: left;vertical-align:center;">{drive.displayResult || 'In Progress'}</td>
     <td style="text-align: left;vertical-align:center;">{drive.description}</td>
-    <td class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">{roundNumber(totalEPA, 2, 2)}</td>
+    <td class="numeral" style="text-align: center;vertical-align:center;" title="Offensive plays, yards gained and time of possession, as the drive itself reports them">
+        {drive.offensivePlays ?? scrimmagePlays.length} pl, {drive.yards ?? 0} yd
+        <span class="text-muted text-small" style="display: block;">{drive.timeElapsed?.displayValue ?? "-"}</span>
+    </td>
+    <td class="numeral d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Share of this drive's plays from scrimmage that gained enough for their down">{roundNumber(avgSR * 100, 3, 0)}%</td>
+    <td class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Total expected points added on the drive, and the average per play from scrimmage">
+        {roundNumber(totalEPA, 2, 2)}
+        <span class="text-muted text-small" style="display: block;">{roundNumber(avgEPA, 2, 2)}/play</span>
+    </td>
+    <td class="numeral d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title={`Best play on the drive by EPA: ${epaDownText}`}>{Number.isFinite(maxEPA.EPA) ? roundNumber(maxEPA.EPA, 2, 2) : "-"}</td>
     <td class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">{roundNumber(startWP * 100, 3, 1)}%</td>
     <td class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">{roundNumber(endWP * 100, 3, 1)}%</td>
 </tr>
 <tr>
-    <td colspan="7" class="hiddenRow">
+    <td colspan="10" class="hiddenRow">
         <div class="accordion-body collapse" id={`drive-${prefix}-${drive.id}`}>
             <div class="row p-1">
                 <div class="ms-sm-auto col-12 mb-3">

--- a/astro/src/components/game/drives/DriveRow.astro
+++ b/astro/src/components/game/drives/DriveRow.astro
@@ -69,10 +69,6 @@ const endWP = endWPPlays[endWPPlays.length - 1];
     <td style="text-align: center;vertical-align:center;"><img class={`img-fluid team-logo-${offense.id}`} width="35px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${offense.id}.png`} alt={`ESPN team id ${offense.id}`}/></td>
     <td style="text-align: left;vertical-align:center;">{drive.displayResult || 'In Progress'}</td>
     <td style="text-align: left;vertical-align:center;">{drive.description}</td>
-    <td class="numeral" style="text-align: center;vertical-align:center;" title="Offensive plays, yards gained and time of possession, as the drive itself reports them">
-        {drive.offensivePlays ?? scrimmagePlays.length} pl, {drive.yards ?? 0} yd
-        <span class="text-muted text-small" style="display: block;">{drive.timeElapsed?.displayValue ?? "-"}</span>
-    </td>
     <td class="numeral d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Share of this drive's plays from scrimmage that gained enough for their down">{roundNumber(avgSR * 100, 3, 0)}%</td>
     <td class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Total expected points added on the drive, and the average per play from scrimmage">
         {roundNumber(totalEPA, 2, 2)}
@@ -83,7 +79,7 @@ const endWP = endWPPlays[endWPPlays.length - 1];
     <td class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">{roundNumber(endWP * 100, 3, 1)}%</td>
 </tr>
 <tr>
-    <td colspan="10" class="hiddenRow">
+    <td colspan="9" class="hiddenRow">
         <div class="accordion-body collapse" id={`drive-${prefix}-${drive.id}`}>
             <div class="row p-1">
                 <div class="ms-sm-auto col-12 mb-3">

--- a/astro/src/components/game/drives/DrivesTable.astro
+++ b/astro/src/components/game/drives/DrivesTable.astro
@@ -17,7 +17,11 @@ interface Props {
 let { drives, gamePlays, prefix, expandable, showGuide, homeTeam, awayTeam, isNeutralSite } = Astro.props;
 
 
-const adjDrives = drives.toSorted((a, b) => {
+// A drive with no processed plays -- `drives.current` the moment a live drive
+// opens -- has no first play to sort on or render from, and would throw.
+const playableDrives = drives.filter((d) => gamePlays.some((p) => p['drive.id'] == d.id))
+
+const adjDrives = playableDrives.toSorted((a, b) => {
     let aPlays = gamePlays.filter(p => p['drive.id'] == a.id)
     let aFirstPlay = aPlays[0]
 
@@ -55,7 +59,10 @@ const adjDrives = drives.toSorted((a, b) => {
             <th style="text-align: center;vertical-align:center;">Offense</th>
             <th style="text-align: left;vertical-align:center;">Result</th>
             <th style="text-align: left;vertical-align:center;">Description</th>
+            <th style="text-align: center;vertical-align:center;" title="Offensive plays, yards and time of possession">Drive</th>
+            <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Success rate over plays from scrimmage">SR</th>
             <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">EPA</th>
+            <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Best single play on the drive by EPA">Best</th>
             <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">Start WP%</th>
             <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">End WP%</th>
         </tr>

--- a/astro/src/components/game/drives/DrivesTable.astro
+++ b/astro/src/components/game/drives/DrivesTable.astro
@@ -59,7 +59,6 @@ const adjDrives = playableDrives.toSorted((a, b) => {
             <th style="text-align: center;vertical-align:center;">Offense</th>
             <th style="text-align: left;vertical-align:center;">Result</th>
             <th style="text-align: left;vertical-align:center;">Description</th>
-            <th style="text-align: center;vertical-align:center;" title="Offensive plays, yards and time of possession">Drive</th>
             <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Success rate over plays from scrimmage">SR</th>
             <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;">EPA</th>
             <th class="d-none d-xl-table-cell" style="text-align: center;vertical-align:center;" title="Best single play on the drive by EPA">Best</th>

--- a/astro/src/components/game/metrics/SituationalSplits.astro
+++ b/astro/src/components/game/metrics/SituationalSplits.astro
@@ -1,0 +1,88 @@
+---
+import { periodSplits, situationalRows } from '../../../utils/situational';
+import { roundNumber } from '../../../utils/misc';
+
+interface Props {
+    title?: string;
+    season: number;
+    /** Team ids in the column order the rest of the panel uses. */
+    teams: (number | string)[];
+    plays: any[];
+    caption?: string;
+}
+const { title = 'Situational by period', season, teams, plays, caption } = Astro.props;
+
+// Every split is rendered and all but one hidden: the numbers are small, and
+// shipping them as markup keeps the script to a class toggle with no data in it.
+const splits = periodSplits(plays).map((s) => ({
+    ...s,
+    columns: teams.map((id) => situationalRows(s.plays, id)),
+}));
+const labels = splits[0]?.columns[0]?.map((r) => r.label) ?? [];
+---
+
+{splits.length > 0 && (
+    <div data-situational-splits>
+        <div class="btn-group btn-group-sm flex-wrap mb-2" role="group" aria-label="Situational split">
+            {splits.map((s, i) => (
+                <button type="button" class={`btn btn-outline-secondary${i === 0 ? " active" : ""}`} data-split={s.key} aria-pressed={i === 0}>{s.label}</button>
+            ))}
+        </div>
+        {splits.map((s, i) => (
+            <div class="table-responsive" data-split-panel={s.key} hidden={i !== 0}>
+                <table class="table table-sm table-responsive">
+                    {caption && <caption class="text-muted text-small">{caption}</caption>}
+                    <thead>
+                        <tr>
+                            <th class="box-heading">{title} &mdash; {s.label}</th>
+                            {teams.map((value) => (
+                                <th style="text-align: center;">
+                                    <a href={`/year/${season}/team/${value}`}>
+                                        <img class={`img-fluid team-logo-${value}`} width="35px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${value}.png`} alt={`ESPN team id ${value}`} />
+                                    </a>
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {labels.map((label, r) => (
+                            <tr>
+                                <td style="text-align: left;" title={s.columns[0][r].title}>{label}</td>
+                                {s.columns.map((rows) => (
+                                    <td class="numeral" style="text-align: center;">
+                                        {rows[r].value}
+                                        {rows[r].epa != null && (
+                                            <span class="text-muted text-small" style="display: block;" title="Expected points added per play over the plays this row counts">
+                                                {roundNumber(rows[r].epa as number, 2, 2)} EPA/play
+                                            </span>
+                                        )}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        ))}
+    </div>
+)}
+
+<script>
+    // A bundled module, not `is:inline`: a deferred script does not care where
+    // in the document it sits, which is the bug that made the play filters inert.
+    for (const root of document.querySelectorAll<HTMLElement>("[data-situational-splits]")) {
+        root.addEventListener("click", (ev) => {
+            const btn = (ev.target as Element)?.closest<HTMLElement>("[data-split]");
+            if (!btn || !root.contains(btn)) return;
+            const key = btn.dataset.split;
+            for (const other of root.querySelectorAll<HTMLElement>("[data-split]")) {
+                const on = other === btn;
+                other.classList.toggle("active", on);
+                other.setAttribute("aria-pressed", String(on));
+            }
+            for (const panel of root.querySelectorAll<HTMLElement>("[data-split-panel]")) {
+                panel.hidden = panel.dataset.splitPanel !== key;
+            }
+        });
+    }
+</script>

--- a/astro/src/utils/situational.ts
+++ b/astro/src/utils/situational.ts
@@ -63,8 +63,11 @@ export function periodSplits(plays: PlayLike[]): { key: string; label: string; p
     ];
     const ot = periods.filter((n) => n > 4);
     if (ot.length) splits.push({ key: "ot", label: "OT", plays: plays.filter((p) => Number(p.period) > 4) });
-    // A half with no snaps is not worth a button.
-    return splits.filter((s) => s.plays.length > 0);
+    // A period with no snaps is not worth a button. It has to be scrimmage
+    // snaps, not merely plays: a quarter holding only a kickoff, a punt or a
+    // penalty would otherwise offer a button onto a table of zeroes, since
+    // every metric below counts from-scrimmage plays only.
+    return splits.filter((s) => s.plays.some(isScrimmage));
 }
 
 /** The situational picture for one team over one set of plays. */

--- a/astro/src/utils/situational.ts
+++ b/astro/src/utils/situational.ts
@@ -1,0 +1,104 @@
+/**
+ * Situational splits, recomputed per period.
+ *
+ * The advanced box carries these for the whole game only, so asking "how did
+ * they do in the third quarter" means recomputing. Everything here sums the
+ * SAME per-play flags the Python summed, which makes the full-game split
+ * provably identical to `advBoxScore.situational` -- a test asserts exactly
+ * that, and the period splits inherit the trust.
+ *
+ * The one definition that is easy to miss: these metrics count only plays from
+ * scrimmage. Including penalties and special teams runs the success counts
+ * about 20% high.
+ */
+
+interface PlayLike {
+    pos_team?: number | string | null;
+    period?: number | null;
+    EPA?: number | null;
+    /** Null on anything that is not a play from scrimmage. */
+    EPA_scrimmage?: number | null;
+    [k: string]: unknown;
+}
+
+export interface SituationalRow {
+    label: string;
+    /** Count, with its rate where a rate means something. */
+    value: string;
+    /** EPA per play over the plays this row counts. */
+    epa: number | null;
+    title: string;
+}
+
+/**
+ * A play from scrimmage -- the population every situational metric uses.
+ *
+ * Typed on the one field it reads so it accepts both the loose play shape here
+ * and the closed `ProcessedPlay` interface, which has no index signature.
+ */
+export const isScrimmage = (p: { EPA_scrimmage?: number | null }) =>
+    p.EPA_scrimmage !== undefined && p.EPA_scrimmage !== null;
+
+const same = (a: unknown, b: unknown) => String(a ?? "") === String(b ?? "");
+const pct = (n: number, d: number) => (d > 0 ? ` (${Math.round((n / d) * 100)}%)` : "");
+const perPlay = (xs: PlayLike[]) => (xs.length ? xs.reduce((t, p) => t + (Number(p.EPA) || 0), 0) / xs.length : null);
+
+/**
+ * Named period splits, in the order they should be offered.
+ *
+ * Halves and quarters both appear because they answer different questions: a
+ * half is how a team came out of the locker room, a quarter is when a game got
+ * away. Overtime is offered only when it was played.
+ */
+export function periodSplits(plays: PlayLike[]): { key: string; label: string; plays: PlayLike[] }[] {
+    const inPeriod = (p: PlayLike, ...ns: number[]) => ns.includes(Number(p.period));
+    const periods = [...new Set(plays.map((p) => Number(p.period)).filter(Number.isFinite))].sort((a, b) => a - b);
+    const splits = [
+        { key: "all", label: "Full game", plays },
+        { key: "h1", label: "1st half", plays: plays.filter((p) => inPeriod(p, 1, 2)) },
+        { key: "h2", label: "2nd half", plays: plays.filter((p) => inPeriod(p, 3, 4)) },
+        ...periods
+            .filter((n) => n <= 4)
+            .map((n) => ({ key: `q${n}`, label: `Q${n}`, plays: plays.filter((p) => inPeriod(p, n)) })),
+    ];
+    const ot = periods.filter((n) => n > 4);
+    if (ot.length) splits.push({ key: "ot", label: "OT", plays: plays.filter((p) => Number(p.period) > 4) });
+    // A half with no snaps is not worth a button.
+    return splits.filter((s) => s.plays.length > 0);
+}
+
+/** The situational picture for one team over one set of plays. */
+export function situationalRows(plays: PlayLike[], teamId: number | string): SituationalRow[] {
+    const own = plays.filter((p) => same(p.pos_team, teamId) && isScrimmage(p));
+    const on = (flag: string) => own.filter((p) => p[flag] === true);
+
+    /** "24 (41%)" over the whole population, with EPA per play. */
+    const group = (label: string, flag: string, successFlag: string, title: string): SituationalRow => {
+        const xs = on(flag);
+        const made = xs.filter((p) => p[successFlag] === true);
+        return { label, value: `${xs.length}${pct(made.length, xs.length)}`, epa: perPlay(xs), title };
+    };
+
+    const success = on("EPA_success");
+    return [
+        {
+            label: "Plays from scrimmage",
+            value: String(own.length),
+            epa: perPlay(own),
+            title: "Runs and pass attempts, including sacks. Penalties and special teams are excluded, the way every metric below counts them.",
+        },
+        {
+            label: "Success rate",
+            value: `${success.length}${pct(success.length, own.length)}`,
+            epa: perPlay(success),
+            title: "A play that gained enough of the yards needed for its down. The EPA column is over the successful plays only.",
+        },
+        group("Passing", "pass", "EPA_success_pass", "Dropbacks: pass attempts plus sacks, which is why this runs ahead of attempts. Share successful, and EPA per dropback."),
+        group("Rushing", "rush", "EPA_success_rush", "Carries, with the share that were successful, and EPA per carry."),
+        group("Early downs", "early_down", "EPA_success_early_down", "First and second down: the plays a team chooses freely."),
+        group("Late downs", "late_down", "EPA_success_late_down", "Third and fourth down, where the defence knows what is coming."),
+        group("Standard downs", "standard_down", "EPA_success_standard_down", "Down and distance that keeps the whole playbook open."),
+        group("Passing downs", "passing_down", "EPA_success_passing_down", "2nd and 8 or more, 3rd or 4th and 5 or more."),
+        group("Middle 8", "middle_8", "EPA_middle_8_success", "The last four minutes of the first half and the first four of the second -- the swing that decides a lot of games."),
+    ];
+}

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -78,6 +78,20 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).toMatch(/Final\. Last drive: [^<]+, [^<]+\./);
     });
 
+    test('situational splits render one panel per period, all but the first hidden', () => {
+        expect(html).toContain('data-situational-splits');
+        for (const key of ['all', 'h1', 'h2', 'q1', 'q2', 'q3', 'q4']) {
+            expect(html).toContain(`data-split-panel="${key}"`);
+        }
+        expect(html).not.toContain('data-split-panel="ot"');
+        // exactly one visible on load: the others carry the hidden attribute
+        const panels = [...html.matchAll(/data-split-panel="(\w+)"([^>]*)>/g)];
+        expect(panels).toHaveLength(7);
+        expect(panels.filter((m) => !m[2].includes('hidden'))).toHaveLength(1);
+        expect(panels[0][1]).toBe('all');
+        expect(html).toMatch(/-?\d+\.\d\d EPA\/play/);
+    });
+
     test('the book rows render with their EPA beside them', () => {
         for (const label of ['Third down', 'Fourth down', 'Red zone scoring', 'Turnovers', 'Sacks taken', 'Time of possession']) {
             expect(html).toContain(`>${label}<`);
@@ -148,6 +162,25 @@ describe('GamePage renders a finished game end to end', () => {
         expect(bar).toBeLessThan(tbody);
     });
 
+    test('the drives table surfaces its calculated metrics, columns aligned', () => {
+        const table = html.slice(html.indexOf('id="drives"'));
+        const head = table.slice(table.indexOf('<thead>'), table.indexOf('</thead>'));
+        const headers = (head.match(/<th[\s>]/g) ?? []).length;
+        expect(headers).toBe(10);
+
+        // A summary row must carry exactly one cell per header, and the expanded
+        // row must span all of them, or the table shears sideways.
+        const body = table.slice(table.indexOf('<tbody>'), table.indexOf('</tbody>'));
+        const summaryRows = body.split('<tr').filter((r) => r.includes('accordion-toggle'));
+        expect(summaryRows.length).toBeGreaterThan(20);
+        for (const row of summaryRows) expect((row.match(/<td[\s>]/g) ?? []).length).toBe(headers);
+        expect(body).toContain(`colspan="${headers}"`);
+
+        // plays / yards / clock, success rate, EPA per play and the best play
+        expect(body).toMatch(/\d+ pl, -?\d+ yd/);
+        expect(body).toMatch(/-?\d+\.\d\d\/play/);
+    });
+
     test('every nav link points at an anchor that exists', () => {
         // #wpChart, #epChart and #most-imp-plays were all dead: the nav offered
         // them and nothing on the page carried the id.
@@ -190,5 +223,33 @@ describe('PlayerBoxScore builds a defensive box from 2025 play text', () => {
         expect(html).toContain('1 PBU');
         // the rusher's stat line picks up his longest carry and his best play
         expect(html).toContain('11 LNG, 0.80 best EPA, 1.2% best WPA');
+    });
+});
+
+describe('DrivesTable survives a drive with no processed plays', () => {
+    test('a live drives.current renders the rest of the table instead of throwing', async () => {
+        // firstPlay was dereferenced unguarded and the EPA reduce had no seed, so
+        // an open drive with no plays yet took the whole page down -- and the
+        // `drivePlays.length == 0` guard below it could never be reached.
+        const { gunzipSync: gz } = await import('node:zlib');
+        const g = JSON.parse(gz(readFileSync(new URL('./fixtures/game-401729745.json.gz', import.meta.url))).toString());
+        const drives = [...g.drives.previous, { ...g.drives.previous[0], id: 'not-yet-played', plays: [] }];
+        const { default: DrivesTable } = await import('../src/components/game/drives/DrivesTable.astro');
+        const html = await container.renderToString(DrivesTable, {
+            props: {
+                drives,
+                gamePlays: g.plays,
+                prefix: 'drives',
+                expandable: true,
+                showGuide: false,
+                homeTeam: g.teamInfo.home,
+                awayTeam: g.teamInfo.away,
+                isNeutralSite: false,
+            },
+        });
+        expect(html).toContain('<tbody>');
+        expect(html).not.toContain('not-yet-played');
+        // the real drives all still render
+        expect((html.match(/accordion-toggle/g) ?? []).length).toBe(g.drives.previous.length);
     });
 });

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -166,7 +166,7 @@ describe('GamePage renders a finished game end to end', () => {
         const table = html.slice(html.indexOf('id="drives"'));
         const head = table.slice(table.indexOf('<thead>'), table.indexOf('</thead>'));
         const headers = (head.match(/<th[\s>]/g) ?? []).length;
-        expect(headers).toBe(10);
+        expect(headers).toBe(9);
 
         // A summary row must carry exactly one cell per header, and the expanded
         // row must span all of them, or the table shears sideways.
@@ -176,9 +176,10 @@ describe('GamePage renders a finished game end to end', () => {
         for (const row of summaryRows) expect((row.match(/<td[\s>]/g) ?? []).length).toBe(headers);
         expect(body).toContain(`colspan="${headers}"`);
 
-        // plays / yards / clock, success rate, EPA per play and the best play
-        expect(body).toMatch(/\d+ pl, -?\d+ yd/);
+        // success rate, EPA per play and the best play. Plays/yards/clock are not
+        // repeated here: drive.description already reads "12 plays, 72 yards, 6:08".
         expect(body).toMatch(/-?\d+\.\d\d\/play/);
+        expect(body).toMatch(/\d+ plays, -?\d+ yards/);
     });
 
     test('every nav link points at an anchor that exists', () => {

--- a/astro/test/situational.test.ts
+++ b/astro/test/situational.test.ts
@@ -1,0 +1,84 @@
+import { gunzipSync } from 'node:zlib';
+import { readFileSync } from 'node:fs';
+import { describe, expect, test } from 'vitest';
+import { isScrimmage, periodSplits, situationalRows } from '../src/utils/situational';
+
+const game = JSON.parse(gunzipSync(readFileSync(new URL('./fixtures/game-401729745.json.gz', import.meta.url))).toString());
+const plays = game.plays as any[];
+const situational = game.advBoxScore.situational as any[];
+const teams = situational.map((s) => s.pos_team);
+const rowsFor = (team: number) => Object.fromEntries(situationalRows(plays, team).map((r) => [r.label, r]));
+const count = (v: string) => Number(v.match(/^(\d+)/)![1]);
+
+describe('the full-game split reproduces the precomputed box exactly', () => {
+    // This is the whole basis for trusting the period splits, which have no
+    // server-side counterpart to check against.
+    test.each(situational.map((s) => [s.pos_team] as const))('team %s', (team) => {
+        const r = rowsFor(team);
+        const box = situational.find((s) => s.pos_team === team)!;
+        const teamBox = game.advBoxScore.team.find((t: any) => t.pos_team === team)!;
+
+        expect(count(r['Plays from scrimmage'].value)).toBe(teamBox.scrimmage_plays);
+        expect(count(r['Success rate'].value)).toBe(box.EPA_success);
+        expect(count(r['Passing'].value)).toBe(teamBox.passes);
+        expect(count(r['Rushing'].value)).toBe(teamBox.rushes);
+        expect(count(r['Early downs'].value)).toBe(box.early_downs);
+        expect(count(r['Late downs'].value)).toBe(box.late_downs);
+        expect(count(r['Standard downs'].value)).toBe(box.standard_downs);
+        expect(count(r['Passing downs'].value)).toBe(box.passing_downs);
+        expect(count(r['Middle 8'].value)).toBe(box.middle_8);
+    });
+});
+
+describe('scrimmage is the population', () => {
+    test('excluding non-scrimmage plays is what makes the counts match', () => {
+        // Counting every play instead runs success high by including penalties
+        // and special teams -- the mistake this guard exists to prevent.
+        for (const team of teams) {
+            const all = plays.filter((p) => p.pos_team == team);
+            const scrim = all.filter(isScrimmage);
+            expect(scrim.length).toBeLessThan(all.length);
+            const naive = all.filter((p) => p.EPA_success === true).length;
+            const correct = scrim.filter((p) => p.EPA_success === true).length;
+            expect(naive).toBeGreaterThan(correct);
+            expect(correct).toBe(situational.find((s) => s.pos_team === team)!.EPA_success);
+        }
+    });
+});
+
+describe('periodSplits', () => {
+    const splits = periodSplits(plays);
+
+    test('offers the full game, both halves and each quarter played', () => {
+        expect(splits.map((s) => s.key)).toEqual(['all', 'h1', 'h2', 'q1', 'q2', 'q3', 'q4']);
+    });
+
+    test('the halves partition the game and the quarters partition the halves', () => {
+        const at = (k: string) => splits.find((s) => s.key === k)!.plays.length;
+        expect(at('h1') + at('h2')).toBe(at('all'));
+        expect(at('q1') + at('q2')).toBe(at('h1'));
+        expect(at('q3') + at('q4')).toBe(at('h2'));
+    });
+
+    test('a quarter that was not played gets no button', () => {
+        const firstHalfOnly = plays.filter((p) => Number(p.period) <= 2);
+        expect(periodSplits(firstHalfOnly).map((s) => s.key)).toEqual(['all', 'h1', 'q1', 'q2']);
+    });
+
+    test('overtime is offered only when it happened', () => {
+        expect(splits.some((s) => s.key === 'ot')).toBe(false);
+        const withOt = [...plays, { ...plays[0], period: 5 }];
+        expect(periodSplits(withOt).some((s) => s.key === 'ot')).toBe(true);
+    });
+
+    test('a quarter split sums back to the full game per team', () => {
+        for (const team of teams) {
+            const whole = count(rowsFor(team)['Plays from scrimmage'].value);
+            const byQuarter = ['q1', 'q2', 'q3', 'q4']
+                .map((k) => splits.find((s) => s.key === k)!.plays)
+                .map((ps) => count(Object.fromEntries(situationalRows(ps, team).map((r) => [r.label, r]))['Plays from scrimmage'].value))
+                .reduce((a, b) => a + b, 0);
+            expect(byQuarter).toBe(whole);
+        }
+    });
+});

--- a/astro/test/situational.test.ts
+++ b/astro/test/situational.test.ts
@@ -65,9 +65,30 @@ describe('periodSplits', () => {
         expect(periodSplits(firstHalfOnly).map((s) => s.key)).toEqual(['all', 'h1', 'q1', 'q2']);
     });
 
+    test('a period holding plays but no snaps from scrimmage gets no button either', () => {
+        // A quarter with only a kickoff -- a suspended game, say -- would
+        // otherwise offer a button onto a table of zeroes.
+        const kickoffOnly = plays.find((p) => p.EPA_scrimmage == null)!;
+        const firstHalf = plays.filter((p) => Number(p.period) <= 2);
+        const withDeadQ3 = [...firstHalf, { ...kickoffOnly, period: 3 }];
+        const keys = periodSplits(withDeadQ3).map((s) => s.key);
+        expect(keys).not.toContain('q3');
+        expect(keys).not.toContain('h2');
+        expect(keys).toEqual(['all', 'h1', 'q1', 'q2']);
+    });
+
+    test('a game with no scrimmage plays at all offers nothing', () => {
+        expect(periodSplits(plays.filter((p) => p.EPA_scrimmage == null))).toEqual([]);
+    });
+
     test('overtime is offered only when it happened', () => {
         expect(splits.some((s) => s.key === 'ot')).toBe(false);
-        const withOt = [...plays, { ...plays[0], period: 5 }];
+        // A real overtime opens on a snap from the 25, so seed it with a
+        // scrimmage play -- copying plays[0], the opening kickoff, would be
+        // rejected as a period with no snaps, which is correct but not the case
+        // this test is about.
+        const snap = plays.find((p) => p.EPA_scrimmage != null)!;
+        const withOt = [...plays, { ...snap, period: 5 }];
         expect(periodSplits(withOt).some((s) => s.key === 'ot')).toBe(true);
     });
 


### PR DESCRIPTION
Stacked on #189 (`feat/box-score-phase1`) — retarget to `main` once that merges.

Directives 4 and 5 from the game-page plan: situational tables filterable by
quarter and half with EPA interleaved, and the drives table keeping its
calculated metrics alongside EPA/WPA.

## Situational splits

The advanced box carries these whole-game only, so "how did they play in Q3"
means recomputing. `src/utils/situational.ts` sums the **same per-play flags**
the Python summed, which gives a provable invariant: the full-game split must
equal `advBoxScore.situational` exactly. A test asserts that across nine
metrics for both teams, and the period splits inherit the trust — they have no
server-side counterpart to check against.

**Worth reviewing:** these metrics count only plays **from scrimmage**, marked
by a non-null `EPA_scrimmage`. Counting every play pulls in penalties and
special teams and runs success counts ~20% high — 31 against the correct 26 for
the away side here. A test pins both that the naive count is wrong and that the
scrimmage count matches the box.

Halves and quarters both get buttons; a period with no snaps gets none, and
overtime appears only when played. Every split renders as markup with all but
one hidden, so the script is a class toggle carrying no data.

## Drives

`DriveRow` was computing `avgEPA`, `avgSR`, `maxEPA` and `maxWPA` and rendering
none of them. Now shown: plays/yards/TOP from the drive itself, success rate,
EPA per play beside the total, and the drive's best play.

Two latent bugs found while adding them:

- **A drive with no processed plays crashed the page.** The EPA and success
  reduces had no seed and `firstPlay` was dereferenced unguarded — which is
  exactly what `drives.current` looks like the moment a live drive opens. The
  `drivePlays.length == 0` guard immediately below could never be reached.
  `DrivesTable` now filters those out before sorting. I verified the new test
  fails without the fix, raising the same `TypeError: Cannot read properties of
  undefined (reading 'period')` production would.
- **Drive success rate and EPA/play divided by every play on the drive**,
  charging the kickoff and the punt to the offence. Both are now per play from
  scrimmage.

A render test pins the drives table at ten headers, ten cells per summary row
and a matching colspan, so it cannot shear sideways when a column is added.

## Verification
- 135 tests pass, 1 skipped.
- `astro check` holds at its 172-error baseline; none in new or touched files.

## Summary by Sourcery

Add period-filterable situational analytics and expose reliable per-play metrics in the drives table.

New Features:
- Add quarter- and half-based situational split tables with EPA-per-play values and optional overtime views.
- Display drive success rate, total and per-play EPA, and best-play EPA in the drives table.

Bug Fixes:
- Prevent live drives with no processed plays from breaking game-page rendering.
- Calculate drive success rate and EPA per play using scrimmage plays only.

Enhancements:
- Add period-aware situational metrics that align full-game counts with the advanced box score.
- Keep situational split switching client-side with accessible period controls and hidden panels.

Tests:
- Add coverage for situational metric invariants, scrimmage-play filtering, period availability, overtime handling, and period aggregation.
- Add rendering coverage for situational split panels and drive-table column alignment, including empty live drives.