### PR TITLE
fix(game): preview feedback — charts restored, bigger marks, Latest only while live

### DIFF
--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -165,7 +165,7 @@ Target Matrix
   --mark-stop: #6c757d;
   --mark-explosive: #0dcaf0;
 }
-.play-marks { white-space: nowrap; margin-left: .5rem; font-size: 15px; line-height: 1; vertical-align: -1px; }
+.play-marks { white-space: nowrap; margin-left: .5rem; font-size: 26px; line-height: 1; vertical-align: -4px; } /* ~3/4 of the 35px team logo */
 .play-marks .pi + .pi, .play-marks .pi + .pi-pill, .play-marks .pi-pill + .pi, .play-marks .pi-pill + .pi-pill { margin-left: 4px; }
 /* Placement: beside the team logo, never under it.
    Measured on a real game page at 1440px: a play row is 45px tall and that
@@ -188,7 +188,7 @@ Target Matrix
        row to row. A fixed slot keeps every logo on the same x. */
     .play-offense-cell { display: flex; align-items: center; justify-content: flex-start; gap: 4px; padding-left: 6px; }
     .play-offense-cell > a { flex: 0 0 35px; }
-    .play-marks-beside { display: flex; flex-wrap: wrap; align-content: center; gap: 2px; margin-left: 0; max-width: 55px; max-height: 35px; }
+    .play-marks-beside { display: flex; flex-wrap: wrap; align-content: center; gap: 2px; margin-left: 0; max-width: 56px; max-height: 56px; }
     .play-marks-beside .pi + .pi, .play-marks-beside .pi + .pi-pill,
     .play-marks-beside .pi-pill + .pi, .play-marks-beside .pi-pill + .pi-pill { margin-left: 0; }
 }
@@ -200,7 +200,7 @@ Target Matrix
 }
 /* SACK / TFL are text tags: fixed 14px so they sit inside the text line and never scale with the slot;
    neutral outline (chosen 2026-09-01 over red/solid) in the stop tone. */
-.pi-pill { display: inline-block; box-sizing: border-box; vertical-align: 1px; height: 14px; padding: 0 4px; border: 1.5px solid var(--mark-stop); border-radius: 3px; color: var(--mark-stop); background: transparent; font: 700 9.5px/11px Chivo, system-ui, sans-serif; letter-spacing: .06em; text-transform: uppercase; }
+.pi-pill { display: inline-block; box-sizing: border-box; vertical-align: 4px; height: 19px; padding: 0 5px; border: 2px solid var(--mark-stop); border-radius: 4px; color: var(--mark-stop); background: transparent; font: 700 12.5px/15px Chivo, system-ui, sans-serif; letter-spacing: .06em; text-transform: uppercase; }
 .pi { width: 1em; height: 1em; display: inline-block; vertical-align: -.15em; }
 .pi-td, .pi-td-xp, .pi-td-xp-miss, .pi-td-2pt, .pi-td-2pt-miss, .pi-fg, .pi-safety { --c: var(--mark-score); }
 .pi-def, .pi-def-2pt { --c: var(--mark-turnover); } /* defensive score: same glyph, turnover colour */

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -100,7 +100,9 @@ const previewUrlParams = new URLSearchParams({
 
 // The top of the page answers "what just happened" before any chart does.
 // Newest first here -- this strip is read downward as a feed, unlike All Plays.
-const latestPlays = game.plays.slice(-5).toReversed();
+// Live and halftime only: once the game is final the whole page is the recap,
+// and a "Latest" strip repeating the last five plays is noise.
+const latestPlays = gameStatus.type.completed === true ? [] : game.plays.slice(-5).toReversed();
 // Quarters actually played, so overtime only offers a button when it happened.
 const periodsPlayed = [...new Set(game.plays.map((p: any) => Number(p.period)).filter(Number.isFinite))].sort((a, b) => a - b);
 const lastPlay: any = game.plays.at(-1);
@@ -117,8 +119,8 @@ const scrollerItems: ScrollerItem[] = [
     // The Latest panel only renders when there are plays, so a game with none
     // must not advertise an anchor that isn't on the page.
     ...(latestPlays.length > 0 ? [{ href: "#latest", title: "Latest" }] : []),
-    { href: "#wpChart", title: "WP Chart" },
-    { href: "#epChart", title: "EPA Chart" },
+    { href: "#wp-section", title: "WP Chart" },
+    { href: "#ep-section", title: "EPA Chart" },
     { href: "#team-stats", title: "Team Stats" },
     { href: "#player-stats", title: "Player Stats" },
     { href: "#big-plays", title: "Big Plays" },
@@ -254,12 +256,15 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
         </div>
         <div class="container-fluid">
             <div class="row mb-3">
-                <div id="wpChart" class="col-lg-6 ms-sm-auto px-md-4">
+                <!-- The nav anchor must NOT be wpChart/epChart: those ids belong to the canvases
+     inside the Svelte charts, and a duplicate id makes getElementById hand
+     Chart.js the wrapper div -- both charts then silently never draw. -->
+                <div id="wp-section" class="col-lg-6 ms-sm-auto px-md-4">
                     <WinProbabilityChart client:only id={id} homeComp={homeComp} awayComp={awayComp} gameStatus={game.header.competitions[0].status} homeTeamSpread={game.homeTeamSpread} overUnder={game.overUnder} plays={wpPlays} percentiles={percentiles} gei={game.gei}>
                         <FallbackSpinner slot="fallback" />
                     </WinProbabilityChart>
                 </div>
-                <div id="epChart" class="col-lg-6 ms-sm-auto px-md-4">
+                <div id="ep-section" class="col-lg-6 ms-sm-auto px-md-4">
                     <ExpectedPointsChart client:only id={id} plays={epPlays} homeTeam={game.teamInfo.home} awayTeam={game.teamInfo.away}>
                         <FallbackSpinner slot="fallback" />
                     </ExpectedPointsChart>

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -84,10 +84,17 @@ describe('GamePage renders a finished game end to end', () => {
         // a wrapper div carrying id="wpChart" shadowed the canvas and both
         // charts silently never drew (the Svelte components getElementById
         // their own canvases)
-        expect((html.match(/id="wpChart"/g) ?? []).length).toBeLessThanOrEqual(1);
-        expect((html.match(/id="epChart"/g) ?? []).length).toBeLessThanOrEqual(1);
+        // client:only means the canvases are NOT in the SSR output at all --
+        // they arrive at hydration. So the exact SSR invariant is zero
+        // claimants on those ids: any server-rendered element carrying them
+        // would shadow the canvas when it mounts.
+        expect((html.match(/id="wpChart"/g) ?? []).length).toBe(0);
+        expect((html.match(/id="epChart"/g) ?? []).length).toBe(0);
         expect(html).toContain('id="wp-section"');
         expect(html).toContain('id="ep-section"');
+        // and the islands that will mount them are present
+        expect(html).toMatch(/astro-island[^>]+WinProbabilityChart/);
+        expect(html).toMatch(/astro-island[^>]+ExpectedPointsChart/);
     });
 
     test('the book rows render with their EPA beside them', () => {

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -73,11 +73,21 @@ describe('GamePage renders a finished game end to end', () => {
         expect(html).toMatch(/Maverick McIvor[\s\S]{0,400}?18 LNG/);
     });
 
-    test('the Latest strip leads the page, newest play first', () => {
-        expect(html).toContain('id="latest"');
-        // it must sit above the win probability chart, which was the old first panel
-        expect(html.indexOf('id="latest"')).toBeLessThan(html.indexOf('id="wpChart"'));
-        expect(html).toMatch(/Final\. Last drive: [^<]+, [^<]+\./);
+    test('a final game has no Latest strip -- the page IS the recap', () => {
+        // the fixture game is completed; the strip (and its nav entry) only
+        // renders while the game is live
+        expect(html).not.toContain('id="latest"');
+        expect(html).not.toContain('href="#latest"');
+    });
+
+    test('the chart canvas ids are unique -- Chart.js finds the canvas, not a wrapper', () => {
+        // a wrapper div carrying id="wpChart" shadowed the canvas and both
+        // charts silently never drew (the Svelte components getElementById
+        // their own canvases)
+        expect((html.match(/id="wpChart"/g) ?? []).length).toBeLessThanOrEqual(1);
+        expect((html.match(/id="epChart"/g) ?? []).length).toBeLessThanOrEqual(1);
+        expect(html).toContain('id="wp-section"');
+        expect(html).toContain('id="ep-section"');
     });
 
     test('the book rows render with their EPA beside them', () => {


### PR DESCRIPTION
Three fixes from preview review of the v2 game page (all behind the `game-page-v2` flag; public classic page untouched):

1. **WP/EP charts were invisible on v2** — root cause: the wrapper divs took `id="wpChart"`/`id="epChart"` (added for the nav-anchor test), but those ids belong to the **canvases inside the Svelte components**; `getElementById` returned the wrapper and Chart.js silently never drew. Anchors renamed `wp-section`/`ep-section`; a test now asserts the canvas ids are unique in the document.
2. **Play marks sized to ~¾ of the team logo** — 15px → 26px (logo is 35px), pills scaled to match (19px tall, 12.5px type), beside-container bounds widened.
3. **Latest strip disappears at final** — it renders only while the game is live; the final page is the recap.

vitest 148/148 (new canvas-uniqueness test; the Latest test now asserts absence on the final fixture).

## Summary by Sourcery

Fix v2 game-page preview issues by restoring chart rendering, improving play-mark visibility, and limiting Latest feedback to games still in progress.

Bug Fixes:
- Restore WP and EPA chart rendering by preventing navigation anchors from conflicting with chart canvas identifiers.
- Show the Latest plays strip only for live or halftime games, leaving completed games to the recap view.

Enhancements:
- Increase play-mark and text-pill sizing and expand their layout space beside team logos.

Tests:
- Add coverage ensuring completed games omit the Latest strip and chart canvas identifiers remain unshadowed.