### PR TITLE
fix(admin): preview cookie lives seven days; end-to-end chain test

### DIFF
--- a/astro/src/utils/preview.ts
+++ b/astro/src/utils/preview.ts
@@ -8,7 +8,11 @@
 // signed with ADMIN_PASS so it cannot be minted client-side, and it expires.
 
 export const PREVIEW_COOKIE = 'gop_preview';
-export const PREVIEW_TTL_S = 12 * 60 * 60;
+// Seven days, not twelve hours: the cookie expires SILENTLY -- pages just
+// revert to the public variant with no signal -- and a solo admin re-toggling
+// mid-season twice a day is worse than a longer-lived, HMAC-signed, view-only
+// cookie. The /admin button always shows the live state.
+export const PREVIEW_TTL_S = 7 * 24 * 60 * 60;
 
 async function hmacHex(secret: string, msg: string): Promise<string> {
     const key = await crypto.subtle.importKey(

--- a/astro/test/preview.test.ts
+++ b/astro/test/preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { mintPreviewCookie, verifyPreviewCookie, readCookie, PREVIEW_COOKIE } from '../src/utils/preview';
+import { mintPreviewCookie, verifyPreviewCookie, readCookie, PREVIEW_COOKIE, PREVIEW_TTL_S } from '../src/utils/preview';
 import { isFeatureEnabled, FLAGS } from '../src/utils/features';
 
 describe('preview cookie', () => {
@@ -12,7 +12,7 @@ describe('preview cookie', () => {
     expect(await verifyPreviewCookie(c, 'other')).toBe(false);
     const [v, exp, sig] = c.split('.');
     expect(await verifyPreviewCookie(`${v}.${Number(exp) + 1}.${sig}`, 's3cret')).toBe(false);
-    const expired = await mintPreviewCookie('s3cret', Math.floor(Date.now() / 1000) - 100000);
+    const expired = await mintPreviewCookie('s3cret', Math.floor(Date.now() / 1000) - (PREVIEW_TTL_S + 3600));
     expect(await verifyPreviewCookie(expired, 's3cret')).toBe(false);
     const atBoundary = await mintPreviewCookie('s3cret');
     const boundary = Number(atBoundary.split('.')[1]);

--- a/astro/test/previewFlow.test.ts
+++ b/astro/test/previewFlow.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// End-to-end preview chain: a minted cookie through the REAL middleware must
+// set locals.preview, and an expired one must not -- silently, which is the
+// on-page symptom "preview features stopped working".
+vi.mock('astro:env/server', () => ({ getSecret: (k: string) => (k === 'ADMIN_PASS' ? 'test-secret' : undefined) }));
+vi.mock('astro:middleware', () => ({ defineMiddleware: (fn: unknown) => fn }));
+
+import { onRequest } from '../src/middleware';
+import { mintPreviewCookie, PREVIEW_COOKIE } from '../src/utils/preview';
+
+async function run(cookie: string | null) {
+    const locals: Record<string, unknown> = {};
+    const ctx: any = {
+        request: new Request('https://gameonpaper.com/game/401752746', {
+            headers: cookie ? { cookie: `${PREVIEW_COOKIE}=${cookie}` } : {},
+        }),
+        locals,
+        cache: { set: () => {} },
+        redirect: (l: string) => new Response(null, { status: 302, headers: { Location: l } }),
+    };
+    const res = await (onRequest as any)(ctx, async () => new Response('ok'));
+    return { locals, res };
+}
+
+describe('the preview chain end to end', () => {
+    test('a valid cookie sets locals.preview and the response is no-store', async () => {
+        const { locals, res } = await run(await mintPreviewCookie('test-secret'));
+        expect(locals.preview).toBe(true);
+        expect(res.headers.get('Cache-Control')).toBe('no-store');
+    });
+    test('an expired cookie fails silently -- the "stopped working" symptom', async () => {
+        const { locals } = await run(await mintPreviewCookie('test-secret', Math.floor(Date.now() / 1000) - 8 * 24 * 3600));
+        expect(locals.preview).toBe(false);
+    });
+    test('a cookie minted under a different secret fails', async () => {
+        const { locals } = await run(await mintPreviewCookie('other'));
+        expect(locals.preview).toBe(false);
+    });
+    test('no cookie leaves preview unset', async () => {
+        const { locals } = await run(null);
+        expect(locals.preview).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Root cause of "preview features stopped working": the preview cookie's **12-hour expiry fails silently** — verification simply stops passing, `locals.preview` stays unset, and pages revert to the public variant with no signal. New `previewFlow.test.ts` drives a minted cookie through the **real middleware** and pins valid / expired / wrong-secret / absent behavior (the expired case reproduces the symptom exactly). TTL → 7 days: solo-admin, HMAC-signed, view-only; the /admin button remains the live-state source of truth. Re-toggle Preview once after this deploys and it sticks for a week.

## Summary by Sourcery

Keep admin preview mode active for seven days and verify its middleware behavior across valid and invalid cookie states.

Bug Fixes:
- Extend the preview cookie lifetime from 12 hours to seven days to prevent preview mode from silently reverting during normal use.

Enhancements:
- Add end-to-end coverage for the complete preview middleware chain, including valid, expired, invalid-secret, and absent-cookie behavior.

Tests:
- Update preview cookie expiry tests to derive expiration behavior from the configured seven-day TTL.