### PR TITLE
feat(admin): preview mode — in-development features hidden until promoted

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -2,7 +2,11 @@
 import { getSecret } from "astro:env/server"
 
 const APP_VERSION = getSecret("APP_VERSION");
+const preview = Astro.locals.preview === true;
 ---
+{preview && (
+  <div style="position:fixed;left:1rem;bottom:1.25rem;z-index:1030" class="badge text-bg-warning" title="Admin preview mode: unreleased features are visible and nothing you load is cached. Turn off in /admin.">PREVIEW</div>
+)}
 <div class="container-fluid">
   <div class="row text-center">
   <footer class="blog-footer">

--- a/astro/src/env.d.ts
+++ b/astro/src/env.d.ts
@@ -11,6 +11,9 @@ interface ImportMeta {
 }
 
 declare namespace App {
+    interface Locals {
+        preview?: boolean;
+    }
   interface SessionData {
     favorites?: {
       teams?: (string | number)[];

--- a/astro/src/middleware.ts
+++ b/astro/src/middleware.ts
@@ -4,6 +4,7 @@ import {
   createCollector, gopStorage, sendToIngest, clientIp, type GopCollector,
 } from './utils/telemetry';
 import { checkBasicAuth } from './resources/admin';
+import { PREVIEW_COOKIE, readCookie, verifyPreviewCookie } from './utils/preview';
 import { legacyCfbTarget, staleRedirectTarget } from './utils/legacyCfb';
 
 const GAME_ID_RE = /\/game\/(\d+)/;
@@ -26,6 +27,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return context.redirect(stale + url.search, 301);
   }
 
+  // Admin preview mode: a valid signed cookie renders 'preview'-state features
+  // (utils/features.ts) on public pages. Verified once here; pages read
+  // locals.preview. The response is then forced uncacheable below -- a preview
+  // variant in Workers Caching would be served to everyone.
+  const previewCookie = readCookie(context.request.headers.get('cookie'), PREVIEW_COOKIE);
+  if (previewCookie) {
+    context.locals.preview = await verifyPreviewCookie(previewCookie, getSecret('ADMIN_PASS'));
+  }
+
   if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {
     const ok = checkBasicAuth(context.request.headers.get('authorization'),
       getSecret('ADMIN_USER'), getSecret('ADMIN_PASS'));
@@ -37,7 +47,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   const key = getSecret('GOP_INGEST_KEY') ?? '';
   const enabled = (getSecret('TELEMETRY_ENABLED') ?? '1') !== '0' && !!key;
-  if (!enabled || url.pathname.startsWith('/api/client-log')) return next();
+  if (!enabled || url.pathname.startsWith('/api/client-log')) {
+    return withPreviewCacheGuard(context, await next());
+  }
 
   const collector = createCollector();
   collector.game_id = (url.pathname.match(GAME_ID_RE) || [])[1] ?? null;
@@ -56,7 +68,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     throw err;
   }
   emit(context, collector, url, response, response.status, t0, key);
-  return response;
+  return withPreviewCacheGuard(context, response);
 });
 
 function emit(context: any, c: GopCollector, url: URL, res: Response | null, status: number, t0: number, key: string) {
@@ -102,4 +114,16 @@ function parseIntOrNull(v: string | null | undefined): number | null {
 
 function safeClientAddress(context: any): string | null {
   try { return context.clientAddress ?? null; } catch { return null; }
+}
+
+// A previewing admin's render must never enter Workers Caching. set(false)
+// alone emits no header (heuristic 2h cache -- see 311d80e); no-store is the
+// explicit opt-out, and cache.set(false) after render wins over any options
+// the page itself accumulated.
+function withPreviewCacheGuard(context: any, response: Response): Response {
+  if (context.locals?.preview === true) {
+    try { context.cache?.set(false); } catch { /* cache provider absent in dev */ }
+    response.headers.set('Cache-Control', 'no-store');
+  }
+  return response;
 }

--- a/astro/src/pages/admin/api/preview.ts
+++ b/astro/src/pages/admin/api/preview.ts
@@ -16,8 +16,11 @@ export const GET: APIRoute = async ({ request }) => {
 export const POST: APIRoute = async ({ request }) => {
     const secret = getSecret('ADMIN_PASS');
     if (!secret) return Response.json({ ok: false, error: 'ADMIN_PASS not set' }, { status: 500 });
-    let on = false;
-    try { on = Boolean(((await request.json()) as { on?: unknown })?.on); } catch { /* default off */ }
+    let on: unknown;
+    try { on = ((await request.json()) as { on?: unknown })?.on; } catch { on = undefined; }
+    if (typeof on !== 'boolean') {
+        return Response.json({ ok: false, error: 'body must be {"on": true|false}' }, { status: 400 });
+    }
     const cookie = on
         ? `${PREVIEW_COOKIE}=${await mintPreviewCookie(secret)}; Path=/; Max-Age=${PREVIEW_TTL_S}; HttpOnly; Secure; SameSite=Lax`
         : `${PREVIEW_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;

--- a/astro/src/pages/admin/api/preview.ts
+++ b/astro/src/pages/admin/api/preview.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from 'astro';
+import { getSecret } from 'astro:env/server';
+import { PREVIEW_COOKIE, PREVIEW_TTL_S, mintPreviewCookie, readCookie, verifyPreviewCookie } from '../../../utils/preview';
+
+export const prerender = false;
+
+// Toggle admin preview mode (see utils/features.ts). Behind /admin basic auth
+// via the middleware. GET reports state; POST {"on": true|false} sets or
+// clears the signed cookie for the whole site (Path=/).
+export const GET: APIRoute = async ({ request }) => {
+    const enabled = await verifyPreviewCookie(
+        readCookie(request.headers.get('cookie'), PREVIEW_COOKIE), getSecret('ADMIN_PASS'));
+    return Response.json({ enabled }, { headers: { 'Cache-Control': 'no-store' } });
+};
+
+export const POST: APIRoute = async ({ request }) => {
+    const secret = getSecret('ADMIN_PASS');
+    if (!secret) return Response.json({ ok: false, error: 'ADMIN_PASS not set' }, { status: 500 });
+    let on = false;
+    try { on = Boolean(((await request.json()) as { on?: unknown })?.on); } catch { /* default off */ }
+    const cookie = on
+        ? `${PREVIEW_COOKIE}=${await mintPreviewCookie(secret)}; Path=/; Max-Age=${PREVIEW_TTL_S}; HttpOnly; Secure; SameSite=Lax`
+        : `${PREVIEW_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
+    return Response.json({ ok: true, enabled: on }, {
+        headers: { 'Set-Cookie': cookie, 'Cache-Control': 'no-store' },
+    });
+};

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -14,6 +14,7 @@ const subtitle = "Operational dashboards for Game on Paper";
   <div class="d-flex align-items-center flex-wrap gap-2 mb-3">
     <h2 class="mb-0">Admin</h2>
     <span class="badge text-bg-danger text-uppercase">ops</span>
+    <button class="btn btn-sm btn-outline-warning ms-3" id="preview-toggle" title="Render 'preview'-state features (utils/features.ts) on the public site for this browser only. Responses are never cached while previewing.">Preview: …</button>
     <span class="ms-auto small admin-muted" id="asof"></span>
   </div>
   <ul class="nav nav-tabs admin-tabs mb-3" id="tabs">
@@ -150,6 +151,21 @@ const subtitle = "Operational dashboards for Game on Paper";
   const fmt = (x, d = 0) => (x == null ? '—' : Number(x).toFixed(d));
   const hhmm = (t) => new Date(t).toTimeString().slice(0, 5);
   const api = (name, qs = '') => fetch(`/admin/api/${name}${qs}`).then((r) => r.json());
+
+  // ---- preview mode toggle ----
+  const pvBtn = document.getElementById('preview-toggle');
+  function pvRender(enabled) {
+    pvBtn.textContent = `Preview: ${enabled ? 'ON' : 'off'}`;
+    pvBtn.classList.toggle('btn-warning', enabled);
+    pvBtn.classList.toggle('btn-outline-warning', !enabled);
+    pvBtn.dataset.on = enabled ? '1' : '';
+  }
+  fetch('/admin/api/preview').then((r) => r.json()).then((d) => pvRender(d.enabled)).catch(() => {});
+  pvBtn.addEventListener('click', async () => {
+    const on = !pvBtn.dataset.on;
+    const d = await fetch('/admin/api/preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ on }) }).then((r) => r.json());
+    pvRender(d.enabled);
+  });
 
   function line(id, labels, datasets) {
     charts[id]?.destroy();

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -14,7 +14,7 @@ const subtitle = "Operational dashboards for Game on Paper";
   <div class="d-flex align-items-center flex-wrap gap-2 mb-3">
     <h2 class="mb-0">Admin</h2>
     <span class="badge text-bg-danger text-uppercase">ops</span>
-    <button class="btn btn-sm btn-outline-warning ms-3" id="preview-toggle" title="Render 'preview'-state features (utils/features.ts) on the public site for this browser only. Responses are never cached while previewing.">Preview: …</button>
+    <button class="btn btn-sm btn-outline-warning ms-3" id="preview-toggle" disabled title="Render 'preview'-state features (utils/features.ts) on the public site for this browser only. Responses are never cached while previewing.">Preview: …</button>
     <span class="ms-auto small admin-muted" id="asof"></span>
   </div>
   <ul class="nav nav-tabs admin-tabs mb-3" id="tabs">
@@ -154,17 +154,23 @@ const subtitle = "Operational dashboards for Game on Paper";
 
   // ---- preview mode toggle ----
   const pvBtn = document.getElementById('preview-toggle');
+  // the button stays disabled until the state it would toggle is known, and
+  // during a toggle, so a quick click cannot race the initial GET
   function pvRender(enabled) {
     pvBtn.textContent = `Preview: ${enabled ? 'ON' : 'off'}`;
     pvBtn.classList.toggle('btn-warning', enabled);
     pvBtn.classList.toggle('btn-outline-warning', !enabled);
     pvBtn.dataset.on = enabled ? '1' : '';
+    pvBtn.disabled = false;
   }
-  fetch('/admin/api/preview').then((r) => r.json()).then((d) => pvRender(d.enabled)).catch(() => {});
+  fetch('/admin/api/preview').then((r) => r.json()).then((d) => pvRender(d.enabled)).catch(() => { pvBtn.textContent = 'Preview: ?'; });
   pvBtn.addEventListener('click', async () => {
-    const on = !pvBtn.dataset.on;
-    const d = await fetch('/admin/api/preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ on }) }).then((r) => r.json());
-    pvRender(d.enabled);
+    pvBtn.disabled = true;
+    try {
+      const on = !pvBtn.dataset.on;
+      const d = await fetch('/admin/api/preview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ on }) }).then((r) => r.json());
+      pvRender(d.enabled);
+    } catch { pvBtn.disabled = false; }
   });
 
   function line(id, labels, datasets) {

--- a/astro/src/utils/features.ts
+++ b/astro/src/utils/features.ts
@@ -1,0 +1,28 @@
+// In-development features, hidden behind admin preview mode.
+//
+//   'off'      -> rendered for nobody (parked work)
+//   'preview'  -> rendered only when the viewer holds a valid preview cookie
+//                 (toggled from /admin; see utils/preview.ts)
+//   'on'       -> rendered for everyone
+//
+// Ship a feature as 'preview', eyeball it on production data via the admin
+// panel's Preview toggle, then PROMOTE it with a one-line 'preview' -> 'on'
+// change -- promotion stays a reviewed commit, and the public path costs
+// nothing (no store reads; the cookie check happens once in middleware).
+//
+// Usage in a component or page:
+//   import { isFeatureEnabled } from '../utils/features';
+//   { isFeatureEnabled('my-flag', Astro.locals) && <NewThing /> }
+
+export type FeatureState = 'off' | 'preview' | 'on';
+
+export const FLAGS: Record<string, FeatureState> = {
+    // 'example-widget': 'preview',
+};
+
+export function isFeatureEnabled(name: string, locals: { preview?: boolean } | undefined): boolean {
+    const state = FLAGS[name] ?? 'off';
+    if (state === 'on') return true;
+    if (state === 'preview') return locals?.preview === true;
+    return false;
+}

--- a/astro/src/utils/preview.ts
+++ b/astro/src/utils/preview.ts
@@ -27,7 +27,7 @@ export async function verifyPreviewCookie(value: string | undefined | null, secr
     if (!value || !secret) return false;
     const [v, expiryRaw, sig] = value.split('.');
     const expiry = Number(expiryRaw);
-    if (v !== 'v1' || !Number.isFinite(expiry) || expiry < nowS || !sig) return false;
+    if (v !== 'v1' || !Number.isFinite(expiry) || expiry <= nowS || !sig) return false;
     const expected = await hmacHex(secret, `gop-preview:${expiry}`);
     if (sig.length !== expected.length) return false;
     let diff = 0;

--- a/astro/src/utils/preview.ts
+++ b/astro/src/utils/preview.ts
@@ -1,0 +1,44 @@
+// Preview mode: an HMAC-signed, expiring cookie that lets an admin see
+// in-development features on the PUBLIC site. The middleware treats a valid
+// cookie as "this response must never be cached" (Workers Caching would
+// otherwise serve the preview variant to everyone), sets locals.preview, and
+// components gate on it via utils/features.ts.
+//
+// The cookie grants view-only access to unreleased UI, nothing more; it is
+// signed with ADMIN_PASS so it cannot be minted client-side, and it expires.
+
+export const PREVIEW_COOKIE = 'gop_preview';
+export const PREVIEW_TTL_S = 12 * 60 * 60;
+
+async function hmacHex(secret: string, msg: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+        'raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(msg));
+    return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function mintPreviewCookie(secret: string, nowS = Math.floor(Date.now() / 1000)): Promise<string> {
+    const expiry = nowS + PREVIEW_TTL_S;
+    return `v1.${expiry}.${await hmacHex(secret, `gop-preview:${expiry}`)}`;
+}
+
+export async function verifyPreviewCookie(value: string | undefined | null, secret: string | undefined,
+                                          nowS = Math.floor(Date.now() / 1000)): Promise<boolean> {
+    if (!value || !secret) return false;
+    const [v, expiryRaw, sig] = value.split('.');
+    const expiry = Number(expiryRaw);
+    if (v !== 'v1' || !Number.isFinite(expiry) || expiry < nowS || !sig) return false;
+    const expected = await hmacHex(secret, `gop-preview:${expiry}`);
+    if (sig.length !== expected.length) return false;
+    let diff = 0;
+    for (let i = 0; i < expected.length; i++) diff |= sig.charCodeAt(i) ^ expected.charCodeAt(i);
+    return diff === 0;
+}
+
+export function readCookie(header: string | null, name: string): string | null {
+    for (const part of (header ?? '').split(';')) {
+        const [k, ...rest] = part.trim().split('=');
+        if (k === name) return rest.join('=');
+    }
+    return null;
+}

--- a/astro/test/preview.test.ts
+++ b/astro/test/preview.test.ts
@@ -14,6 +14,10 @@ describe('preview cookie', () => {
     expect(await verifyPreviewCookie(`${v}.${Number(exp) + 1}.${sig}`, 's3cret')).toBe(false);
     const expired = await mintPreviewCookie('s3cret', Math.floor(Date.now() / 1000) - 100000);
     expect(await verifyPreviewCookie(expired, 's3cret')).toBe(false);
+    const atBoundary = await mintPreviewCookie('s3cret');
+    const exp = Number(atBoundary.split('.')[1]);
+    expect(await verifyPreviewCookie(atBoundary, 's3cret', exp)).toBe(false); // expiry is exclusive
+    expect(await verifyPreviewCookie(atBoundary, 's3cret', exp - 1)).toBe(true);
     expect(await verifyPreviewCookie(undefined, 's3cret')).toBe(false);
     expect(await verifyPreviewCookie(c, undefined)).toBe(false);
   });

--- a/astro/test/preview.test.ts
+++ b/astro/test/preview.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { mintPreviewCookie, verifyPreviewCookie, readCookie, PREVIEW_COOKIE } from '../src/utils/preview';
+import { isFeatureEnabled, FLAGS } from '../src/utils/features';
+
+describe('preview cookie', () => {
+  test('round-trips with the right secret', async () => {
+    const c = await mintPreviewCookie('s3cret');
+    expect(await verifyPreviewCookie(c, 's3cret')).toBe(true);
+  });
+  test('rejects a wrong secret, tampering, and expiry', async () => {
+    const c = await mintPreviewCookie('s3cret');
+    expect(await verifyPreviewCookie(c, 'other')).toBe(false);
+    const [v, exp, sig] = c.split('.');
+    expect(await verifyPreviewCookie(`${v}.${Number(exp) + 1}.${sig}`, 's3cret')).toBe(false);
+    const expired = await mintPreviewCookie('s3cret', Math.floor(Date.now() / 1000) - 100000);
+    expect(await verifyPreviewCookie(expired, 's3cret')).toBe(false);
+    expect(await verifyPreviewCookie(undefined, 's3cret')).toBe(false);
+    expect(await verifyPreviewCookie(c, undefined)).toBe(false);
+  });
+  test('readCookie parses a multi-cookie header', () => {
+    expect(readCookie(`a=1; ${PREVIEW_COOKIE}=v1.2.abc; b=2`, PREVIEW_COOKIE)).toBe('v1.2.abc');
+    expect(readCookie(null, PREVIEW_COOKIE)).toBe(null);
+  });
+});
+
+describe('feature flags', () => {
+  test('preview flags render only with locals.preview', () => {
+    FLAGS['__test'] = 'preview';
+    expect(isFeatureEnabled('__test', { preview: true })).toBe(true);
+    expect(isFeatureEnabled('__test', { preview: false })).toBe(false);
+    expect(isFeatureEnabled('__test', undefined)).toBe(false);
+    FLAGS['__test'] = 'on';
+    expect(isFeatureEnabled('__test', undefined)).toBe(true);
+    delete FLAGS['__test'];
+    expect(isFeatureEnabled('__test', { preview: true })).toBe(false);
+  });
+});

--- a/astro/test/preview.test.ts
+++ b/astro/test/preview.test.ts
@@ -15,9 +15,9 @@ describe('preview cookie', () => {
     const expired = await mintPreviewCookie('s3cret', Math.floor(Date.now() / 1000) - 100000);
     expect(await verifyPreviewCookie(expired, 's3cret')).toBe(false);
     const atBoundary = await mintPreviewCookie('s3cret');
-    const exp = Number(atBoundary.split('.')[1]);
-    expect(await verifyPreviewCookie(atBoundary, 's3cret', exp)).toBe(false); // expiry is exclusive
-    expect(await verifyPreviewCookie(atBoundary, 's3cret', exp - 1)).toBe(true);
+    const boundary = Number(atBoundary.split('.')[1]);
+    expect(await verifyPreviewCookie(atBoundary, 's3cret', boundary)).toBe(false); // expiry is exclusive
+    expect(await verifyPreviewCookie(atBoundary, 's3cret', boundary - 1)).toBe(true);
     expect(await verifyPreviewCookie(undefined, 's3cret')).toBe(false);
     expect(await verifyPreviewCookie(c, undefined)).toBe(false);
   });


### PR DESCRIPTION
Next slice of the admin/privileged-user proposal: preview in-development site changes on production, from the admin panel, before promoting them.

## How it works
- **Registry in code** — `utils/features.ts`: `'off' | 'preview' | 'on'` per flag. Ship UI wrapped in `isFeatureEnabled('my-flag', Astro.locals)` as `'preview'`; **promotion is a one-line `'preview' → 'on'` PR** — reviewed, deterministic, no runtime store, zero cost on the public path.
- **Preview cookie** — HMAC-SHA256 signed with `ADMIN_PASS`, 12 h expiry, `HttpOnly/Secure/SameSite=Lax`, toggled by the new **Preview** button on `/admin` (endpoint behind the existing basic auth). Constant-time compare; tamper/expiry/wrong-secret covered in tests.
- **Cache safety (the part that actually matters)** — middleware verifies the cookie once into `locals.preview`; after render, any previewing response gets `cache.set(false)` **and** `Cache-Control: no-store`, applied *after* the page's own cache options so nothing can re-enable caching. A preview variant can never enter Workers Caching and be served to the public — the exact failure mode from the live-page freeze (311d80e).
- **You always know which variant you're on** — a fixed "PREVIEW" pill (shared footer) whenever the cookie is active.

## Trying it
1. Merge + deploy, open `/admin`, click **Preview: off** → ON.
2. Add a flag `'my-thing': 'preview'` and wrap the new UI; only browsers with the cookie see it.
3. Promote by flipping to `'on'` (or park with `'off'`).

vitest 95/95 (6 new in `test/preview.test.ts`); worker compiles on Node 22.

## Summary by Sourcery

Enable admins to preview unreleased feature-flagged changes on production safely before promoting them to all users.

New Features:
- Add code-defined feature flags with off, preview, and on states for safely previewing and promoting unreleased UI.
- Add an authenticated admin control for enabling or disabling site-wide preview mode in the current browser.
- Display a persistent PREVIEW indicator while preview mode is active.

Bug Fixes:
- Prevent preview responses from being cached or served to public users by enforcing no-store behavior after page rendering.

Enhancements:
- Add expiring HMAC-signed preview cookies with tamper-resistant verification and constant-time signature comparison.

Tests:
- Add coverage for preview cookie issuance, validation, expiry, tampering, cookie parsing, and feature-flag behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-controlled Preview Mode for viewing unreleased features.
  * Added a Preview toggle to the admin page.
  * Displays a “PREVIEW” badge while preview mode is active.
  * Added feature-flag support for preview-only functionality.
  * Added signed, expiring preview access controls.

* **Bug Fixes**
  * Preview-mode responses are excluded from caching.

* **Tests**
  * Added coverage for preview access, expiration, tampering, cookie handling, and feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->