### PR TITLE
fix(game): a shared ?span= link never windows data for a public render

### DIFF
--- a/astro/src/middleware.ts
+++ b/astro/src/middleware.ts
@@ -7,6 +7,7 @@ import { checkBasicAuth } from './resources/admin';
 import { PREVIEW_COOKIE, readCookie, verifyPreviewCookie } from './utils/preview';
 import { ADMIN_COOKIE, verifyAdminCookie } from './utils/adminSession';
 import { legacyCfbTarget, staleRedirectTarget } from './utils/legacyCfb';
+import { FLAGS } from './utils/features';
 
 const GAME_ID_RE = /\/game\/(\d+)/;
 
@@ -132,12 +133,21 @@ function safeClientAddress(context: any): string | null {
 // alone emits no header (heuristic 2h cache -- see 311d80e); no-store is the
 // explicit opt-out, and cache.set(false) after render wins over any options
 // the page itself accumulated.
-function withPreviewCacheGuard(context: any, response: Response): Response {
-  const isAdmin = new URL(context.request.url).pathname.startsWith('/admin');
+export function withPreviewCacheGuard(context: any, response: Response): Response {
+  const url = new URL(context.request.url);
+  const isAdmin = url.pathname.startsWith('/admin');
+  // A ?span= URL renders two different pages while game-page-v2 is in preview:
+  // v2 windows the boxes to the span, classic drops it and shows the full game.
+  // Cloudflare keys the cache on the URL and does not vary on the preview
+  // cookie, so the PUBLIC (classic) copy would be served to a previewing admin
+  // -- who would silently get the un-windowed page they were trying to check.
+  // Scoped to the preview state: once the flag is 'on' the span means the same
+  // thing to everyone and these URLs become cacheable again.
+  const spanVariesByViewer = url.searchParams.has('span') && FLAGS['game-page-v2'] === 'preview';
   // Preview renders are per-viewer; /admin responses are authenticated. Either
   // way a cached copy would be served to the wrong audience on a HIT -- and a
   // HIT never runs the Worker, so the auth check would be skipped entirely.
-  if (context.locals?.preview === true || isAdmin) {
+  if (context.locals?.preview === true || isAdmin || spanVariesByViewer) {
     try { context.cache?.set(false); } catch { /* cache provider absent in dev */ }
     response.headers.set('Cache-Control', 'no-store');
   }

--- a/astro/src/pages/game/[id].astro
+++ b/astro/src/pages/game/[id].astro
@@ -44,7 +44,14 @@ try {
         // a valid ?span= also windows the python-computed advanced boxes; the
         // API keys its cache on it, and falls back to full-game when the window
         // is invalid or empty
-        game = await retrieveProcessedGame(id, config.maxAge || 30, parseSpan(Astro.url.searchParams.get('span'))?.key ?? null);
+        // The span may only window the data when the v2 page (which renders the
+        // pills and the "showing Q3 only" banner) will actually be shown. A
+        // public/classic render with a shared ?span= link would otherwise show
+        // silently windowed box scores inside a full-game page.
+        const spanKey = isFeatureEnabled('game-page-v2', Astro.locals)
+            ? parseSpan(Astro.url.searchParams.get('span'))?.key ?? null
+            : null;
+        game = await retrieveProcessedGame(id, config.maxAge || 30, spanKey);
     }
 
     if (guarded.regressed) {

--- a/astro/src/pages/game/[id].astro
+++ b/astro/src/pages/game/[id].astro
@@ -2,7 +2,7 @@
 import GamePage from '../../components/game/GamePage.astro';
 import GamePageClassic from '../../components/game/classic/GamePage.astro';
 import { isFeatureEnabled } from '../../utils/features';
-import { parseSpan } from '../../utils/span';
+import { requestedSpanKey } from '../../utils/span';
 import PreGamePage from '../../components/game/PreGamePage.astro';
 import { ESPN_IN_PROGRESS_STATUS_NAMES, ESPN_INVALID_GAME_STATUS_NAMES, retrieveGamePageGuarded, type ESPNPlayByPlayResponse } from '../../resources/espn';
 import { gopStorage } from '../../utils/telemetry';
@@ -48,9 +48,7 @@ try {
         // pills and the "showing Q3 only" banner) will actually be shown. A
         // public/classic render with a shared ?span= link would otherwise show
         // silently windowed box scores inside a full-game page.
-        const spanKey = isFeatureEnabled('game-page-v2', Astro.locals)
-            ? parseSpan(Astro.url.searchParams.get('span'))?.key ?? null
-            : null;
+        const spanKey = requestedSpanKey(Astro.locals, Astro.url.searchParams, isFeatureEnabled);
         game = await retrieveProcessedGame(id, config.maxAge || 30, spanKey);
     }
 

--- a/astro/src/utils/span.ts
+++ b/astro/src/utils/span.ts
@@ -77,3 +77,24 @@ export function availableSpans(plays: { period?: unknown }[]): { key: string; la
     if ([...periods].some((n) => n > 4)) out.push({ key: 'ot', label: 'Overtime' });
     return out;
 }
+
+/**
+ * The span key the python API should be asked for, given who is looking.
+ *
+ * A `?span=` in a shared link may only window the data when the v2 page will
+ * actually render -- it is v2 that draws the pills and the "showing Q3 only"
+ * banner. On the classic page a windowed box score would be silently wrong
+ * numbers inside a full-game layout, so the span is dropped.
+ *
+ * This lives here rather than inline in `pages/game/[id].astro` so it can be
+ * tested against real inputs: the route needs `Astro.cache`, which the Astro
+ * container does not provide, so the route itself cannot be rendered in vitest.
+ */
+export function requestedSpanKey(
+    locals: { preview?: boolean } | undefined,
+    searchParams: URLSearchParams,
+    isEnabled: (name: string, locals: { preview?: boolean } | undefined) => boolean,
+): string | null {
+    if (!isEnabled('game-page-v2', locals)) return null;
+    return parseSpan(searchParams.get('span'))?.key ?? null;
+}

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -462,3 +462,12 @@ describe('the ?span= filter narrows the page to a window', () => {
         expect(plain).toContain('?span=q1');
     });
 });
+
+test('a shared ?span= link never windows the data for a public render', async () => {
+    // classic has no pills and no banner, so windowed boxes there would be
+    // silently wrong numbers -- the span must ride only with the v2 page
+    const mod = await import('../src/pages/game/[id].astro');
+    expect(mod).toBeTruthy();
+    const src = readFileSync(new URL('../src/pages/game/[id].astro', import.meta.url), 'utf-8');
+    expect(src).toMatch(/isFeatureEnabled\('game-page-v2', Astro\.locals\)\s*\n?\s*\? parseSpan/);
+});

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -465,9 +465,24 @@ describe('the ?span= filter narrows the page to a window', () => {
 
 test('a shared ?span= link never windows the data for a public render', async () => {
     // classic has no pills and no banner, so windowed boxes there would be
-    // silently wrong numbers -- the span must ride only with the v2 page
-    const mod = await import('../src/pages/game/[id].astro');
-    expect(mod).toBeTruthy();
-    const src = readFileSync(new URL('../src/pages/game/[id].astro', import.meta.url), 'utf-8');
-    expect(src).toMatch(/isFeatureEnabled\('game-page-v2', Astro\.locals\)\s*\n?\s*\? parseSpan/);
+    // silently wrong numbers -- the span must ride only with the v2 page.
+    //
+    // This calls the same function the route calls, with the real feature
+    // check, rather than matching the route's source text: a source regex keeps
+    // passing if a later change forwards the span on the public path while
+    // leaving the matched expression in place. The route itself cannot be
+    // rendered here -- it needs Astro.cache, which the container does not
+    // provide -- so the decision lives in requestedSpanKey() to stay reachable.
+    const { requestedSpanKey } = await import('../src/utils/span');
+    const { isFeatureEnabled } = await import('../src/utils/features');
+    const shared = new URL(`https://gameonpaper.com/game/${GAME_ID}?span=q3`).searchParams;
+
+    // public: the flag is off, so the span is dropped before the API call
+    expect(requestedSpanKey({}, shared, isFeatureEnabled)).toBeNull();
+    expect(requestedSpanKey(undefined, shared, isFeatureEnabled)).toBeNull();
+    // preview: v2 draws the pills and the banner, so the span rides along
+    expect(requestedSpanKey({ preview: true }, shared, isFeatureEnabled)).toBe('q3');
+    // and a junk span is still rejected even with the flag on
+    const junk = new URL(`https://gameonpaper.com/game/${GAME_ID}?span=nope`).searchParams;
+    expect(requestedSpanKey({ preview: true }, junk, isFeatureEnabled)).toBeNull();
 });

--- a/astro/test/span.test.ts
+++ b/astro/test/span.test.ts
@@ -49,3 +49,39 @@ test('availableSpans offers only played windows', () => {
     expect(availableSpans([...reg, p(5)]).map((s) => s.key)).toContain('ot');
     expect(availableSpans([p(null)])).toEqual([]);
 });
+
+describe('cache guard: a ?span= URL varies by viewer while v2 is in preview', () => {
+    // Cloudflare keys the cache on the URL and never varies on the preview
+    // cookie, and a cache HIT does not run the Worker at all -- so a cached
+    // public (classic, span dropped) response would be handed to a previewing
+    // admin, who would silently get the un-windowed page they came to check.
+    const guard = async (url: string, locals: Record<string, unknown> = {}) => {
+        const { withPreviewCacheGuard } = await import('../src/middleware');
+        const calls: unknown[] = [];
+        const res = withPreviewCacheGuard(
+            { request: new Request(url), locals, cache: { set: (v: unknown) => calls.push(v) } },
+            new Response('x'),
+        );
+        return { cacheControl: res.headers.get('Cache-Control'), cacheCalls: calls };
+    };
+
+    test('a public ?span= render is not cached', async () => {
+        const r = await guard('https://gameonpaper.com/game/401729745?span=q3');
+        expect(r.cacheControl).toBe('no-store');
+        expect(r.cacheCalls).toEqual([false]);
+    });
+
+    test('the same page without a span still caches normally', async () => {
+        const r = await guard('https://gameonpaper.com/game/401729745');
+        expect(r.cacheControl).toBeNull();
+        expect(r.cacheCalls).toEqual([]);
+    });
+
+    test('a preview render is uncacheable either way', async () => {
+        expect((await guard('https://gameonpaper.com/game/401729745', { preview: true })).cacheControl).toBe('no-store');
+    });
+
+    test('/admin stays uncacheable', async () => {
+        expect((await guard('https://gameonpaper.com/admin')).cacheControl).toBe('no-store');
+    });
+});


### PR DESCRIPTION
Found while explaining why Safari colleagues 'couldn't see' a shared `?span=q3` link: they got the classic page (correct — no preview cookie) but `[id].astro` still forwarded the span to the API, so the **advanced box scores were silently Q3-windowed inside a full-game page with no banner**. The span now rides only when the v2 page (pills + banner) will actually render. Test pins the guard.

## Summary by Sourcery

Ensure shared span links display correctly across public and preview game-page experiences.

Bug Fixes:
- Prevent shared `?span=` links from silently returning quarter-windowed game data on the public classic page.
- Ensure span filtering is applied only when the game-page-v2 experience is active.

Enhancements:
- Disable caching for `?span=` game URLs while the v2 page is in preview so public and preview responses cannot be mixed.
- Centralize span selection based on feature state and viewer context.

Tests:
- Add coverage for public, preview, invalid-span, and cache-guard behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shared game links with `?span=` parameters.
  * Public game pages now ignore unsupported span values, while preview pages preserve valid spans.
  * Invalid span parameters are rejected to prevent incorrect game views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->