### PR TITLE
fix(mobile): tranche 2 — drive-chart props (−4MB), type floor, sticky nav, header row, week default

### DIFF
--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -222,3 +222,18 @@ Target Matrix
 .game-thumb-actions .btn { min-height: 44px; display: inline-flex; align-items: center; }
 .toggle-link { display: inline-block; padding: 12px 6px; margin: -10px 0; }
 
+/* Mobile QA tranche 2: the play-row decision badges computed to 10.5px. */
+.badge.rounded { font-size: 12px; }
+/* v2 game page: the section nav sticks on phones so a 4,000px page keeps its
+   wayfinding; desktop keeps the in-flow bar. */
+@media (max-width: 768px) {
+  .game-nav-sticky { position: sticky; top: 0; z-index: 1020; background: var(--bs-body-bg, #fff); }
+}
+/* On phones the seven nav items stacked three rows deep and pushed content
+   below the fold; one swipeable row costs no JS and keeps every link. */
+@media (max-width: 768px) {
+  .site-nav-row { flex-wrap: nowrap; overflow-x: auto; justify-content: flex-start !important; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
+  .site-nav-row::-webkit-scrollbar { display: none; }
+  .site-nav-row .nav-link { white-space: nowrap; }
+}
+

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -11,7 +11,7 @@ const METRIC_YEAR = LAST_YEAR;
                 <a href="/" class="fs-4 blog-header-logo text-decoration-none text-reset"><img src="/assets/img/favicon.svg" height="25px" class="align-self-center me-2"/>Game on Paper</a>
             </div>
 
-            <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
+            <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0 site-nav-row">
                 <li><a href="/" class="nav-link px-2 link-secondary">Scoreboard</a></li>
                 <li class="nav-item dropdown">
                     <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -260,7 +260,7 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
                 </div>
             </header>
 
-            <NavScroller items={scrollerItems} />
+            <div class="game-nav-sticky"><NavScroller items={scrollerItems} /></div>
             <div class="d-flex align-items-center flex-wrap gap-1 px-3 py-1 span-pills">
                 <a class={`btn btn-sm ${activeSpan ? 'btn-outline-secondary' : 'btn-secondary'}`} href={`/game/${id}`}>Full game</a>
                 {spanPills.map((sp) => (

--- a/astro/src/components/game/drives/DriveRow.astro
+++ b/astro/src/components/game/drives/DriveRow.astro
@@ -17,6 +17,16 @@ interface Props {
 }
 
 const { drive, prefix, expandable, drivePlays, isNeutralSite, homeTeam, awayTeam } = Astro.props;
+// The chart island serializes its plays prop into the HTML. A full
+// ProcessedPlay is ~25KB x ~10 plays x every drive = 4.4MB of the page (84%
+// measured 2026-09-03); the chart reads exactly seven fields.
+const slimPlay = (p: ProcessedPlay) => ({
+    rush: p.rush, pass: p.pass,
+    type: { text: p.type?.text },
+    start: { yardsToEndzone: p.start?.yardsToEndzone, team: { id: p.start?.team?.id } },
+    end: { yardsToEndzone: p.end?.yardsToEndzone, team: { id: p.end?.team?.id } },
+});
+const chartPlays = drivePlays.map(slimPlay);
 
 // let drivePlays = gameData.plays.filter((p) => (p['drive.id'] == drive.id))
 const firstPlay = drivePlays[0]
@@ -84,7 +94,7 @@ const endWP = endWPPlays[endWPPlays.length - 1];
             <div class="row p-1">
                 <div class="ms-sm-auto col-12 mb-3">
                 <p class="m-0 mb-1"><strong>Drive Chart</strong> <span>(Direction of play - left to right)</span>:</p>
-                <DriveChart client:only id={drive.id} subtitle={`${offense.abbreviation} - ${drive.result || drive.displayResult || 'In Progress'} - ${drive.description}`} plays={drivePlays} offense={offense} defense={defense} isNeutralSite={isNeutralSite} result={drive.result}>
+                <DriveChart client:only id={drive.id} subtitle={`${offense.abbreviation} - ${drive.result || drive.displayResult || 'In Progress'} - ${drive.description}`} plays={chartPlays} offense={offense} defense={defense} isNeutralSite={isNeutralSite} result={drive.result}>
                     <FallbackSpinner slot="fallback" />
                 </DriveChart>
                 <p class="m-0 text-muted"><small>Note: vertical position of plays on chart does not indicate actual vertical position on field.</small></p>

--- a/astro/src/pages/index.astro
+++ b/astro/src/pages/index.astro
@@ -47,4 +47,4 @@ try {
 
 ---
 
-<SchedulePage title={"College Football | Game on Paper"} season={CURRENT_YEAR} isScoreboard={true} games={games} />
+<SchedulePage title={"College Football | Game on Paper"} season={CURRENT_YEAR} week={games[0]?.week?.number} seasontype={games[0]?.season?.type} isScoreboard={true} games={games} />


### PR DESCRIPTION
Second tranche from the mobile QA note. The headline: decomposing the 5.3MB game page showed **84% was astro-island props — 26 `DriveChart` islands each serializing full ProcessedPlay objects** (~25KB/play). The chart reads exactly seven fields (`rush`, `pass`, `type.text`, `start/end.yardsToEndzone`, `start/end.team.id`); slimming the prop takes the fixture page **5.32MB → 1.31MB**. The earlier expanded-row hypothesis measured out at only 8% and was dropped.

Also: 12px floor for the decision badges (the audit's only sub-12px source, 10.5px), sticky section nav on phones (v2 page only — inherently behind the preview wall), the header's 3-row nav stack becomes one swipeable CSS-only row, and the scoreboard preselects the current week from the payload.

Per maintainer direction these files stay standard (no flag gating); the sticky nav lives in the v2 tree so it previews anyway. vitest 189/189; compiles on Node 22. Will re-measure live post-deploy.

## Summary by Sourcery

Optimize mobile game pages and improve phone navigation, readability, and scoreboard week selection.

Bug Fixes:
- Reduce game-page HTML payloads by passing only the fields required by drive charts instead of full play objects.
- Set the scoreboard's initial week and season type from the loaded game payload.
- Improve mobile navigation usability with a sticky game section nav and a horizontally swipeable site navigation row.
- Raise rounded decision badge text to a minimum of 12px.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile navigation with a sticky game navigation bar and a horizontally scrollable site navigation row.
  * Added non-wrapping navigation links and hidden scrollbars for smoother mobile browsing.
* **Style**
  * Reduced play-row badge size to 12px on mobile screens.
* **Bug Fixes**
  * Schedule pages now use the current week and season type when displaying scoreboard information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->