### PR TITLE
fix(ci): track the astro lockfile and install with npm ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: astro/package-lock.json
       # astro/package-lock.json is tracked (see .gitignore note); ci installs the
       # locked tree and cannot drift with the registry.
       - run: npm ci --no-audit --no-fund


### PR DESCRIPTION
## Why

`astro/` tracked no lockfile (`*/package-lock.json` was gitignored), so every CI run re-resolved ~390 transitive dependencies from the registry.

Today that started failing in npm's arborist:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

**No repo change caused it.** The same commits on `feat/span-filter` and `feat/box-row-focus` passed at 12:17/12:20 UTC and failed at 12:24/12:29. Re-running `main`'s own merged commit also failed. The registry moved under the caret ranges.

Direct-dependency pinning can't reach this — `edgesOut` is a failure while building the dependency *graph*, somewhere in the transitive set.

## What

- Remove `*/package-lock.json` from `.gitignore` and track `astro/package-lock.json`.
- `test.yml`: `npm install` → `npm ci`, plus the `setup-node` npm cache (both were previously unavailable for want of a lockfile).

`npm ci` doesn't resolve at all — it materializes the locked tree — so registry movement can no longer break CI.

## Verification

- **This PR's own CI is green**: `npm ci` in 10s (the fresh resolve took 29s), 400 packages, 18/18 test files passing.
- Also verified locally with `npm ci` under **npm 11**, the version CI uses.
- Re-resolution is idempotent: a second `--package-lock-only` pass produces no diff.
- The lockfile was generated in a clean directory. Generating it in the worktree poisons it: `astro/node_modules` there is a symlink into a sibling worktree, and npm follows it, writing `../../` paths that escape the project root.

`deploy.yml` already ran `npm ci` in its wrangler `preCommands`; it now gets a real tracked lockfile instead of one generated on the fly.

## Follow-up

The exact pins from e0b6664 (`astro` / `@astrojs/cloudflare`) stay for now — #205 tracks reverting them once that pair is compatible again.

## Summary by Sourcery

Use the tracked Astro dependency lockfile to make CI installations deterministic and resilient to registry changes.

Bug Fixes:
- Make CI installs reproducible by using the tracked lockfile with `npm ci`, preventing failures caused by transitive dependency re-resolution.

Enhancements:
- Enable npm dependency caching in the test workflow based on the Astro lockfile.

CI:
- Update the test workflow to cache npm dependencies and install the locked dependency tree with `npm ci`.