### PR TITLE
feat(admin): matchup-named errors + box-vs-official data-quality scorecard

### DIFF
--- a/astro/src/pages/admin/api/[name].ts
+++ b/astro/src/pages/admin/api/[name].ts
@@ -3,7 +3,7 @@ import { getSecret } from 'astro:env/server';
 
 export const prerender = false;
 
-const ALLOWED = ['overview', 'games', 'upstream', 'errors', 'traffic', 'system', 'page'];
+const ALLOWED = ['overview', 'games', 'upstream', 'errors', 'traffic', 'system', 'page', 'dq'];
 
 export const GET: APIRoute = async ({ params, url }) => {
   const name = params.name ?? '';

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -21,6 +21,7 @@ const subtitle = "Operational dashboards for Game on Paper";
     <li class="nav-item"><button class="nav-link" data-t="games">Live games</button></li>
     <li class="nav-item"><button class="nav-link" data-t="upstream">ESPN / upstream</button></li>
     <li class="nav-item"><button class="nav-link" data-t="errors">Errors</button></li>
+    <li class="nav-item"><button class="nav-link" data-t="dq">Data quality</button></li>
     <li class="nav-item"><button class="nav-link" data-t="traffic">Traffic</button></li>
     <li class="nav-item"><button class="nav-link" data-t="system">System</button></li>
     <li class="nav-item"><button class="nav-link" data-t="staleness">Staleness</button></li>
@@ -52,6 +53,21 @@ const subtitle = "Operational dashboards for Game on Paper";
     <div class="card twrap"><table class="table table-sm mb-0" id="t-errgroups"></table></div>
     <h6 class="admin-label">Most recent</h6>
     <div id="err-recent"></div>
+  </section>
+  <section id="dq">
+    <div class="card"><p class="admin-muted m-0">Play-flag box score vs ESPN's official team box, per completed game.
+      Zero is not the target for every stat (our pass flag counts sacks; ESPN's net passing subtracts sack yardage;
+      penalty yards differ in sign) &mdash; the signal is a <b>stable</b> delta distribution. A shift aligned with an
+      sdv-py version is a parser regression.</p></div>
+    <h6 class="admin-label">Scorecard · <span id="dq-days">14</span>d</h6>
+    <div class="card twrap"><table class="table table-sm mb-0" id="t-dqscore"></table></div>
+    <div class="grid2 mt-2">
+      <div class="card twrap"><h6 class="admin-label mt-0">Lints (expectation: 0)</h6><table class="table table-sm mb-0" id="t-dqlints"></table></div>
+      <div class="card twrap"><h6 class="admin-label mt-0">Mean delta by sdv-py version</h6><table class="table table-sm mb-0" id="t-dqver"></table></div>
+    </div>
+    <h6 class="admin-label">Worst games (click a row for per-stat detail)</h6>
+    <div class="card twrap"><table class="table table-sm mb-0" id="t-dqgames"></table></div>
+    <div id="dq-detail"></div>
   </section>
   <section id="traffic">
     <div class="card"><p class="admin-muted m-0">Visitor analytics live in
@@ -236,15 +252,45 @@ const subtitle = "Operational dashboards for Game on Paper";
       { label: '5xx', data: d.failures.map((f) => f.s5xx), borderColor: S[1] },
       { label: 'timeout', data: d.failures.map((f) => f.timeouts), borderColor: S[3] }]);
     table('t-slowest', ['When', 'Target', 'Game', 'ms', 'Status'],
-      d.slowest.map((s) => ({ cells: [`<span class="mono">${hhmm(s.ts)}</span>`, `<span class="mono">${esc(s.target)}</span>`, esc(s.game_id ?? '—'), fmt(s.duration_ms), s.status ?? '—'] })));
+      d.slowest.map((s) => ({ cells: [`<span class="mono">${hhmm(s.ts)}</span>`, `<span class="mono">${esc(s.target)}</span>`,
+        s.game_id ? `<a href="/game/${esc(s.game_id)}" target="_blank">${esc(s.matchup ?? s.game_id)}</a>` : '—',
+        fmt(s.duration_ms), s.status ?? '—'] })));
   }
 
   async function refreshErrors() {
     const d = await api('errors');
-    table('t-errgroups', ['Signature', 'Service', 'Count', 'Last seen'],
-      d.groups.map((g) => ({ cells: [esc(g.signature), esc(g.service), g.n, `<span class="mono">${hhmm(g.last_seen)}</span>`] })));
+    table('t-errgroups', ['Signature', 'Service', 'Game', 'Count', 'Last seen'],
+      d.groups.map((g) => ({ cells: [esc(g.signature), esc(g.service),
+        g.game_id ? `<a href="/game/${esc(g.game_id)}" target="_blank">${esc(g.matchup ?? g.game_id)}</a>` : '—',
+        g.n, `<span class="mono">${hhmm(g.last_seen)}</span>`] })));
     document.getElementById('err-recent').innerHTML = d.recent.slice(0, 5).map((e) =>
-      `<div class="card" style="margin-bottom:10px"><div style="display:flex;justify-content:space-between"><span>[${esc(e.service)}] ${esc(e.message).slice(0, 120)}</span><b class="mono">${hhmm(e.ts)}</b></div>${e.stack ? `<pre>${esc(e.stack).slice(0, 1200)}</pre>` : ''}</div>`).join('');
+      `<div class="card" style="margin-bottom:10px"><div style="display:flex;justify-content:space-between"><span>[${esc(e.service)}] ${esc(e.message).slice(0, 120)}</span><b class="mono">${e.game_id ? `<a href="/game/${esc(e.game_id)}" target="_blank">${esc(e.matchup ?? e.game_id)}</a> · ` : ''}${hhmm(e.ts)}</b></div>${e.stack ? `<pre>${esc(e.stack).slice(0, 1200)}</pre>` : ''}</div>`).join('');
+  }
+
+  async function refreshDq() {
+    const d = await api('dq');
+    table('t-dqscore', ['Stat', 'Rows', 'Exact', '|Δ| ≤ 2', 'Mean Δ', 'Median Δ', 'Worst |Δ|'],
+      d.scorecard.map((r) => ({ cells: [`<span class="mono">${esc(r.stat)}</span>`, r.n,
+        fmt(100 * r.exact / r.n, 0) + '%', fmt(100 * r.close / r.n, 0) + '%', r.mean_delta, r.median_delta, r.worst] })));
+    table('t-dqlints', ['Lint', 'Games flagged', 'Total', 'Last seen'],
+      d.lints.map((r) => ({ cells: [`<span class="mono">${esc(r.stat)}</span>`, r.games_flagged, r.total, `<span class="mono">${hhmm(r.last_seen)}</span>`] })));
+    table('t-dqver', ['sdv-py', 'Stat', 'Games', 'Mean Δ'],
+      d.by_version.map((r) => ({ cells: [`<span class="mono">${esc((r.sdv_py_sha || '?').slice(0, 8))}</span>`, `<span class="mono">${esc(r.stat)}</span>`, r.n, r.mean_delta] })));
+    table('t-dqgames', ['Game', 'Σ|Δ|', 'Stats off', 'Checked', 'sdv-py'],
+      d.worst_games.map((g) => ({ attr: ` data-game="${esc(g.game_id)}" style="cursor:pointer"`, cells: [
+        `<a href="/game/${g.game_id}" target="_blank">${esc(g.matchup ?? g.game_id)}</a>`,
+        g.total_abs_delta, g.stats_off, `<span class="mono">${hhmm(g.checked_at)}</span>`,
+        `<span class="mono">${esc((g.sdv_py_sha || '?').slice(0, 8))}</span>`] })));
+    [...document.querySelectorAll('#t-dqgames tr[data-game]')].forEach((tr) =>
+      tr.addEventListener('click', () => loadDqDetail(tr.dataset.game).catch(() => {})));
+  }
+
+  async function loadDqDetail(gameId) {
+    const d = await api('dq', `?game_id=${gameId}`);
+    const el = document.getElementById('dq-detail');
+    el.innerHTML = `<h6 class="admin-label">Game ${esc(gameId)}</h6><div class="card twrap"><table class="table table-sm mb-0" id="t-dqdetail"></table></div>`;
+    table('t-dqdetail', ['Team', 'Stat', 'Ours', 'ESPN', 'Δ'],
+      d.game.map((r) => ({ cells: [r.team_id ?? '—', `<span class="mono">${esc(r.stat)}</span>`, r.ours, r.espn ?? '—', r.delta ?? '—'] })));
   }
 
   async function refreshTraffic() {
@@ -326,7 +372,7 @@ const subtitle = "Operational dashboards for Game on Paper";
   }
   document.getElementById('st-probe').addEventListener('click', () => probeStaleness().catch((e) => console.error(e)));
 
-  const refreshers = { overview: refreshOverview, games: refreshGames, upstream: refreshUpstream, errors: refreshErrors, traffic: refreshTraffic, system: refreshSystem, staleness: refreshStaleness };
+  const refreshers = { overview: refreshOverview, games: refreshGames, upstream: refreshUpstream, errors: refreshErrors, dq: refreshDq, traffic: refreshTraffic, system: refreshSystem, staleness: refreshStaleness };
   let active = 'overview';
   document.getElementById('tabs').addEventListener('click', (e) => {
     const b = e.target.closest('button');

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -275,7 +275,7 @@ const subtitle = "Operational dashboards for Game on Paper";
     table('t-dqlints', ['Lint', 'Games flagged', 'Total', 'Last seen'],
       d.lints.map((r) => ({ cells: [`<span class="mono">${esc(r.stat)}</span>`, r.games_flagged, r.total, `<span class="mono">${hhmm(r.last_seen)}</span>`] })));
     table('t-dqver', ['sdv-py', 'Stat', 'Games', 'Mean Δ'],
-      d.by_version.map((r) => ({ cells: [`<span class="mono">${esc((r.sdv_py_sha || '?').slice(0, 8))}</span>`, `<span class="mono">${esc(r.stat)}</span>`, r.n, r.mean_delta] })));
+      d.by_version.map((r) => ({ cells: [`<span class="mono">${esc(r.sdv_py_version ?? '?')} @ ${esc((r.sdv_py_sha || '?').slice(0, 8))}</span>`, `<span class="mono">${esc(r.stat)}</span>`, r.n, r.mean_delta] })));
     table('t-dqgames', ['Game', 'Σ|Δ|', 'Stats off', 'Checked', 'sdv-py'],
       d.worst_games.map((g) => ({ attr: ` data-game="${esc(g.game_id)}" style="cursor:pointer"`, cells: [
         `<a href="/game/${g.game_id}" target="_blank">${esc(g.matchup ?? g.game_id)}</a>`,

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import SchedulePage from "../components/schedule/SchedulePage.astro";
+import { gopStorage } from "../utils/telemetry";
 import { getCurrentScoreboard, type ESPNScheduleEvent } from "../resources/espn";
 import { CACHE_TTL_MULTIPLIER, CURRENT_SEASON_CONFIG } from "../utils/config";
 import { CURRENT_YEAR } from "../utils/constants";
@@ -7,6 +8,30 @@ import { CURRENT_YEAR } from "../utils/constants";
 let games: ESPNScheduleEvent[] = [];
 try {
     games = await getCurrentScoreboard(true, true);
+    // Feed the matchup dimension: one upserted gop.game_meta row per event, so
+    // admin views can name a game instead of showing a bare id. The ingest path
+    // batches these; the write is an ON CONFLICT upsert.
+    const gop = gopStorage.getStore();
+    if (gop) {
+        for (const ev of games) {
+            const comp = ev.competitions?.[0];
+            const side = (ha: string) => comp?.competitors?.find((c: any) => c.homeAway === ha);
+            const home = side("home"), away = side("away");
+            if (!ev.id || !comp) continue;
+            gop.events.push({ table: "game_meta", row: {
+                game_id: Number(ev.id),
+                season: (ev as any).season?.year ?? null,
+                week: (ev as any).week?.number ?? null,
+                away_abbr: away?.team?.abbreviation ?? null,
+                home_abbr: home?.team?.abbreviation ?? null,
+                away_score: away?.score != null ? Number(away.score) : null,
+                home_score: home?.score != null ? Number(home.score) : null,
+                status: comp.status?.type?.name ?? null,
+                kickoff_ts: comp.date ?? null,
+                last_seen: new Date().toISOString(),
+            } });
+        }
+    }
     Astro.cache.set({
         maxAge: CURRENT_SEASON_CONFIG.scoreboardRefreshRate,
         swr: CURRENT_SEASON_CONFIG.scoreboardRefreshRate * CACHE_TTL_MULTIPLIER,

--- a/python/app.py
+++ b/python/app.py
@@ -2,24 +2,22 @@ from functools import wraps
 import math
 
 from flask import Flask, request, jsonify, Response, g
-import numpy as np
 from datetime import datetime as dt, timezone as tz
-import polars as pl
 from sportsdataverse.cfb import CFBPlayProcess
 from flask_compress import Compress
 import orjson
 
 import os
 import logging
-import json
 import base64
 
 from telemetry import TEL, stage, init_flask
 import gop_routes
 import espn_proxy
+import dq
 
 HTTP_TOKEN = os.getenv("PYTHON_HTTP_TOKEN")
-assert HTTP_TOKEN, f"HTTP_TOKEN not provided, can not start server"
+assert HTTP_TOKEN, "HTTP_TOKEN not provided, can not start server"
 
 app = Flask(__name__)
 app.config["LOG_TYPE"] = os.environ.get("LOG_TYPE", "stream")
@@ -327,6 +325,11 @@ def process(game_id: int):
         response.headers["X-Result-Cache"] = "MISS"
         # _emit_metrics(timings, gameId, 200)
         return response, 200
+        try:
+            _emit_dq(game_id, game, processed_game)
+        except Exception as e:  # observability must never cost a render
+            logging.getLogger("root").warning(f"dq emit failed for {game_id}: {e}")
+
         return jsonify(processed_game), 200
     except KeyError as e:
         logging.getLogger("root").error(
@@ -374,6 +377,41 @@ def process(game_id: int):
         return jsonify(
             {"status": "bad", "message": "Unknown error occurred, check logs."}
         ), 500
+
+
+def _sdv_identity():
+    try:
+        with open(
+            os.path.join(os.path.dirname(os.path.abspath(__file__)), "sdv_py_sha.txt")
+        ) as f:
+            sha = f.read().strip() or None
+    except Exception:
+        sha = None
+    try:
+        from importlib.metadata import version
+
+        ver = version("sportsdataverse")
+    except Exception:
+        ver = None
+    return ver, sha
+
+
+_SDV_VERSION, _SDV_SHA = _sdv_identity()
+
+
+def _emit_dq(game_id, game, processed_game):
+    header = (
+        (getattr(game, "json", None) or {}).get("header")
+        or processed_game.get("header")
+        or {}
+    )
+    TEL.push("game_meta", dq.build_game_meta_row(header, game_id))
+    status = ((header.get("competitions") or [{}])[0].get("status") or {}).get(
+        "type"
+    ) or {}
+    if status.get("completed") is True:
+        for row in dq.build_dq_rows(processed_game, game_id, _SDV_VERSION, _SDV_SHA):
+            TEL.push("dq_boxscore", row)
 
 
 @app.route("/healthcheck", methods=["GET"])

--- a/python/dq.py
+++ b/python/dq.py
@@ -1,0 +1,150 @@
+"""Data-quality rows for the admin dashboard.
+
+Two products, both written through TEL after a completed game is processed:
+
+- ``game_meta``: one upserted row per game (matchup, score, status) so admin
+  views can show "UNC @ TCU" instead of a bare game id.
+- ``dq_boxscore``: per-team deltas between the box score we aggregate from
+  play-text flags (``advBoxScore.team``) and ESPN's official team box
+  (``advBoxScore.espn_team``), plus reference-free lints over the plays.
+
+Zero is NOT the target for every stat -- our ``pass`` flag counts sacks and
+ESPN's net passing subtracts sack yardage, so some pairs carry a structural
+offset. The dashboard's signal is the STABILITY of each delta's distribution
+across games and sdv-py versions: a parser regression shows up as a
+version-aligned shift, the way the 2025 late-insert and penalty-EPA bugs
+would have.
+"""
+
+from datetime import datetime, timezone
+
+# (stat name, our team-box column, ESPN official-box key)
+BOX_PAIRS = [
+    ("rush_attempts", "rushes", "rushingAttempts"),
+    ("rush_yards", "rush_yards", "rushingYards"),
+    ("pass_attempts", "passes", "pass_attempts"),
+    ("pass_yards", "pass_yards", "netPassingYards"),
+    ("penalties", "penalties", "penalties"),
+    ("penalty_yards", "penalty_yards", "penalty_yards"),
+    ("first_downs_created", None, "firstDowns"),  # ours = passing + rushing created
+]
+
+
+def _num(v):
+    try:
+        f = float(v)
+    except (TypeError, ValueError):
+        return None
+    return f if f == f else None
+
+
+def build_game_meta_row(header, game_id):
+    """One upsertable row from an ESPN game header (``pbp['header']`` shape)."""
+    comp = (header or {}).get("competitions", [{}])[0]
+    status = (comp.get("status") or {}).get("type") or {}
+    sides = {c.get("homeAway"): c for c in comp.get("competitors", []) or []}
+    home, away = sides.get("home", {}), sides.get("away", {})
+    season = (header or {}).get("season") or {}
+    week = (header or {}).get("week")
+    return {
+        "game_id": int(game_id),
+        "season": season.get("year"),
+        "week": week
+        if isinstance(week, int)
+        else (week or {}).get("number")
+        if isinstance(week, dict)
+        else None,
+        "away_abbr": (away.get("team") or {}).get("abbreviation"),
+        "home_abbr": (home.get("team") or {}).get("abbreviation"),
+        "away_score": _num(away.get("score")),
+        "home_score": _num(home.get("score")),
+        "status": status.get("name"),
+        "kickoff_ts": comp.get("date"),
+        "last_seen": datetime.now(timezone.utc),
+    }
+
+
+def build_dq_rows(processed_game, game_id, sdv_version=None, sdv_sha=None):
+    """Per-team box deltas + game-level lints for one completed game."""
+    ts = datetime.now(timezone.utc)
+    base = {
+        "ts": ts,
+        "game_id": int(game_id),
+        "sdv_py_version": sdv_version,
+        "sdv_py_sha": sdv_sha,
+    }
+    rows = []
+    box = processed_game.get("advBoxScore") or {}
+    espn_by_team = {
+        int(t["team_id"]): t
+        for t in box.get("espn_team") or []
+        if t.get("team_id") is not None
+    }
+    for team in box.get("team") or []:
+        tid = team.get("pos_team")
+        if tid is None or int(tid) not in espn_by_team:
+            continue
+        espn = espn_by_team[int(tid)]
+        for stat, ours_key, espn_key in BOX_PAIRS:
+            if ours_key is None:
+                ours = _num(team.get("passing_first_downs_created"))
+                extra = _num(team.get("rushing_first_downs_created"))
+                ours = (
+                    None
+                    if ours is None and extra is None
+                    else (ours or 0) + (extra or 0)
+                )
+            else:
+                ours = _num(team.get(ours_key))
+            theirs = _num(espn.get(espn_key))
+            if ours is None and theirs is None:
+                continue
+            rows.append(
+                {
+                    **base,
+                    "team_id": int(tid),
+                    "stat": stat,
+                    "ours": ours,
+                    "espn": theirs,
+                    "delta": None if ours is None or theirs is None else ours - theirs,
+                }
+            )
+    # Reference-free lints: espn is NULL and the expectation is delta == 0.
+    plays = processed_game.get("plays") or []
+    scrimmage = [p for p in plays if p.get("scrimmage_play") == True]  # noqa: E712
+    lints = {
+        "lint:epa_null": sum(1 for p in scrimmage if p.get("EPA") is None),
+        "lint:wp_oob": sum(
+            1
+            for p in plays
+            for v in (p.get("wp_before"), p.get("wp_after"))
+            if v is not None and not (0.0 <= v <= 1.0)
+        ),
+        "lint:ep_between_big": sum(
+            1
+            for p in plays
+            if p.get("EP_between") is not None and abs(p["EP_between"]) > 3.0
+        ),
+    }
+    for stat, n in lints.items():
+        rows.append(
+            {
+                **base,
+                "team_id": None,
+                "stat": stat,
+                "ours": float(n),
+                "espn": None,
+                "delta": float(n),
+            }
+        )
+    rows.append(
+        {
+            **base,
+            "team_id": None,
+            "stat": "plays",
+            "ours": float(len(plays)),
+            "espn": None,
+            "delta": None,
+        }
+    )
+    return rows

--- a/python/gop_routes.py
+++ b/python/gop_routes.py
@@ -138,19 +138,87 @@ def _upstream(args):
                 count(*) FILTER (WHERE status >= 500)::int AS s5xx,
                 count(*) FILTER (WHERE status IS NULL AND ok = false)::int AS timeouts
             FROM gop.upstream_log WHERE ts > now() - interval '24 hours' GROUP BY 1 ORDER BY 1"""),
-        "slowest": _q("""SELECT ts, target, game_id, duration_ms, status FROM gop.upstream_log
+        "slowest": _q("""SELECT u.ts, u.target, u.game_id, u.duration_ms, u.status,
+                gm.away_abbr || ' @ ' || gm.home_abbr AS matchup FROM gop.upstream_log u LEFT JOIN gop.game_meta gm ON gm.game_id::text = u.game_id
             WHERE ts > now() - interval '1 hour' ORDER BY duration_ms DESC NULLS LAST LIMIT 10"""),
     }
 
 
 def _errors(args):
     return {
-        "groups": _q("""SELECT service, left(message, 120) AS signature, count(*)::int AS n,
-                max(ts) AS last_seen, max(game_id) AS game_id
-            FROM gop.error_log WHERE ts > now() - interval '24 hours'
+        "groups": _q("""SELECT e.service, left(e.message, 120) AS signature, count(*)::int AS n,
+                max(e.ts) AS last_seen, max(e.game_id) AS game_id,
+                max(gm.away_abbr || ' @ ' || gm.home_abbr) AS matchup
+            FROM gop.error_log e
+            LEFT JOIN gop.game_meta gm ON gm.game_id::text = e.game_id
+            WHERE e.ts > now() - interval '24 hours'
             GROUP BY 1, 2 ORDER BY last_seen DESC LIMIT 50"""),
-        "recent": _q("""SELECT ts, service, level, message, stack, path, game_id
-            FROM gop.error_log ORDER BY ts DESC LIMIT 20"""),
+        "recent": _q("""SELECT e.ts, e.service, e.level, e.message, e.stack, e.path, e.game_id,
+                gm.away_abbr || ' @ ' || gm.home_abbr AS matchup
+            FROM gop.error_log e
+            LEFT JOIN gop.game_meta gm ON gm.game_id::text = e.game_id
+            ORDER BY e.ts DESC LIMIT 20"""),
+    }
+
+
+def _dq(args):
+    """Box-vs-official deltas and lints. Stability across sdv_py_sha is the
+    signal; a version-aligned shift in a stat's delta distribution is a parser
+    regression."""
+    days = min(int(args.get("days", 14)), 90)
+    return {
+        "scorecard": _q(
+            """SELECT stat,
+                count(*)::int AS n,
+                count(*) FILTER (WHERE delta = 0)::int AS exact,
+                count(*) FILTER (WHERE abs(delta) <= 2)::int AS close,
+                round(avg(delta)::numeric, 2)::float AS mean_delta,
+                round(percentile_cont(0.5) WITHIN GROUP (ORDER BY delta)::numeric, 2)::float AS median_delta,
+                round(max(abs(delta))::numeric, 1)::float AS worst
+            FROM gop.dq_boxscore
+            WHERE ts > now() - make_interval(days => %s) AND delta IS NOT NULL
+            GROUP BY 1 ORDER BY 1""",
+            (days,),
+        ),
+        "by_version": _q(
+            """SELECT sdv_py_sha, stat,
+                count(*)::int AS n, round(avg(delta)::numeric, 2)::float AS mean_delta
+            FROM gop.dq_boxscore
+            WHERE ts > now() - make_interval(days => %s) AND delta IS NOT NULL
+                AND stat NOT LIKE 'lint:%%'
+            GROUP BY 1, 2 ORDER BY max(ts) DESC, 2 LIMIT 60""",
+            (days,),
+        ),
+        "worst_games": _q(
+            """SELECT d.game_id,
+                gm.away_abbr || ' @ ' || gm.home_abbr AS matchup,
+                max(d.ts) AS checked_at, max(d.sdv_py_sha) AS sdv_py_sha,
+                round(sum(abs(d.delta))::numeric, 1)::float AS total_abs_delta,
+                count(*) FILTER (WHERE d.delta <> 0)::int AS stats_off
+            FROM gop.dq_boxscore d
+            LEFT JOIN gop.game_meta gm ON gm.game_id = d.game_id
+            WHERE d.ts > now() - make_interval(days => %s)
+                AND d.delta IS NOT NULL AND d.stat NOT LIKE 'lint:%%'
+            GROUP BY 1, 2 ORDER BY total_abs_delta DESC LIMIT 25""",
+            (days,),
+        ),
+        "lints": _q(
+            """SELECT stat, count(*) FILTER (WHERE delta > 0)::int AS games_flagged,
+                sum(delta)::int AS total, max(ts) AS last_seen
+            FROM gop.dq_boxscore
+            WHERE ts > now() - make_interval(days => %s) AND stat LIKE 'lint:%%'
+            GROUP BY 1 ORDER BY 1""",
+            (days,),
+        ),
+        "game": _q(
+            """SELECT d.stat, d.team_id, d.ours, d.espn, d.delta
+            FROM gop.dq_boxscore d WHERE d.game_id = %s
+                AND d.ts = (SELECT max(ts) FROM gop.dq_boxscore WHERE game_id = %s)
+            ORDER BY d.team_id NULLS LAST, d.stat""",
+            (args.get("game_id", 0), args.get("game_id", 0)),
+        )
+        if args.get("game_id")
+        else [],
     }
 
 
@@ -223,6 +291,7 @@ _ADMIN = {
     "games": _games,
     "upstream": _upstream,
     "errors": _errors,
+    "dq": _dq,
     "traffic": _traffic,
     "system": _system,
     "page": _page,

--- a/python/gop_routes.py
+++ b/python/gop_routes.py
@@ -147,8 +147,13 @@ def _upstream(args):
 def _errors(args):
     return {
         "groups": _q("""SELECT e.service, left(e.message, 120) AS signature, count(*)::int AS n,
-                max(e.ts) AS last_seen, max(e.game_id) AS game_id,
-                max(gm.away_abbr || ' @ ' || gm.home_abbr) AS matchup
+                max(e.ts) AS last_seen,
+                -- game_id and matchup must come from the SAME row (the latest
+                -- error), or a multi-game signature links one game while
+                -- naming another; both arrays share one deterministic order
+                (array_agg(e.game_id ORDER BY e.ts DESC, e.game_id DESC))[1] AS game_id,
+                (array_agg(gm.away_abbr || ' @ ' || gm.home_abbr
+                           ORDER BY e.ts DESC, e.game_id DESC))[1] AS matchup
             FROM gop.error_log e
             LEFT JOIN gop.game_meta gm ON gm.game_id::text = e.game_id
             WHERE e.ts > now() - interval '24 hours'
@@ -181,12 +186,12 @@ def _dq(args):
             (days,),
         ),
         "by_version": _q(
-            """SELECT sdv_py_sha, stat,
+            """SELECT sdv_py_version, sdv_py_sha, stat,
                 count(*)::int AS n, round(avg(delta)::numeric, 2)::float AS mean_delta
             FROM gop.dq_boxscore
             WHERE ts > now() - make_interval(days => %s) AND delta IS NOT NULL
                 AND stat NOT LIKE 'lint:%%'
-            GROUP BY 1, 2 ORDER BY max(ts) DESC, 2 LIMIT 60""",
+            GROUP BY 1, 2, 3 ORDER BY max(ts) DESC, 3 LIMIT 60""",
             (days,),
         ),
         "worst_games": _q(

--- a/python/gop_routes.py
+++ b/python/gop_routes.py
@@ -182,6 +182,7 @@ def _dq(args):
                 round(max(abs(delta))::numeric, 1)::float AS worst
             FROM gop.dq_boxscore
             WHERE ts > now() - make_interval(days => %s) AND delta IS NOT NULL
+                AND stat NOT LIKE 'lint:%%'
             GROUP BY 1 ORDER BY 1""",
             (days,),
         ),
@@ -204,6 +205,8 @@ def _dq(args):
             LEFT JOIN gop.game_meta gm ON gm.game_id = d.game_id
             WHERE d.ts > now() - make_interval(days => %s)
                 AND d.delta IS NOT NULL AND d.stat NOT LIKE 'lint:%%'
+                -- a reprocessed game writes a fresh batch; only its latest counts
+                AND d.ts = (SELECT max(ts) FROM gop.dq_boxscore WHERE game_id = d.game_id)
             GROUP BY 1, 2 ORDER BY total_abs_delta DESC LIMIT 25""",
             (days,),
         ),

--- a/python/sql/2026-09-02_admin_dq.sql
+++ b/python/sql/2026-09-02_admin_dq.sql
@@ -1,0 +1,36 @@
+-- Admin data-quality slice: matchup dimension + box-vs-official deltas.
+-- Applied manually on the droplet (gop schema has no migration runner);
+-- kept here as the documented DDL. Owner: sdv. 2026-09-02.
+
+CREATE TABLE IF NOT EXISTS gop.game_meta (
+    game_id     bigint PRIMARY KEY,
+    season      int,
+    week        int,
+    away_abbr   text,
+    home_abbr   text,
+    away_score  real,
+    home_score  real,
+    status      text,
+    kickoff_ts  timestamptz,
+    last_seen   timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS gop.dq_boxscore (
+    ts              timestamptz NOT NULL,
+    game_id         bigint NOT NULL,
+    team_id         bigint,
+    stat            text NOT NULL,
+    ours            double precision,
+    espn            double precision,
+    delta           double precision,
+    sdv_py_version  text,
+    sdv_py_sha      text
+);
+CREATE INDEX IF NOT EXISTS dq_boxscore_game_idx ON gop.dq_boxscore (game_id);
+CREATE INDEX IF NOT EXISTS dq_boxscore_stat_ts_idx ON gop.dq_boxscore (stat, ts);
+
+GRANT SELECT ON gop.game_meta, gop.dq_boxscore TO gop_reader;
+GRANT INSERT ON gop.dq_boxscore TO gop_writer;
+-- game_meta is written as an upsert; ON CONFLICT DO UPDATE needs UPDATE, and the
+-- COALESCE(EXCLUDED.c, gop.game_meta.c) expressions read the existing row (SELECT).
+GRANT SELECT, INSERT, UPDATE ON gop.game_meta TO gop_writer;

--- a/python/telemetry.py
+++ b/python/telemetry.py
@@ -42,6 +42,29 @@ _TABLES = {
         "game_id",
         "error",
     ],
+    "game_meta": [
+        "game_id",
+        "season",
+        "week",
+        "away_abbr",
+        "home_abbr",
+        "away_score",
+        "home_score",
+        "status",
+        "kickoff_ts",
+        "last_seen",
+    ],
+    "dq_boxscore": [
+        "ts",
+        "game_id",
+        "team_id",
+        "stat",
+        "ours",
+        "espn",
+        "delta",
+        "sdv_py_version",
+        "sdv_py_sha",
+    ],
     "error_log": [
         "ts",
         "service",
@@ -66,13 +89,25 @@ _TABLES = {
 
 # Columns whose values arrive as strings but need an explicit cast in the
 # INSERT (psycopg sends str as text; PG won't implicitly cast text->inet/jsonb).
-_CASTS = {"ip": "::inet", "context": "::jsonb"}
+_CASTS = {"ip": "::inet", "context": "::jsonb", "kickoff_ts": "::timestamptz"}
 
 _SQL = {
     table: "INSERT INTO gop.%s (%s) VALUES (%s)"
     % (table, ",".join(cols), ",".join("%s" + _CASTS.get(c, "") for c in cols))
     for table, cols in _TABLES.items()
 }
+
+# game_meta is a live-updated dimension, not an append log: the same game is
+# seen by every render, so the insert must be an upsert on game_id.
+_SQL["game_meta"] = (
+    _SQL["game_meta"].rstrip()
+    + " ON CONFLICT (game_id) DO UPDATE SET "
+    + ", ".join(
+        f"{c} = COALESCE(EXCLUDED.{c}, gop.game_meta.{c})"
+        for c in _TABLES["game_meta"]
+        if c != "game_id"
+    )
+)
 
 log = logging.getLogger("app.telemetry")
 
@@ -108,7 +143,9 @@ class Telemetry:
         self._wake = threading.Event()  # signals worker to flush early at batch_rows
         self.dropped = 0
         self._started = False
-        self._host_lock = None   # None=unknown, False=another worker holds it, int=our fd
+        self._host_lock = (
+            None  # None=unknown, False=another worker holds it, int=our fd
+        )
 
     def _default_conn(self):
         import psycopg
@@ -245,6 +282,7 @@ class Telemetry:
             return self._host_lock is not False
         try:
             import fcntl
+
             fd = os.open("/tmp/.gop-host-reporter.lock", os.O_CREAT | os.O_RDWR, 0o600)
             try:
                 fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -252,7 +290,7 @@ class Telemetry:
                 os.close(fd)
                 self._host_lock = False
                 return False
-            self._host_lock = fd       # keep the fd open to hold the lock
+            self._host_lock = fd  # keep the fd open to hold the lock
             return True
         except Exception:
             self._host_lock = False

--- a/python/tests/test_dq.py
+++ b/python/tests/test_dq.py
@@ -1,0 +1,65 @@
+import dq
+
+
+def header(completed=True):
+    return {
+        "season": {"year": 2026},
+        "week": 1,
+        "competitions": [{
+            "date": "2026-08-30T00:00Z",
+            "status": {"type": {"name": "STATUS_FINAL", "completed": completed}},
+            "competitors": [
+                {"homeAway": "home", "score": "10", "team": {"abbreviation": "TCU"}},
+                {"homeAway": "away", "score": "15", "team": {"abbreviation": "UNC"}},
+            ],
+        }],
+    }
+
+
+def test_game_meta_row():
+    r = dq.build_game_meta_row(header(), 401856766)
+    assert r["game_id"] == 401856766 and r["season"] == 2026
+    assert (r["away_abbr"], r["home_abbr"]) == ("UNC", "TCU")
+    assert (r["away_score"], r["home_score"]) == (15.0, 10.0)
+    assert r["status"] == "STATUS_FINAL" and r["kickoff_ts"] == "2026-08-30T00:00Z"
+
+
+def test_game_meta_row_survives_empty_header():
+    r = dq.build_game_meta_row({}, 1)
+    assert r["game_id"] == 1 and r["away_abbr"] is None
+
+
+def test_dq_rows_pair_teams_and_compute_deltas():
+    game = {
+        "advBoxScore": {
+            "team": [
+                {"pos_team": 2628, "rushes": 30, "rush_yards": 120, "passes": 25, "pass_yards": 210,
+                 "penalties": 5, "penalty_yards": -40,
+                 "passing_first_downs_created": 8, "rushing_first_downs_created": 6},
+            ],
+            "espn_team": [
+                {"team_id": 2628, "rushingAttempts": 30, "rushingYards": 118, "pass_attempts": 24,
+                 "netPassingYards": 200, "penalties": 5, "penalty_yards": 40, "firstDowns": 16},
+            ],
+        },
+        "plays": [
+            {"scrimmage_play": True, "EPA": None, "wp_before": 0.5, "wp_after": 1.2, "EP_between": -4.0},
+            {"scrimmage_play": True, "EPA": 0.3, "wp_before": 0.6, "wp_after": 0.61, "EP_between": 0.0},
+        ],
+    }
+    rows = dq.build_dq_rows(game, 401856766, "0.1.3", "abc123")
+    by = {(r["team_id"], r["stat"]): r for r in rows}
+    assert by[(2628, "rush_yards")]["delta"] == 2.0
+    assert by[(2628, "pass_attempts")]["delta"] == 1.0
+    assert by[(2628, "first_downs_created")]["ours"] == 14.0 and by[(2628, "first_downs_created")]["delta"] == -2.0
+    assert by[(None, "lint:epa_null")]["delta"] == 1.0
+    assert by[(None, "lint:wp_oob")]["delta"] == 1.0
+    assert by[(None, "lint:ep_between_big")]["delta"] == 1.0
+    assert by[(None, "plays")]["ours"] == 2.0
+    assert all(r["sdv_py_sha"] == "abc123" for r in rows)
+
+
+def test_dq_rows_skip_unmatched_teams():
+    game = {"advBoxScore": {"team": [{"pos_team": 1}], "espn_team": []}, "plays": []}
+    rows = dq.build_dq_rows(game, 5)
+    assert all(r["stat"].startswith("lint:") or r["stat"] == "plays" for r in rows)

--- a/python/tests/test_dq.py
+++ b/python/tests/test_dq.py
@@ -5,14 +5,24 @@ def header(completed=True):
     return {
         "season": {"year": 2026},
         "week": 1,
-        "competitions": [{
-            "date": "2026-08-30T00:00Z",
-            "status": {"type": {"name": "STATUS_FINAL", "completed": completed}},
-            "competitors": [
-                {"homeAway": "home", "score": "10", "team": {"abbreviation": "TCU"}},
-                {"homeAway": "away", "score": "15", "team": {"abbreviation": "UNC"}},
-            ],
-        }],
+        "competitions": [
+            {
+                "date": "2026-08-30T00:00Z",
+                "status": {"type": {"name": "STATUS_FINAL", "completed": completed}},
+                "competitors": [
+                    {
+                        "homeAway": "home",
+                        "score": "10",
+                        "team": {"abbreviation": "TCU"},
+                    },
+                    {
+                        "homeAway": "away",
+                        "score": "15",
+                        "team": {"abbreviation": "UNC"},
+                    },
+                ],
+            }
+        ],
     }
 
 
@@ -33,25 +43,56 @@ def test_dq_rows_pair_teams_and_compute_deltas():
     game = {
         "advBoxScore": {
             "team": [
-                {"pos_team": 2628, "rushes": 30, "rush_yards": 120, "passes": 25, "pass_yards": 210,
-                 "penalties": 5, "penalty_yards": -40,
-                 "passing_first_downs_created": 8, "rushing_first_downs_created": 6},
+                {
+                    "pos_team": 2628,
+                    "rushes": 30,
+                    "rush_yards": 120,
+                    "passes": 25,
+                    "pass_yards": 210,
+                    "penalties": 5,
+                    "penalty_yards": -40,
+                    "passing_first_downs_created": 8,
+                    "rushing_first_downs_created": 6,
+                },
             ],
             "espn_team": [
-                {"team_id": 2628, "rushingAttempts": 30, "rushingYards": 118, "pass_attempts": 24,
-                 "netPassingYards": 200, "penalties": 5, "penalty_yards": 40, "firstDowns": 16},
+                {
+                    "team_id": 2628,
+                    "rushingAttempts": 30,
+                    "rushingYards": 118,
+                    "pass_attempts": 24,
+                    "netPassingYards": 200,
+                    "penalties": 5,
+                    "penalty_yards": 40,
+                    "firstDowns": 16,
+                },
             ],
         },
         "plays": [
-            {"scrimmage_play": True, "EPA": None, "wp_before": 0.5, "wp_after": 1.2, "EP_between": -4.0},
-            {"scrimmage_play": True, "EPA": 0.3, "wp_before": 0.6, "wp_after": 0.61, "EP_between": 0.0},
+            {
+                "scrimmage_play": True,
+                "EPA": None,
+                "wp_before": 0.5,
+                "wp_after": 1.2,
+                "EP_between": -4.0,
+            },
+            {
+                "scrimmage_play": True,
+                "EPA": 0.3,
+                "wp_before": 0.6,
+                "wp_after": 0.61,
+                "EP_between": 0.0,
+            },
         ],
     }
     rows = dq.build_dq_rows(game, 401856766, "0.1.3", "abc123")
     by = {(r["team_id"], r["stat"]): r for r in rows}
     assert by[(2628, "rush_yards")]["delta"] == 2.0
     assert by[(2628, "pass_attempts")]["delta"] == 1.0
-    assert by[(2628, "first_downs_created")]["ours"] == 14.0 and by[(2628, "first_downs_created")]["delta"] == -2.0
+    assert (
+        by[(2628, "first_downs_created")]["ours"] == 14.0
+        and by[(2628, "first_downs_created")]["delta"] == -2.0
+    )
     assert by[(None, "lint:epa_null")]["delta"] == 1.0
     assert by[(None, "lint:wp_oob")]["delta"] == 1.0
     assert by[(None, "lint:ep_between_big")]["delta"] == 1.0


### PR DESCRIPTION
First slice of the admin/DQ proposal (ClaudeCowork `notes/2026-09-02-gop-admin-dq-proposal.md`).

## Matchup names on tracked errors
`gop.game_meta` (game_id PK → season/week/abbrs/score/status/kickoff), upserted from two writers that already hold the payload: the scoreboard render (whole slate, self-backfilling) and the python API after each `process()`. Errors, upstream-slowest and DQ views LEFT JOIN it — "UNC @ TCU" linkified to the game page, id fallback when meta hasn't been seen yet. Upsert `COALESCE`s per column so a sparse writer never clobbers a fuller row (exercised live as `gop_writer`).

## Data-quality scorecard
`gop.dq_boxscore`: per-team deltas between the play-flag box (`advBoxScore.team`) and ESPN's official box (`advBoxScore.espn_team`) for 7 countable stats, plus reference-free lints (`lint:epa_null`, `lint:wp_oob`, `lint:ep_between_big`), stamped with sdv-py version+sha; written fire-and-forget after completed games only.

New **Data quality** admin tab: per-stat scorecard (exact / |Δ|≤2 rates, mean/median/worst), lints, mean-delta-by-sdv-py-version (a version-aligned shift = parser regression — the dashboard form of how the late-insert and penalty-EPA bugs were found), and a worst-games table with per-stat drill-down.

**Zero is not the target for every stat** — our `pass` flag counts sacks, ESPN's net passing subtracts sack yardage, penalty-yard signs differ. The tab says so; the signal is distribution stability.

## Ops
DDL at `python/sql/2026-09-02_admin_dq.sql`, already applied on the droplet (tables + grants verified, incl. `SELECT` for the upsert's COALESCE reads). Every new/modified admin query EXPLAIN-checked against the live schema. Tests: python 12 passed (4 new in `tests/test_dq.py`), vitest 91 passed, worker compiles on Node 22.

## Summary by Sourcery

Add matchup-aware admin diagnostics and a data-quality scorecard for monitoring box-score stability and parser regressions.

New Features:
- Add an admin Data Quality dashboard comparing play-derived and official box-score statistics, tracking lints, parser-version shifts, and worst-game drill-downs.

Enhancements:
- Associate tracked errors and slow upstream requests with human-readable game matchups and links when metadata is available.
- Capture and upsert game metadata from scoreboard and processing paths while preserving existing non-null fields.
- Record per-team box-score deltas and reference-free play-data lints for completed games with sportsdataverse version identity.

Deployment:
- Add the database schema, indexes, and permissions required for game metadata and data-quality records.

Tests:
- Add unit coverage for game metadata construction and data-quality row generation, including stat pairing, lints, and unmatched teams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin Data Quality tab with scorecards, lint results, version comparisons, worst-performing games, and detailed game statistics.
  * Added automated comparison of game data against official box scores, including data-quality metrics and lint findings.
  * Added game metadata tracking to support richer administrative reporting.
  * Added matchup links and game context to error and upstream admin views.
* **Tests**
  * Added coverage for metadata extraction, score comparisons, lint metrics, play counts, and unmatched teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->