### PR TITLE
ci: single deploy concurrency group; test workflow runs on merge_group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,14 @@
 name: deploy
 
+# One deploy per burst: every job shares one concurrency group, queued not
+# cancelled (cancelling mid-compose is how the 2026-08-31 outage happened).
+# GitHub keeps at most one running + one pending run per group and supersedes
+# anything between, so N rapid merges collapse to at most two deploys -- and
+# with the merge queue batching PRs into a single push, exactly one.
+concurrency:
+  group: deploy
+  cancel-in-progress: false
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
 on:
   pull_request:
+  merge_group:
   push:
     branches: [main]
 jobs:


### PR DESCRIPTION
Workflow half of the merge-queue setup. Workflow-level `concurrency: deploy` (queued, never cancelled — cancelling mid-compose caused the 2026-08-31 outage) collapses any merge burst to at most one running + one pending deploy across BOTH jobs (the web job had no group, so a 4-PR train meant 4 worker deploys and 4 cold Workers caches). `test.yml` gains the `merge_group` trigger so the required check can report inside merge-queue batches. The queue itself is a repo ruleset — proposed separately.

## Summary by Sourcery

Coordinate deployment runs and enable required tests to execute within merge queue batches.

Enhancements:
- Serialize deployment workflow runs through a shared, non-cancelling concurrency group to limit queued deployments and prevent overlapping deploy bursts.
- Run the test workflow for merge queue batches via the `merge_group` trigger.

CI:
- Update deployment and test workflow concurrency and event configuration for merge queue operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Deployment runs are now coordinated to allow one active run and one queued run, reducing conflicts during rapid deployments.
  - Automated checks now run for merge-queue validation in addition to pull requests and direct updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->