### PR TITLE
feat(game): whole-page ?span= time filter (phase 1)

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -537,7 +537,7 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
                     <Panel id="drives" title="Drives">
                         <div class="row" slot="panel-body">
                             {
-                                (gameDrives.length == 0) && (<p class="text-center text-muted">No drives in this game</p>)
+                                (spanDrives.length == 0) && (<p class="text-center text-muted">{activeSpan ? `No drives in ${activeSpan.label}` : "No drives in this game"}</p>)
                             }
                             {
                                 (spanDrives.length > 0) && <DrivesTable drives={spanDrives} gamePlays={game.plays} prefix='drives' expandable={true} homeTeam={game.teamInfo.home} awayTeam={game.teamInfo.away} isNeutralSite={game.header.competitions[0].neutralSite} showGuide={true} />

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -15,6 +15,7 @@ import PlayFilters from './plays/PlayFilters.astro';
 import PlayFocus from './plays/PlayFocus.astro';
 import PlayMarkSprite from './plays/PlayMarkSprite.astro';
 import { threeAndOutPlays } from '../../utils/playIcons';
+import { availableSpans, parseSpan } from '../../utils/span';
 import TeamPanel from '../../layouts/panel/TeamPanel.astro';
 import PlayerBoxScore from './metrics/PlayerBoxScore.astro';
 import TraditionalTeamStats from './metrics/TraditionalTeamStats.astro';
@@ -63,6 +64,20 @@ salvageGame(game);
 // drive-shaped mark: flag the punt that ends a three-and-out so PlayMarks can render it per row
 for (const n of threeAndOutPlays(game.plays)) { const p = game.plays.find((x: any) => x.game_play_number === n); if (p) (p as any).three_and_out = true; }
 
+// ?span= filters the whole page to a time window (utils/span.ts). game.plays is
+// filtered ONCE here, before any derivation, so every astro-computed section --
+// play tables, drives, situational, defensive box, traditional stats, penalties
+// -- recomputes for free. The charts and the Latest strip deliberately keep the
+// full game (fullGamePlays); the python-computed advanced boxes stay full-game
+// until the API grows the same parameter, and the banner below says so.
+const fullGamePlays = game.plays;
+const activeSpan = parseSpan(Astro.url.searchParams.get('span'));
+if (activeSpan) {
+    game.plays = fullGamePlays.filter((p: any) => activeSpan.test(p));
+    game.scoringPlays = game.scoringPlays.filter((p: any) => activeSpan.test(p));
+}
+const spanPills = availableSpans(fullGamePlays);
+
 const percentiles = await retrievePercentiles((CURRENT_YEAR == game.season.year) ? LAST_YEAR : game.season.year, undefined);
 const homeComp = game.header.competitions[0].competitors[0];
 const awayComp = game.header.competitions[0].competitors[1];
@@ -105,7 +120,7 @@ const previewUrlParams = new URLSearchParams({
 // Newest first here -- this strip is read downward as a feed, unlike All Plays.
 // Live and halftime only: once the game is final the whole page is the recap,
 // and a "Latest" strip repeating the last five plays is noise.
-const latestPlays = gameStatus.type.completed === true ? [] : game.plays.slice(-5).toReversed();
+const latestPlays = gameStatus.type.completed === true ? [] : fullGamePlays.slice(-5).toReversed();
 // Quarters actually played, so overtime only offers a button when it happened.
 const periodsPlayed = [...new Set(game.plays.map((p: any) => Number(p.period)).filter(Number.isFinite))].sort((a, b) => a - b);
 const lastPlay: any = game.plays.at(-1);
@@ -160,13 +175,15 @@ const mostImpPlays = game.plays.toSorted((a, b) => {
 
 let gameDrives = game.drives.current ? (game.drives.previous ?? []).concat([game.drives.current]) : (game.drives.previous ?? []);
 gameDrives = deduplicateByKey(gameDrives, "id");
-const epPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
+// under a span, only drives that intersect the window
+const spanDrives = activeSpan ? gameDrives.filter((d: any) => (d.plays ?? []).some((p: any) => activeSpan.test(p))) : gameDrives;
+const epPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
     return {
         pos_team: p.pos_team, 
         expectedPoints: p.expectedPoints
     }
 });
-const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
+const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
     return {
         pos_team: p.pos_team, 
         period: p.period,
@@ -244,6 +261,18 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
             </header>
 
             <NavScroller items={scrollerItems} />
+            <div class="d-flex align-items-center flex-wrap gap-1 px-3 py-1 span-pills">
+                <a class={`btn btn-sm ${activeSpan ? 'btn-outline-secondary' : 'btn-secondary'}`} href={`/game/${id}`}>Full game</a>
+                {spanPills.map((sp) => (
+                    <a class={`btn btn-sm ${activeSpan?.key === sp.key ? 'btn-secondary' : 'btn-outline-secondary'}`} href={`/game/${id}?span=${sp.key}`}>{sp.label}</a>
+                ))}
+            </div>
+            {activeSpan && (
+                <div class="alert alert-info py-1 px-3 mb-2 small">
+                    Showing <strong>{activeSpan.label}</strong> only. Play-by-play, drives, situational, defensive, traditional and penalty
+                    sections are filtered; the charts and advanced box scores still show the full game.
+                </div>
+            )}
             {latestPlays.length > 0 && (
                 <div class="row mb-3">
                     <div class="col-md-12 ms-sm-auto col-lg-12 px-md-4">
@@ -511,7 +540,7 @@ const wpPlays = game.plays.filter(p => (p.scrimmage_play == true)).map(p => {
                                 (gameDrives.length == 0) && (<p class="text-center text-muted">No drives in this game</p>)
                             }
                             {
-                                (gameDrives.length > 0) && <DrivesTable drives={gameDrives} gamePlays={game.plays} prefix='drives' expandable={true} homeTeam={game.teamInfo.home} awayTeam={game.teamInfo.away} isNeutralSite={game.header.competitions[0].neutralSite} showGuide={true} />
+                                (spanDrives.length > 0) && <DrivesTable drives={spanDrives} gamePlays={game.plays} prefix='drives' expandable={true} homeTeam={game.teamInfo.home} awayTeam={game.teamInfo.away} isNeutralSite={game.header.competitions[0].neutralSite} showGuide={true} />
                             }
                         </div>
                     </Panel>

--- a/astro/src/utils/span.ts
+++ b/astro/src/utils/span.ts
@@ -1,0 +1,79 @@
+// A time window over one game, parsed from ?span= on the game page. Applied
+// once in GamePage frontmatter (game.plays is filtered before any derivation),
+// so every astro-computed section -- play tables, drives, situational,
+// defensive box, traditional stats, penalties -- recomputes for free. The
+// python-computed advanced boxes stay full-game until the API grows the same
+// parameter; the charts deliberately keep the whole game for context.
+//
+// Specs: q1..q4, ot (any period > 4), h1, h2, or "<from>-<to>" in game-clock
+// seconds remaining (adj_TimeSecsRem: 3600 = Q1 15:00 counting down to 0).
+// Clock ranges are normalized to 30-second buckets so crawlers cannot mint an
+// unbounded set of cache keys, and apply to regulation only (the pipeline's
+// adjusted clock collapses in OT).
+
+export interface Span {
+    key: string;
+    label: string;
+    test: (p: { period?: unknown; ['start.adj_TimeSecsRem']?: unknown }) => boolean;
+}
+
+const PERIOD_SPANS: Record<string, { label: string; periods?: number[]; ot?: boolean }> = {
+    q1: { label: 'Q1', periods: [1] },
+    q2: { label: 'Q2', periods: [2] },
+    q3: { label: 'Q3', periods: [3] },
+    q4: { label: 'Q4', periods: [4] },
+    h1: { label: '1st half', periods: [1, 2] },
+    h2: { label: '2nd half', periods: [3, 4] },
+    ot: { label: 'Overtime', ot: true },
+};
+
+/** "3300" -> "Q1 10:00" -- where a game clock reading lives. */
+export function fmtAdjClock(sec: number): string {
+    const q = sec > 2700 ? 1 : sec > 1800 ? 2 : sec > 900 ? 3 : 4;
+    let rem = sec - (4 - q) * 900;
+    const mm = Math.floor(rem / 60), ss = rem % 60;
+    return `Q${q} ${mm}:${String(ss).padStart(2, '0')}`;
+}
+
+export function parseSpan(raw: string | null | undefined): Span | null {
+    if (!raw) return null;
+    const key = raw.trim().toLowerCase();
+    const named = PERIOD_SPANS[key];
+    if (named) {
+        return {
+            key,
+            label: named.label,
+            test: (p) => {
+                const n = p.period == null ? NaN : Number(p.period);
+                return named.ot ? n > 4 : Number.isFinite(n) && (named.periods as number[]).includes(n);
+            },
+        };
+    }
+    const m = key.match(/^(\d{1,4})-(\d{1,4})$/);
+    if (!m) return null;
+    const bucket = (n: number) => Math.round(n / 30) * 30;
+    const from = bucket(Math.min(Number(m[1]), 3600));
+    const to = bucket(Math.max(Number(m[2]), 0));
+    if (!(from > to)) return null; // the clock counts down: from must be the earlier moment
+    return {
+        key: `${from}-${to}`,
+        label: `${fmtAdjClock(from)} → ${fmtAdjClock(to)}`,
+        test: (p) => {
+            const n = p['start.adj_TimeSecsRem'] == null ? NaN : Number(p['start.adj_TimeSecsRem']);
+            const period = p.period == null ? NaN : Number(p.period);
+            return Number.isFinite(n) && n <= from && n >= to && !(period > 4);
+        },
+    };
+}
+
+/** The pill row: Full + only the windows the game actually played. */
+export function availableSpans(plays: { period?: unknown }[]): { key: string; label: string }[] {
+    const periods = new Set(plays.map((p) => Number(p.period)).filter((n) => Number.isFinite(n) && n >= 1));
+    const out: { key: string; label: string }[] = [];
+    for (const key of ['q1', 'q2', 'h1', 'q3', 'q4', 'h2'] as const) {
+        const def = PERIOD_SPANS[key];
+        if ((def.periods as number[]).some((n) => periods.has(n))) out.push({ key, label: def.label });
+    }
+    if ([...periods].some((n) => n > 4)) out.push({ key: 'ot', label: 'Overtime' });
+    return out;
+}

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -400,3 +400,36 @@ describe('the classic snapshot serves the public while v2 is in preview', () => 
         expect(isFeatureEnabled('game-page-v2', {})).toBe(false);
     });
 });
+
+describe('the ?span= filter narrows the page to a window', () => {
+    test('a Q3 span keeps only third-quarter rows in the All Plays table', async () => {
+        const { retrieveProcessedGame } = await import('../src/resources/python');
+        const game: any = await retrieveProcessedGame(GAME_ID, 30);
+        const { default: GamePage } = await import('../src/components/game/GamePage.astro');
+        const spanned = await container.renderToString(GamePage, {
+            props: { id: GAME_ID, game },
+            request: new Request(`https://gameonpaper.com/game/${GAME_ID}?span=q3`),
+        });
+        const body = spanned.slice(spanned.indexOf('data-plays-body="all"'));
+        const rows = [...body.slice(0, body.indexOf('</tbody>')).matchAll(/data-period="(\d+)"/g)].map((m) => m[1]);
+        expect(rows.length).toBeGreaterThan(10);
+        expect(new Set(rows)).toEqual(new Set(['3']));
+        // the pills and the banner are on
+        expect(spanned).toContain('?span=q1');
+        expect(spanned).toMatch(/Showing <strong>Q3<\/strong> only/);
+        // the charts keep the whole game: the WP chart island still carries all four periods
+        expect(spanned).toMatch(/astro-island[^>]+WinProbabilityChart/);
+    });
+
+    test('no span means no banner, and the pills are still offered', async () => {
+        const { retrieveProcessedGame } = await import('../src/resources/python');
+        const game: any = await retrieveProcessedGame(GAME_ID, 30);
+        const { default: GamePage } = await import('../src/components/game/GamePage.astro');
+        const plain = await container.renderToString(GamePage, {
+            props: { id: GAME_ID, game },
+            request: new Request(`https://gameonpaper.com/game/${GAME_ID}`),
+        });
+        expect(plain).not.toContain('Showing <strong>');
+        expect(plain).toContain('?span=q1');
+    });
+});

--- a/astro/test/span.test.ts
+++ b/astro/test/span.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import { parseSpan, availableSpans, fmtAdjClock } from '../src/utils/span';
+
+const p = (period: number | null, adj?: number) => ({ period, 'start.adj_TimeSecsRem': adj });
+
+describe('parseSpan', () => {
+    test('named spans select their periods', () => {
+        expect(parseSpan('q3')!.test(p(3))).toBe(true);
+        expect(parseSpan('q3')!.test(p(4))).toBe(false);
+        expect(parseSpan('h1')!.test(p(2))).toBe(true);
+        expect(parseSpan('h2')!.test(p(2))).toBe(false);
+        expect(parseSpan('ot')!.test(p(5))).toBe(true);
+        expect(parseSpan('ot')!.test(p(4))).toBe(false);
+        expect(parseSpan('Q2')!.key).toBe('q2'); // case-insensitive
+    });
+    test('null periods never match anything', () => {
+        for (const k of ['q1', 'h1', 'ot']) expect(parseSpan(k)!.test(p(null))).toBe(false);
+    });
+    test('clock ranges: inclusive window on the countdown clock, regulation only', () => {
+        const s = parseSpan('1800-900')!; // Q2 end through Q3
+        expect(s.test(p(3, 1200))).toBe(true);
+        expect(s.test(p(2, 1800))).toBe(true);
+        expect(s.test(p(1, 3000))).toBe(false);
+        expect(s.test(p(4, 300))).toBe(false);
+        expect(s.test(p(5, 1200))).toBe(false); // OT clock readings are not comparable
+        expect(s.test(p(3, undefined))).toBe(false);
+    });
+    test('clock ranges normalize to 30s buckets and reject nonsense', () => {
+        expect(parseSpan('1807-893')!.key).toBe('1800-900');
+        expect(parseSpan('900-1800')).toBe(null); // backwards
+        expect(parseSpan('900-900')).toBe(null);
+        expect(parseSpan('banana')).toBe(null);
+        expect(parseSpan('')).toBe(null);
+        expect(parseSpan(null)).toBe(null);
+    });
+});
+
+test('fmtAdjClock places the reading in its quarter', () => {
+    expect(fmtAdjClock(3600)).toBe('Q1 15:00');
+    expect(fmtAdjClock(2700)).toBe('Q2 15:00');
+    expect(fmtAdjClock(1350)).toBe('Q3 7:30');
+    expect(fmtAdjClock(0)).toBe('Q4 0:00');
+});
+
+test('availableSpans offers only played windows', () => {
+    const reg = [p(1), p(2), p(3), p(4)];
+    expect(availableSpans(reg).map((s) => s.key)).toEqual(['q1', 'q2', 'h1', 'q3', 'q4', 'h2']);
+    expect(availableSpans([p(1), p(2)]).map((s) => s.key)).toEqual(['q1', 'q2', 'h1']);
+    expect(availableSpans([...reg, p(5)]).map((s) => s.key)).toContain('ot');
+    expect(availableSpans([p(null)])).toEqual([]);
+});


### PR DESCRIPTION
Phase 1 of `plans/2026-09-03-gop-game-page-span-filter.md` (preview feedback item 8). `?span=q3|h1|ot|<from>-<to>` filters `game.plays` once in frontmatter — play tables, drives, situational, defensive, traditional and penalty sections all recompute for free; pills are plain links (shareable URLs, back button works, cache-keyed by URL with 30-second clock buckets); a banner names the window and is explicit that charts and the python-computed advanced boxes remain full-game (API phase next). Regulation-only for clock ranges (the adjusted clock collapses in OT). All inside the `game-page-v2` preview wall. vitest 187/187 incl. a render test proving a `?span=q3` page contains only period-3 rows.

## Summary by Sourcery

Add URL-based time-window filtering to the v2 game page while preserving full-game chart and advanced-stat context.

New Features:
- Add shareable whole-page game time-window filters for quarters, halves, overtime, and regulation clock ranges.
- Add contextual span controls and messaging that distinguish filtered game sections from full-game charts and advanced box scores.

Enhancements:
- Centralize span parsing, clock-range normalization, and available-window discovery for consistent filtering behavior.
- Keep latest-play context and chart data based on the full game while filtering derived play and drive content.

Tests:
- Add utility and render coverage for named spans, clock ranges, overtime handling, available pills, banners, and quarter-specific play rows.