### PR TITLE
feat(game): box-score player names filter the play-by-play

### DIFF
--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -215,4 +215,5 @@ Target Matrix
 /* Box-score player names double as play-by-play filters (PlayFocus). */
 .focus-jump { background: none; border: 0; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline dotted; text-underline-offset: 3px; }
 .focus-jump:hover, .focus-jump:focus-visible { text-decoration-style: solid; }
+.focus-jump-dead { text-decoration: none; cursor: default; }
 

--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -211,3 +211,8 @@ Target Matrix
 .pi-penalty, .pi-penalty-declined, .pi-penalty-offset { --c: var(--mark-flag); }
 .pi-explosive { --c: var(--mark-explosive); }
 .play-marks-legend .pi { font-size: 15px; }
+
+/* Box-score player names double as play-by-play filters (PlayFocus). */
+.focus-jump { background: none; border: 0; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline dotted; text-underline-offset: 3px; }
+.focus-jump:hover, .focus-jump:focus-visible { text-decoration-style: solid; }
+

--- a/astro/src/components/game/metrics/PlayerBoxScore.astro
+++ b/astro/src/components/game/metrics/PlayerBoxScore.astro
@@ -70,7 +70,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
             {
                 (pass.length > 0) && (pass.map((p) => (
                     <tr>
-                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.passer_player_name} data-role="pass" title="Filter the play-by-play to this player">{p.passer_player_name}</button></td>
+                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.passer_player_name} data-team={teamId} data-role="pass" title="Filter the play-by-play to this player">{p.passer_player_name}</button></td>
                         <td style="text-align: left;">{p.Comp}/{p.Att}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Pass_TD} TD, {p.Int} INT, {p.Sck} Sck, {roundNumber(p.exp_qbr, 2, 1)} xQBR<span title="Air yards on completions / yards after catch; aDOT = average depth of target (air yards per attempt)">{airLine(p)}</span><span title="Longest completion, and this passer's single best play by EPA and by win probability added">{bestTail(passBest, p.passer_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPA || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
@@ -90,7 +90,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
             {
                 (rush.length > 0) && (rush.map((p) => (
                     <tr>
-                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.rusher_player_name} data-role="rush" title="Filter the play-by-play to this player">{p.rusher_player_name}</button></td>
+                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.rusher_player_name} data-team={teamId} data-role="rush" title="Filter the play-by-play to this player">{p.rusher_player_name}</button></td>
                         <td style="text-align: left;">{p.Car} carr{(Math.abs(p.Car) == 1) ? "y" : "ies"}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rush_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Longest carry, and this rusher's single best play by EPA and by win probability added">{bestTail(rushBest, p.rusher_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPC || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
@@ -110,7 +110,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
             {
                 (receiver.length > 0) && (receiver.map((p) => (
                     <tr>
-                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.receiver_player_name} data-role="recv" title="Filter the play-by-play to this player">{p.receiver_player_name}</button></td>
+                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.receiver_player_name} data-team={teamId} data-role="recv" title="Filter the play-by-play to this player">{p.receiver_player_name}</button></td>
                         <td style="text-align: left;">{p.Rec} catch{(Math.abs(p.Rec) == 1) ? "" : "es"} ({p.Tar} target{(Math.abs(p.Tar) == 1) ? "" : "s"}), {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rec_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Air yards on catches / yards after catch; aDOT = average depth of target (air yards per target)">{airLine(p)}</span><span title="Longest catch, and this receiver's single best play by EPA and by win probability added">{bestTail(recvBest, p.receiver_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPT || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>

--- a/astro/src/components/game/metrics/PlayerBoxScore.astro
+++ b/astro/src/components/game/metrics/PlayerBoxScore.astro
@@ -70,7 +70,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
             {
                 (pass.length > 0) && (pass.map((p) => (
                     <tr>
-                        <td style="text-align: left;">{p.passer_player_name}</td>
+                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.passer_player_name} data-role="pass" title="Filter the play-by-play to this player">{p.passer_player_name}</button></td>
                         <td style="text-align: left;">{p.Comp}/{p.Att}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Pass_TD} TD, {p.Int} INT, {p.Sck} Sck, {roundNumber(p.exp_qbr, 2, 1)} xQBR<span title="Air yards on completions / yards after catch; aDOT = average depth of target (air yards per attempt)">{airLine(p)}</span><span title="Longest completion, and this passer's single best play by EPA and by win probability added">{bestTail(passBest, p.passer_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPA || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
@@ -90,7 +90,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
             {
                 (rush.length > 0) && (rush.map((p) => (
                     <tr>
-                        <td style="text-align: left;">{p.rusher_player_name}</td>
+                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.rusher_player_name} data-role="rush" title="Filter the play-by-play to this player">{p.rusher_player_name}</button></td>
                         <td style="text-align: left;">{p.Car} carr{(Math.abs(p.Car) == 1) ? "y" : "ies"}, {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rush_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Longest carry, and this rusher's single best play by EPA and by win probability added">{bestTail(rushBest, p.rusher_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPC || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>
@@ -110,7 +110,7 @@ receiver = receiver.filter(p => (p.receiver_player_name?.length ?? 0) > 0).toSor
             {
                 (receiver.length > 0) && (receiver.map((p) => (
                     <tr>
-                        <td style="text-align: left;">{p.receiver_player_name}</td>
+                        <td style="text-align: left;"><button type="button" class="focus-jump" data-focus-jump data-name={p.receiver_player_name} data-role="recv" title="Filter the play-by-play to this player">{p.receiver_player_name}</button></td>
                         <td style="text-align: left;">{p.Rec} catch{(Math.abs(p.Rec) == 1) ? "" : "es"} ({p.Tar} target{(Math.abs(p.Tar) == 1) ? "" : "s"}), {p.Yds} yd{(Math.abs(p.Yds) == 1) ? "" : "s"}, {p.Rec_TD} TD, {p.Fum} Fum ({p.Fum_Lost} lost)<span title="Air yards on catches / yards after catch; aDOT = average depth of target (air yards per target)">{airLine(p)}</span><span title="Longest catch, and this receiver's single best play by EPA and by win probability added">{bestTail(recvBest, p.receiver_player_name)}</span></td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.YPT || 0, 2, 2)}</td>
                         <td class="numeral" style="text-align: center;">{roundNumber(p.EPA_per_Play, 2, 2)}</td>

--- a/astro/src/components/game/plays/PlayFocus.astro
+++ b/astro/src/components/game/plays/PlayFocus.astro
@@ -81,9 +81,18 @@ const tags = (Object.keys(PLAY_TAGS) as (keyof typeof PLAY_TAGS)[])
     // dead button; strip the affordance so nothing advertises a click it cannot honor.
     {
         const sel = document.querySelector<HTMLElement>('[data-play-focus="all"]')?.querySelector('select');
-        const known = new Set([...(sel?.options ?? [])].map((o) => `${(o as HTMLOptionElement).dataset.name}|${(o as HTMLOptionElement).dataset.role}`));
-        for (const btn of document.querySelectorAll<HTMLElement>('[data-focus-jump]')) {
-            if (!known.has(`${btn.dataset.name}|${btn.dataset.role}`)) btn.classList.add('focus-jump-dead');
+        const opts = [...(sel?.options ?? [])] as HTMLOptionElement[];
+        for (const btn of document.querySelectorAll<HTMLButtonElement>('[data-focus-jump]')) {
+            // same tolerant team semantics as the click matcher, or a name that
+            // exists only on the other team would look alive and do nothing
+            const alive = opts.some((o) =>
+                o.dataset.name === btn.dataset.name && o.dataset.role === btn.dataset.role
+                && (!btn.dataset.team || !o.dataset.team || o.dataset.team === btn.dataset.team));
+            if (!alive) {
+                btn.classList.add('focus-jump-dead');
+                btn.disabled = true;
+                btn.removeAttribute('title');
+            }
         }
     }
 

--- a/astro/src/components/game/plays/PlayFocus.astro
+++ b/astro/src/components/game/plays/PlayFocus.astro
@@ -20,6 +20,8 @@ const options = ix.players.flatMap((p) =>
         .filter((r) => (p.roles[r] ?? 0) > 0)
         .map((r) => ({
             value: `r:${r}:${p.id}`,
+            name: p.name,
+            role: r,
             team: p.teamId,
             label: `${p.name} — ${ROLE_LABEL[r].toLowerCase()} (${p.roles[r]})`,
             n: p.roles[r] ?? 0,
@@ -45,7 +47,7 @@ const tags = (Object.keys(PLAY_TAGS) as (keyof typeof PLAY_TAGS)[])
             )}
             {options.length > 0 && byTeam.filter((g) => g.opts.length).map((g) => (
                 <optgroup label={nameOf(g.id)}>
-                    {g.opts.map((o) => <option value={o.value}>{o.label}</option>)}
+                    {g.opts.map((o) => <option value={o.value} data-name={o.name} data-role={o.role}>{o.label}</option>)}
                 </optgroup>
             ))}
         </select>
@@ -56,6 +58,23 @@ const tags = (Object.keys(PLAY_TAGS) as (keyof typeof PLAY_TAGS)[])
 <script>
     // Deferred module, not `is:inline`: this renders above the table it drives, so an
     // inline script would look up a tbody that has not been parsed yet.
+    // Box-score names carry data-focus-jump: clicking one selects that player's
+    // matching role in the "all" focus select and jumps to the table. The match
+    // is by (name, role) because the advanced box rows carry no player id.
+    document.addEventListener('click', (e) => {
+        const btn = (e.target as HTMLElement)?.closest?.('[data-focus-jump]') as HTMLElement | null;
+        if (!btn) return;
+        const bar = document.querySelector<HTMLElement>('[data-play-focus="all"]');
+        const sel = bar?.querySelector('select');
+        if (!sel) return;
+        const want = [...sel.options].find((o) =>
+            o.dataset.name === btn.dataset.name && o.dataset.role === btn.dataset.role);
+        if (!want) return;
+        sel.value = want.value;
+        sel.dispatchEvent(new Event('change'));
+        document.querySelector('[data-plays-body="all"]')?.closest('table')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+
     for (const bar of document.querySelectorAll<HTMLElement>('[data-play-focus]')) {
         const target = bar.dataset.playFocus;
         const body = document.querySelector<HTMLElement>(`[data-plays-body="${target}"]`);

--- a/astro/src/components/game/plays/PlayFocus.astro
+++ b/astro/src/components/game/plays/PlayFocus.astro
@@ -47,7 +47,7 @@ const tags = (Object.keys(PLAY_TAGS) as (keyof typeof PLAY_TAGS)[])
             )}
             {options.length > 0 && byTeam.filter((g) => g.opts.length).map((g) => (
                 <optgroup label={nameOf(g.id)}>
-                    {g.opts.map((o) => <option value={o.value} data-name={o.name} data-role={o.role}>{o.label}</option>)}
+                    {g.opts.map((o) => <option value={o.value} data-name={o.name} data-role={o.role} data-team={o.team}>{o.label}</option>)}
                 </optgroup>
             ))}
         </select>
@@ -67,13 +67,25 @@ const tags = (Object.keys(PLAY_TAGS) as (keyof typeof PLAY_TAGS)[])
         const bar = document.querySelector<HTMLElement>('[data-play-focus="all"]');
         const sel = bar?.querySelector('select');
         if (!sel) return;
-        const want = [...sel.options].find((o) =>
-            o.dataset.name === btn.dataset.name && o.dataset.role === btn.dataset.role);
+        const match = (o: HTMLOptionElement) =>
+            o.dataset.name === btn.dataset.name && o.dataset.role === btn.dataset.role
+            && (!btn.dataset.team || !o.dataset.team || o.dataset.team === btn.dataset.team);
+        const want = [...sel.options].find(match);
         if (!want) return;
         sel.value = want.value;
         sel.dispatchEvent(new Event('change'));
         document.querySelector('[data-plays-body="all"]')?.closest('table')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
+
+    // A name the play index never saw (missing player ids in the pbp) would be a
+    // dead button; strip the affordance so nothing advertises a click it cannot honor.
+    {
+        const sel = document.querySelector<HTMLElement>('[data-play-focus="all"]')?.querySelector('select');
+        const known = new Set([...(sel?.options ?? [])].map((o) => `${(o as HTMLOptionElement).dataset.name}|${(o as HTMLOptionElement).dataset.role}`));
+        for (const btn of document.querySelectorAll<HTMLElement>('[data-focus-jump]')) {
+            if (!known.has(`${btn.dataset.name}|${btn.dataset.role}`)) btn.classList.add('focus-jump-dead');
+        }
+    }
 
     for (const bar of document.querySelectorAll<HTMLElement>('[data-play-focus]')) {
         const target = bar.dataset.playFocus;

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -400,3 +400,23 @@ describe('the classic snapshot serves the public while v2 is in preview', () => 
         expect(isFeatureEnabled('game-page-v2', {})).toBe(false);
     });
 });
+
+describe('box-score names jump into the play filter', () => {
+    test('name cells carry the jump wiring and the select options carry the match keys', async () => {
+        const { retrieveProcessedGame } = await import('../src/resources/python');
+        const game: any = await retrieveProcessedGame(GAME_ID, 30);
+        const { default: GamePage } = await import('../src/components/game/GamePage.astro');
+        const page = await container.renderToString(GamePage, {
+            props: { id: GAME_ID, game },
+            request: new Request(`https://gameonpaper.com/game/${GAME_ID}`),
+        });
+        expect(page).toMatch(/<button type="button" class="focus-jump" data-focus-jump data-name="[^"]+" data-role="pass"/);
+        expect(page).toMatch(/data-role="rush"/);
+        expect(page).toMatch(/data-role="recv"/);
+        // the same (name, role) pair exists on a select option, so the click can match
+        const btn = page.match(/data-focus-jump data-name="([^"]+)" data-role="pass"/);
+        expect(btn).toBeTruthy();
+        expect(page).toContain(`<option value="r:pass:`);
+        expect(page).toMatch(new RegExp(`<option value="r:pass:[^"]+" data-name="${btn![1]}" data-role="pass">`));
+    });
+});

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -410,13 +410,13 @@ describe('box-score names jump into the play filter', () => {
             props: { id: GAME_ID, game },
             request: new Request(`https://gameonpaper.com/game/${GAME_ID}`),
         });
-        expect(page).toMatch(/<button type="button" class="focus-jump" data-focus-jump data-name="[^"]+" data-role="pass"/);
+        expect(page).toMatch(/<button type="button" class="focus-jump" data-focus-jump data-name="[^"]+" data-team="[^"]+" data-role="pass"/);
         expect(page).toMatch(/data-role="rush"/);
         expect(page).toMatch(/data-role="recv"/);
         // the same (name, role) pair exists on a select option, so the click can match
-        const btn = page.match(/data-focus-jump data-name="([^"]+)" data-role="pass"/);
+        const btn = page.match(/data-focus-jump data-name="([^"]+)" data-team="[^"]+" data-role="pass"/);
         expect(btn).toBeTruthy();
         expect(page).toContain(`<option value="r:pass:`);
-        expect(page).toMatch(new RegExp(`<option value="r:pass:[^"]+" data-name="${btn![1]}" data-role="pass">`));
+        expect(page).toMatch(new RegExp(`<option value="r:pass:[^"]+" data-name="${btn![1]}" data-role="pass" data-team="[^"]+">`));
     });
 });


### PR DESCRIPTION
Preview feedback item 5's entry point: a stat line's player name is now a click-through into #200's PlayFocus filter — selects the player's matching role (dropbacks/carries/targets), applies the filter, and scrolls to the table. (name, role) matching via data attributes on both sides since advanced-box rows carry no player id; quiet dotted-underline styling; behind the `game-page-v2` wall. vitest 180/180 with a render test proving the button's (name, role) pair exists on a select option.

## Summary by Sourcery

Connect box-score player names to matching role-specific play-by-play filters on the game page.

New Features:
- Make box-score player names clickable controls that filter the play-by-play by the player’s passing, rushing, or receiving role and scroll to the plays table.

Enhancements:
- Add accessible, subdued styling and disable the click affordance when no matching play-filter option exists.
- Expose player name, role, and team metadata on play-filter options to support reliable matching.

Tests:
- Add render coverage verifying box-score player controls and matching play-filter options are emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Player names in passing, rushing, and receiving box-score rows can now be clicked to filter the play-by-play view.
  - Selecting a player automatically updates the play filter and scrolls to the plays table.
  - Unavailable player filters are displayed without an interactive affordance.

- **Style**
  - Added visual styling for clickable and unavailable player-name filters.

- **Tests**
  - Added coverage verifying player-name links and matching play filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->