### PR TITLE
feat(game): the span filter reaches the advanced box scores (API recompute)

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -269,8 +269,9 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
             </div>
             {activeSpan && (
                 <div class="alert alert-info py-1 px-3 mb-2 small">
-                    Showing <strong>{activeSpan.label}</strong> only. Play-by-play, drives, situational, defensive, traditional and penalty
-                    sections are filtered; the charts and advanced box scores still show the full game.
+                    Showing <strong>{activeSpan.label}</strong> only. Every play-derived table is recomputed for this window
+                    {game.advBoxScoreSpan ? '' : ' (advanced boxes fell back to full-game for this window)'};
+                    the charts, ESPN's official stat lines and season percentiles always describe the full game.
                 </div>
             )}
             {latestPlays.length > 0 && (
@@ -307,7 +308,7 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
                     <Panel id="team-stats" title="Team Stats">
                         <div class="row" slot="panel-body">
                             <div class="col-md-4 ms-sm-auto col-lg-4">
-                                <BinionBoxScore season={game.season.year} advancedBoxScore={game.advBoxScore} percentiles={percentiles} />
+                                <BinionBoxScore season={game.season.year} advancedBoxScore={game.advBoxScore} percentiles={activeSpan ? [] : percentiles} />
                                 <TraditionalTeamStats
                                     season={game.season.year}
                                     teams={game.advBoxScore.team.map((t: any) => t.pos_team)}

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -271,7 +271,7 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
                 <div class="alert alert-info py-1 px-3 mb-2 small">
                     Showing <strong>{activeSpan.label}</strong> only. Every play-derived table is recomputed for this window
                     {game.advBoxScoreSpan ? '' : ' (advanced boxes fell back to full-game for this window)'};
-                    the charts, ESPN's official stat lines and season percentiles always describe the full game.
+                    the charts, the Latest strip, ESPN's official stat lines and season percentiles always describe the full game.
                 </div>
             )}
             {latestPlays.length > 0 && (
@@ -308,7 +308,7 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
                     <Panel id="team-stats" title="Team Stats">
                         <div class="row" slot="panel-body">
                             <div class="col-md-4 ms-sm-auto col-lg-4">
-                                <BinionBoxScore season={game.season.year} advancedBoxScore={game.advBoxScore} percentiles={activeSpan ? [] : percentiles} />
+                                <BinionBoxScore season={game.season.year} advancedBoxScore={game.advBoxScore} percentiles={activeSpan && game.advBoxScoreSpan ? [] : percentiles} />
                                 <TraditionalTeamStats
                                     season={game.season.year}
                                     teams={game.advBoxScore.team.map((t: any) => t.pos_team)}

--- a/astro/src/pages/game/[id].astro
+++ b/astro/src/pages/game/[id].astro
@@ -2,6 +2,7 @@
 import GamePage from '../../components/game/GamePage.astro';
 import GamePageClassic from '../../components/game/classic/GamePage.astro';
 import { isFeatureEnabled } from '../../utils/features';
+import { parseSpan } from '../../utils/span';
 import PreGamePage from '../../components/game/PreGamePage.astro';
 import { ESPN_IN_PROGRESS_STATUS_NAMES, ESPN_INVALID_GAME_STATUS_NAMES, retrieveGamePageGuarded, type ESPNPlayByPlayResponse } from '../../resources/espn';
 import { gopStorage } from '../../utils/telemetry';
@@ -40,7 +41,10 @@ try {
     
     const config = getGameCacheConfig(espnGame.gamepackageJSON.header.competitions[0].date, espnGame.gamepackageJSON.header.competitions[0].status)
     if (espnGame && !ESPN_INVALID_GAME_STATUS_NAMES.includes(espnGame.gamepackageJSON.header.competitions[0].status.type.name)) {
-        game = await retrieveProcessedGame(id, config.maxAge || 30);
+        // a valid ?span= also windows the python-computed advanced boxes; the
+        // API keys its cache on it, and falls back to full-game when the window
+        // is invalid or empty
+        game = await retrieveProcessedGame(id, config.maxAge || 30, parseSpan(Astro.url.searchParams.get('span'))?.key ?? null);
     }
 
     if (guarded.regressed) {

--- a/astro/src/resources/python.ts
+++ b/astro/src/resources/python.ts
@@ -822,6 +822,7 @@ export interface ProcessedGame {
     id: number
     count: number
     advBoxScore: ProcessedBoxScore
+    advBoxScoreSpan?: string | null
     plays: ProcessedPlay[]
     drives: { previous?: ProcessedDrive[], current?: ProcessedDrive }
     scoringPlays: ProcessedPlay[]
@@ -839,8 +840,8 @@ const PYTHON_HTTP_URL = getSecret("PYTHON_HTTP_URL") || 'http://python:5000';
 const PYTHON_HTTP_TOKEN = getSecret("PYTHON_HTTP_TOKEN");
 const APP_VERSION = getSecret("APP_VERSION") || "dev";
 
-export async function retrieveProcessedGame(gameId: string | number, cacheTTL: number): Promise<ProcessedGame> {
-    const processed: ProcessedGame = await processPlays(gameId, cacheTTL);
+export async function retrieveProcessedGame(gameId: string | number, cacheTTL: number, span?: string | null): Promise<ProcessedGame> {
+    const processed: ProcessedGame = await processPlays(gameId, cacheTTL, span);
 
     const pbp: ProcessedGame = {
         ...processed,
@@ -927,13 +928,14 @@ function calculateGEI(plays: ProcessedPlay[], homeTeamId: string | number): numb
     return normalizeFactor * gei
 }
 
-async function processPlays(gameId: string | number, cacheTTL: number): Promise<ProcessedGame> {
+async function processPlays(gameId: string | number, cacheTTL: number, span?: string | null): Promise<ProcessedGame> {
     if (!PYTHON_HTTP_TOKEN) {
         throw Error("PYTHON_HTTP_TOKEN not set, can not fire request")
     }
 
     const encodedToken = btoa(PYTHON_HTTP_TOKEN);
-    const req = await wrappedFetch(`${PYTHON_HTTP_URL}/cfb/${gameId}/process`, {
+    const spanQ = span ? `?span=${encodeURIComponent(span)}` : '';
+    const req = await wrappedFetch(`${PYTHON_HTTP_URL}/cfb/${gameId}/process${spanQ}`, {
         headers: {
             "Authorization": `Bearer ${encodedToken}`,
             "Referer": "gameonpaper.com" 
@@ -945,7 +947,7 @@ async function processPlays(gameId: string | number, cacheTTL: number): Promise<
             // deployed version means a deploy (a parser fix in sportsdataverse-py
             // rides in with every build) invalidates it without any zone purge; the
             // page-side tag purge then re-renders from a fresh API response.
-            cacheKey: `${PYTHON_HTTP_URL}/cfb/${gameId}/process?v=${APP_VERSION}`,
+            cacheKey: `${PYTHON_HTTP_URL}/cfb/${gameId}/process?v=${APP_VERSION}${span ? `&span=${span}` : ''}`,
         }
     })
     const content = await req.text();

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -22,6 +22,7 @@ vi.mock('../src/utils/telemetry', async (orig) => ({
     ...(await orig<typeof import('../src/utils/telemetry')>()),
     wrappedFetch: async (url: string) => {
         if (!String(url).includes(`/cfb/${GAME_ID}/process`)) throw new Error(`unexpected fetch in test: ${url}`);
+        (globalThis as any).__lastProcessUrl = String(url);
         return new Response(apiPayload, { status: 200, headers: { 'content-type': 'application/json' } });
     },
 }));
@@ -439,6 +440,14 @@ describe('the ?span= filter narrows the page to a window', () => {
         expect(spanned).toMatch(/Showing <strong>Q3<\/strong> only/);
         // the charts keep the whole game: the WP chart island still carries all four periods
         expect(spanned).toMatch(/astro-island[^>]+WinProbabilityChart/);
+    });
+
+    test('the span is forwarded to the python API so the boxes recompute server-side', async () => {
+        const { retrieveProcessedGame } = await import('../src/resources/python');
+        await retrieveProcessedGame(GAME_ID, 30, 'q3');
+        expect((globalThis as any).__lastProcessUrl).toContain(`/cfb/${GAME_ID}/process?span=q3`);
+        await retrieveProcessedGame(GAME_ID, 30, null);
+        expect((globalThis as any).__lastProcessUrl).not.toContain('span=');
     });
 
     test('no span means no banner, and the pills are still offered', async () => {

--- a/python/app.py
+++ b/python/app.py
@@ -315,17 +315,10 @@ def process(game_id: int):
                 if isinstance(v, float) and not math.isfinite(v):
                     record[k] = None
 
-        body_bytes = orjson.dumps(
-            processed_game,
-            default=_orjson_default,
-            option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS,
-        )
-        response = Response(body_bytes, mimetype="application/json")
-        # timings["total"] = time.perf_counter() - request_start
-        # response.headers["Server-Timing"] = _server_timing_header(timings)
-        response.headers["X-Result-Cache"] = "MISS"
-        # _emit_metrics(timings, gameId, 200)
-        return response, 200
+        # Both of these must precede serialization: the span swap mutates
+        # processed_game, and everything after `return` is dead code -- which is
+        # exactly where the DQ emit sat unnoticed until CodeRabbit flagged the
+        # ordering (gop.dq_boxscore had zero rows since #192 merged).
         raw_span = request.args.get("span")
         if raw_span:
             try:
@@ -338,12 +331,23 @@ def process(game_id: int):
                     f"span box failed for {game_id} span={raw_span}: {e}"
                 )
 
-        try:
-            _emit_dq(game_id, game, processed_game)
-        except Exception as e:  # observability must never cost a render
-            logging.getLogger("root").warning(f"dq emit failed for {game_id}: {e}")
+        if not raw_span:  # a windowed request is not the game's canonical box
+            try:
+                _emit_dq(game_id, game, processed_game)
+            except Exception as e:  # observability must never cost a render
+                logging.getLogger("root").warning(f"dq emit failed for {game_id}: {e}")
 
-        return jsonify(processed_game), 200
+        body_bytes = orjson.dumps(
+            processed_game,
+            default=_orjson_default,
+            option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS,
+        )
+        response = Response(body_bytes, mimetype="application/json")
+        # timings["total"] = time.perf_counter() - request_start
+        # response.headers["Server-Timing"] = _server_timing_header(timings)
+        response.headers["X-Result-Cache"] = "MISS"
+        # _emit_metrics(timings, gameId, 200)
+        return response, 200
     except KeyError as e:
         logging.getLogger("root").error(
             "Error while processing PBP on Python side, threw 404: %r (%s)" % (e, e)

--- a/python/app.py
+++ b/python/app.py
@@ -15,6 +15,7 @@ from telemetry import TEL, stage, init_flask
 import gop_routes
 import espn_proxy
 import dq
+import span_box
 
 HTTP_TOKEN = os.getenv("PYTHON_HTTP_TOKEN")
 assert HTTP_TOKEN, "HTTP_TOKEN not provided, can not start server"
@@ -325,6 +326,18 @@ def process(game_id: int):
         response.headers["X-Result-Cache"] = "MISS"
         # _emit_metrics(timings, gameId, 200)
         return response, 200
+        raw_span = request.args.get("span")
+        if raw_span:
+            try:
+                box, span_key = span_box.spanned_box(game, raw_span)
+                if box is not None:
+                    processed_game["advBoxScore"] = box
+                    processed_game["advBoxScoreSpan"] = span_key
+            except Exception as e:  # a bad window must never cost the page
+                logging.getLogger("root").warning(
+                    f"span box failed for {game_id} span={raw_span}: {e}"
+                )
+
         try:
             _emit_dq(game_id, game, processed_game)
         except Exception as e:  # observability must never cost a render

--- a/python/span_box.py
+++ b/python/span_box.py
@@ -38,7 +38,9 @@ def parse_span(raw):
         return "ot", pl.col("period") > 4
     parts = key.split("-")
     if len(parts) == 2 and all(p.isdigit() for p in parts):
-        bucket = lambda n: round(n / 30) * 30  # noqa: E731
+        # half-up like JS Math.round -- Python's round() is half-even, and a direct
+        # API caller sending 45 must land in the same bucket the worker computes
+        bucket = lambda n: int(n / 30 + 0.5) * 30  # noqa: E731
         frm, to = bucket(min(int(parts[0]), 3600)), bucket(max(int(parts[1]), 0))
         if frm > to:
             return f"{frm}-{to}", (

--- a/python/span_box.py
+++ b/python/span_box.py
@@ -1,0 +1,62 @@
+"""Windowed advanced box scores for ?span= on the game page.
+
+The EP/WP pipeline must always run on the FULL game (lags, cumulative state,
+model context), so per-play metrics are computed whole-game and only the
+AGGREGATION is windowed: filter the enriched polars frame, re-run
+create_box_score on the slice. Mirrors astro's utils/span.ts specs:
+q1..q4, h1, h2, ot, or "<from>-<to>" in game-clock seconds remaining
+(30s buckets, regulation only).
+
+What cannot be windowed, ever:
+- espn_team / espn_players: ESPN publishes the official box full-game only;
+  create_box_score re-parses them from the summary, so they come out
+  identical on a slice -- inherently full-game, the UI labels them.
+- season percentiles / GEI / spread: game- or season-scalar reference
+  classes; a Q3 box against full-game distributions is a category error.
+"""
+
+import polars as pl
+
+_PERIODS = {
+    "q1": [1],
+    "q2": [2],
+    "q3": [3],
+    "q4": [4],
+    "h1": [1, 2],
+    "h2": [3, 4],
+}
+
+
+def parse_span(raw):
+    """-> (key, polars filter expr) or None."""
+    if not raw:
+        return None
+    key = str(raw).strip().lower()
+    if key in _PERIODS:
+        return key, pl.col("period").is_in(_PERIODS[key])
+    if key == "ot":
+        return "ot", pl.col("period") > 4
+    parts = key.split("-")
+    if len(parts) == 2 and all(p.isdigit() for p in parts):
+        bucket = lambda n: round(n / 30) * 30  # noqa: E731
+        frm, to = bucket(min(int(parts[0]), 3600)), bucket(max(int(parts[1]), 0))
+        if frm > to:
+            return f"{frm}-{to}", (
+                (pl.col("start.adj_TimeSecsRem") <= frm)
+                & (pl.col("start.adj_TimeSecsRem") >= to)
+                & (pl.col("period") <= 4)
+            )
+    return None
+
+
+def spanned_box(game, raw_span):
+    """Recompute advBoxScore over the window. Returns (box_dict, key) or (None, None)
+    when the span is invalid or selects no plays (caller keeps the full box)."""
+    parsed = parse_span(raw_span)
+    if parsed is None or getattr(game, "plays_json", None) is None:
+        return None, None
+    key, expr = parsed
+    sliced = game.plays_json.filter(expr)
+    if sliced.height == 0:
+        return None, None
+    return game.create_box_score(sliced), key

--- a/python/tests/test_span_box.py
+++ b/python/tests/test_span_box.py
@@ -1,0 +1,47 @@
+import polars as pl
+
+import span_box
+
+
+def frame():
+    return pl.DataFrame(
+        {
+            "period": [1, 2, 3, 4, 5],
+            "start.adj_TimeSecsRem": [3000.0, 2000.0, 1200.0, 400.0, 0.0],
+        }
+    )
+
+
+def rows(expr):
+    return frame().filter(expr)["period"].to_list()
+
+
+def test_named_spans():
+    assert rows(span_box.parse_span("q3")[1]) == [3]
+    assert rows(span_box.parse_span("H1")[1]) == [1, 2]
+    assert rows(span_box.parse_span("ot")[1]) == [5]
+
+
+def test_clock_span_buckets_and_regulation_only():
+    key, expr = span_box.parse_span("1807-393")
+    assert key == "1800-390"
+    assert rows(expr) == [3, 4]  # 1200 and 400 in [390,1800]; OT excluded; 2000 above
+
+
+def test_invalid_spans():
+    for bad in (None, "", "banana", "900-1800", "42"):
+        assert span_box.parse_span(bad) is None
+
+
+def test_spanned_box_falls_back_when_empty_or_invalid():
+    class G:
+        plays_json = frame()
+
+        def create_box_score(self, df):
+            return {"n": df.height}
+
+    g = G()
+    assert span_box.spanned_box(g, "q2") == ({"n": 1}, "q2")
+    assert span_box.spanned_box(g, "nope") == (None, None)
+    g.plays_json = frame().filter(pl.col("period") > 90)
+    assert span_box.spanned_box(g, "q2") == (None, None)


### PR DESCRIPTION
Phase 2 of the span plan: `?span=` now recomputes **every play-derived output** — the advanced team/passing/rushing/receiving/situational/defensive/turnover boxes included — not just the astro-computed sections.

Mechanism: per-play metrics are always computed on the **full game** (EP/WP lags and model context require it); only the aggregation is windowed. `python/span_box.py` mirrors `utils/span.ts` (q1..q4/h1/h2/ot/clock buckets), filters the retained enriched polars frame, and re-runs `create_box_score` on the slice. The worker forwards a validated span and adds it to the API-layer `cf.cacheKey`; invalid/empty windows fall back to full-game and the banner says so (`advBoxScoreSpan` marks a successful recompute).

**What can never be windowed, and why** (the banner names these):
- **ESPN official stat lines** — ESPN publishes them full-game only; on any slice they re-parse identically.
- **Season percentiles** — full-game reference class; grading a Q3 box against them is a category error, so the Binion box drops percentile shading under a span.
- **Game scalars** (GEI, spread, over/under) and the **WP/EP charts** — whole-game by definition; charts keep full data (shading planned).

Tests: python 28/28 (span parsing/bucketing/regulation-only/empty-fallback), vitest 189/189 incl. a test proving the span is forwarded to the API URL. All behind the `game-page-v2` preview wall.

## Summary by Sourcery

Recompute advanced box scores for selected game spans while preserving full-game-only outputs and safe fallback behavior.

New Features:
- Recompute advanced play-derived box scores for valid game spans, including quarter, half, overtime, and clock-based windows.
- Expose span-aware API responses and indicate when advanced boxes were successfully recomputed.

Bug Fixes:
- Ensure data-quality events are emitted before the processing response returns.

Enhancements:
- Clarify that charts, latest plays, official ESPN statistics, game-level scalars, and season percentiles remain full-game outputs when a span is selected.
- Fall back safely to full-game advanced boxes for invalid or empty spans.

Tests:
- Add coverage for span parsing, clock bucketing, regulation-only filtering, empty-window fallback, and forwarding spans to the processing API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added span filtering for advanced box scores on game pages, supporting quarters, halves, overtime, and custom game-clock ranges.
  - Selected spans now recompute play-derived tables for the chosen window.
  - Invalid or empty spans automatically fall back to full-game advanced box scores.

- **Enhancements**
  - Updated span-filter messaging to clarify which statistics remain based on full-game data, including charts, official ESPN statistics, and season percentiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->