### PR TITLE
fix(mobile): sticky nav spans the page; anchor offset; in-flow phone dropdowns

### DIFF
--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -232,7 +232,10 @@ Target Matrix
   html { scroll-padding-top: 56px; }
   /* dropdowns inside the horizontal nav scroller would be clipped by the
      scroll container; on phones they open in-flow instead */
-  .site-nav-row .dropdown-menu { position: static; float: none; }
+  /* !important because Popper writes position:absolute as an INLINE style on
+     open; important author CSS is the one thing that outranks it, and
+     data-bs-display="static" on the toggles stops Popper positioning at all */
+  .site-nav-row .dropdown-menu { position: static !important; float: none; transform: none !important; }
 }
 /* On phones the seven nav items stacked three rows deep and pushed content
    below the fold; one swipeable row costs no JS and keeps every link. */

--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -228,6 +228,11 @@ Target Matrix
    wayfinding; desktop keeps the in-flow bar. */
 @media (max-width: 768px) {
   .game-nav-sticky { position: sticky; top: 0; z-index: 1020; background: var(--bs-body-bg, #fff); }
+  /* anchor jumps must land below the stuck bar, not underneath it */
+  html { scroll-padding-top: 56px; }
+  /* dropdowns inside the horizontal nav scroller would be clipped by the
+     scroll container; on phones they open in-flow instead */
+  .site-nav-row .dropdown-menu { position: static; float: none; }
 }
 /* On phones the seven nav items stacked three rows deep and pushed content
    below the fold; one swipeable row costs no JS and keeps every link. */

--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -14,7 +14,7 @@ const METRIC_YEAR = LAST_YEAR;
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0 site-nav-row">
                 <li><a href="/" class="nav-link px-2 link-secondary">Scoreboard</a></li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
                         Leaderboards
                     </a>
                     <ul class="dropdown-menu">
@@ -29,7 +29,7 @@ const METRIC_YEAR = LAST_YEAR;
                     </ul>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
                         Charts
                     </a>
                     <ul class="dropdown-menu">
@@ -38,7 +38,7 @@ const METRIC_YEAR = LAST_YEAR;
                     </ul>
                 </li>
                 <li class="nav-item dropdown">
-                    <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <a class="nav-link px-2 link-secondary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" data-bs-display="static" aria-expanded="false">
                         Seasons
                     </a>
                     <ul class="dropdown-menu">

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -259,8 +259,13 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
                     </div>
                 </div>
             </header>
-
-            <div class="game-nav-sticky"><NavScroller items={scrollerItems} /></div>
+        </div>
+        {/* Outside the header container on purpose: position sticky only works
+            while the PARENT is in view; inside the small header container the
+            nav released after a single scroll (CodeRabbit, #208). At body
+            level it sticks for the whole page. */}
+        <div class="game-nav-sticky"><NavScroller items={scrollerItems} /></div>
+        <div class="container-fluid">
             <div class="d-flex align-items-center flex-wrap gap-1 px-3 py-1 span-pills">
                 <a class={`btn btn-sm ${activeSpan ? 'btn-outline-secondary' : 'btn-secondary'}`} href={`/game/${id}`}>Full game</a>
                 {spanPills.map((sp) => (


### PR DESCRIPTION
The three late CodeRabbit findings on #208 (they landed after the sweep and merge), all verified against the structure and fixed: (1) the sticky wrapper sat inside the header `container-fluid`, so it released after one scroll — lifted to body level between the containers; (2) `scroll-padding-top` so anchor jumps land below the stuck bar; (3) nav dropdowns opened inside the horizontal scroller and were clipped — in-flow (`position: static`) on phones. vitest 193/193; compiles.

## Summary by Sourcery

Fix mobile navigation behavior so the sticky game bar remains visible, anchor links scroll to the correct position, and dropdowns open within the page flow.

Bug Fixes:
- Keep the mobile game navigation bar sticky for the full page and offset anchor navigation so content is not hidden beneath it.
- Prevent phone navigation dropdowns from being clipped within the horizontal scroller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile navigation dropdowns so they open within the page without being clipped.
  - Anchor links on mobile now position content below the sticky navigation bar.
  - Fixed the navigation bar so it remains pinned while scrolling through the full page.
  - Updated dropdown behavior for Leaderboards, Charts, and Seasons to provide more reliable positioning on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->