### PR TITLE
fix(dq): derive our box under official conventions so zero is the target

### DIFF
--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -81,7 +81,7 @@ const subtitle = "Operational dashboards for Game on Paper";
       a TD counts as a first down, penalties count accepted flags), so <b>zero IS the target</b>; residuals of a few
       yards/units per game are normal spotter-vs-play-text noise. The signal is a <b>stable</b> delta distribution
       &mdash; a shift aligned with an sdv-py version is a parser regression. Rows before 2026-09-07 predate this
-      reconciliation and read much worse.</p></div>
+      reconciliation and are excluded from these views (per-game detail still shows whatever the latest batch holds).</p></div>
     <h6 class="admin-label">Scorecard · <span id="dq-days">14</span>d</h6>
     <div class="card twrap"><table class="table table-sm mb-0" id="t-dqscore"></table></div>
     <div class="grid2 mt-2">

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -76,10 +76,12 @@ const subtitle = "Operational dashboards for Game on Paper";
     <div id="err-recent"></div>
   </section>
   <section id="dq">
-    <div class="card"><p class="admin-muted m-0">Play-flag box score vs ESPN's official team box, per completed game.
-      Zero is not the target for every stat (our pass flag counts sacks; ESPN's net passing subtracts sack yardage;
-      penalty yards differ in sign) &mdash; the signal is a <b>stable</b> delta distribution. A shift aligned with an
-      sdv-py version is a parser regression.</p></div>
+    <div class="card"><p class="admin-muted m-0">Play-derived box score vs ESPN's official team box, per completed game.
+      Our side is computed under official conventions (sacks count as rushes, pass yards are completions only,
+      a TD counts as a first down, penalties count accepted flags), so <b>zero IS the target</b>; residuals of a few
+      yards/units per game are normal spotter-vs-play-text noise. The signal is a <b>stable</b> delta distribution
+      &mdash; a shift aligned with an sdv-py version is a parser regression. Rows before 2026-09-07 predate this
+      reconciliation and read much worse.</p></div>
     <h6 class="admin-label">Scorecard · <span id="dq-days">14</span>d</h6>
     <div class="card twrap"><table class="table table-sm mb-0" id="t-dqscore"></table></div>
     <div class="grid2 mt-2">

--- a/python/dq.py
+++ b/python/dq.py
@@ -8,26 +8,31 @@ Two products, both written through TEL after a completed game is processed:
   play-text flags (``advBoxScore.team``) and ESPN's official team box
   (``advBoxScore.espn_team``), plus reference-free lints over the plays.
 
-Zero is NOT the target for every stat -- our ``pass`` flag counts sacks and
-ESPN's net passing subtracts sack yardage, so some pairs carry a structural
-offset. The dashboard's signal is the STABILITY of each delta's distribution
-across games and sdv-py versions: a parser regression shows up as a
-version-aligned shift, the way the 2025 late-insert and penalty-EPA bugs
-would have.
+Our side is derived from plays under ESPN/NCAA OFFICIAL conventions rather
+than read off ``advBoxScore.team`` -- those columns are modeling aggregates
+(adjusted rush yardage, sacks kept with pass plays, penalty first downs split
+out), and diffing them against the official box drowned real signal in
+convention offsets (rush_yards had |delta|>2 in 86%% of games). Conventions,
+measured against 16 team-games on 2026-09-07:
+
+- sacks are RUSHING attempts and their (negative) yardage is rushing yardage;
+- pass yards count completions only (``netPassingYards`` is gross in CFB);
+- attempts/completions come from the official ``completionAttempts`` "C/A"
+  string (there is no ``pass_attempts`` key -- the old pair diffed against
+  None forever);
+- a touchdown counts as a first down;
+- penalties count ACCEPTED flags only, attributed via ``penalty_team_id``.
+
+Residual deltas are a few yards/units per game (spotters vs play-text); the
+dashboard's signal is the STABILITY of each delta's distribution across games
+and sdv-py versions -- a parser regression shows up as a version-aligned
+shift, the way the 2025 late-insert and penalty-EPA bugs would have.
+Rows written before 2026-09-07 predate this reconciliation (and use the stat
+name ``first_downs_created`` instead of ``first_downs``); window queries
+accordingly.
 """
 
 from datetime import datetime, timezone
-
-# (stat name, our team-box column, ESPN official-box key)
-BOX_PAIRS = [
-    ("rush_attempts", "rushes", "rushingAttempts"),
-    ("rush_yards", "rush_yards", "rushingYards"),
-    ("pass_attempts", "passes", "pass_attempts"),
-    ("pass_yards", "pass_yards", "netPassingYards"),
-    ("penalties", "penalties", "penalties"),
-    ("penalty_yards", "penalty_yards", "penalty_yards"),
-    ("first_downs_created", None, "firstDowns"),  # ours = passing + rushing created
-]
 
 
 def _num(v):
@@ -64,6 +69,85 @@ def build_game_meta_row(header, game_id):
     }
 
 
+def _parse_ca(v):
+    """ESPN's ``completionAttempts`` "15/21" -> (15.0, 21.0)."""
+    parts = str(v or "").split("/")
+    if len(parts) != 2:
+        return None, None
+    return _num(parts[0]), _num(parts[1])
+
+
+def _official_box(plays, team_box):
+    """Per-team stats under official conventions, derived from plays.
+
+    See the module docstring for the convention list and its measurement.
+    """
+    agg = {}
+
+    def team(tid):
+        return agg.setdefault(
+            int(tid),
+            {
+                "rush_attempts": 0.0,
+                "rush_yards": 0.0,
+                "pass_attempts": 0.0,
+                "completions": 0.0,
+                "pass_yards": 0.0,
+                "first_downs": 0.0,
+                "penalties": 0.0,
+                "penalty_yards": 0.0,
+            },
+        )
+
+    for p in plays:
+        tid = p.get("pos_team")
+        if tid is not None:
+            a = team(tid)
+            yards = _num(p.get("statYardage")) or 0.0
+            if p.get("sack") == True:  # noqa: E712
+                a["rush_attempts"] += 1
+                a["rush_yards"] += _num(p.get("yds_sacked")) or 0.0
+            elif p.get("rush") == True:  # noqa: E712
+                a["rush_attempts"] += 1
+                a["rush_yards"] += yards
+            elif p.get("pass") == True:  # noqa: E712
+                a["pass_attempts"] += 1
+                if p.get("completion") == True:  # noqa: E712
+                    a["completions"] += 1
+                    a["pass_yards"] += yards
+            # A TD counts as a first down officially; scrimmage TDs don't
+            # carry first_down_created, so add them on top of the box counts.
+            if (
+                p.get("scrimmage_play") == True  # noqa: E712
+                and p.get("touchdown") == True  # noqa: E712
+                and p.get("first_down_created") != True  # noqa: E712
+            ):
+                a["first_downs"] += 1
+        ptid = p.get("penalty_team_id")
+        if (
+            ptid is not None
+            and p.get("penalty_flag") == True  # noqa: E712
+            and p.get("penalty_declined") != True  # noqa: E712
+        ):
+            pa = team(ptid)
+            pa["penalties"] += 1
+            pa["penalty_yards"] += abs(_num(p.get("yds_penalty")) or 0.0)
+    # First downs by pass/rush/penalty come from the box counts (which match
+    # the official tally); only the TD top-up above is play-derived.
+    for t in team_box or []:
+        tid = t.get("pos_team")
+        if tid is None:
+            continue
+        a = team(tid)
+        for k in (
+            "passing_first_downs_created",
+            "rushing_first_downs_created",
+            "penalty_first_downs_created",
+        ):
+            a["first_downs"] += _num(t.get(k)) or 0.0
+    return agg
+
+
 def build_dq_rows(processed_game, game_id, sdv_version=None, sdv_sha=None):
     """Per-team box deltas + game-level lints for one completed game."""
     ts = datetime.now(timezone.utc)
@@ -75,28 +159,26 @@ def build_dq_rows(processed_game, game_id, sdv_version=None, sdv_sha=None):
     }
     rows = []
     box = processed_game.get("advBoxScore") or {}
-    espn_by_team = {
-        int(t["team_id"]): t
-        for t in box.get("espn_team") or []
-        if t.get("team_id") is not None
-    }
-    for team in box.get("team") or []:
-        tid = team.get("pos_team")
-        if tid is None or int(tid) not in espn_by_team:
+    plays = processed_game.get("plays") or []
+    ours_by_team = _official_box(plays, box.get("team"))
+    for espn in box.get("espn_team") or []:
+        tid = espn.get("team_id")
+        if tid is None or int(tid) not in ours_by_team:
             continue
-        espn = espn_by_team[int(tid)]
-        for stat, ours_key, espn_key in BOX_PAIRS:
-            if ours_key is None:
-                ours = _num(team.get("passing_first_downs_created"))
-                extra = _num(team.get("rushing_first_downs_created"))
-                ours = (
-                    None
-                    if ours is None and extra is None
-                    else (ours or 0) + (extra or 0)
-                )
-            else:
-                ours = _num(team.get(ours_key))
-            theirs = _num(espn.get(espn_key))
+        ours_box = ours_by_team[int(tid)]
+        comp, att = _parse_ca(espn.get("completionAttempts"))
+        espn_vals = {
+            "rush_attempts": _num(espn.get("rushingAttempts")),
+            "rush_yards": _num(espn.get("rushingYards")),
+            "pass_attempts": att,
+            "completions": comp,
+            "pass_yards": _num(espn.get("netPassingYards")),
+            "first_downs": _num(espn.get("firstDowns")),
+            "penalties": _num(espn.get("penalties")),
+            "penalty_yards": _num(espn.get("penalty_yards")),
+        }
+        for stat, theirs in espn_vals.items():
+            ours = ours_box[stat]
             if ours is None and theirs is None:
                 continue
             rows.append(

--- a/python/gop_routes.py
+++ b/python/gop_routes.py
@@ -166,6 +166,13 @@ def _errors(args):
     }
 
 
+# Rows written before this predate the official-conventions reconciliation in
+# dq.py (sacks-as-rushes, completions-only pass yards, TD first downs,
+# accepted-only penalties) and carry structurally huge deltas under the SAME
+# stat names -- mixing them into a window makes every bucket read as broken.
+DQ_RECONCILED_SINCE = "2026-09-07"
+
+
 def _dq(args):
     """Box-vs-official deltas and lints. Stability across sdv_py_sha is the
     signal; a version-aligned shift in a stat's delta distribution is a parser
@@ -181,19 +188,19 @@ def _dq(args):
                 round(percentile_cont(0.5) WITHIN GROUP (ORDER BY delta)::numeric, 2)::float AS median_delta,
                 round(max(abs(delta))::numeric, 1)::float AS worst
             FROM gop.dq_boxscore
-            WHERE ts > now() - make_interval(days => %s) AND delta IS NOT NULL
-                AND stat NOT LIKE 'lint:%%'
+            WHERE ts > now() - make_interval(days => %s) AND ts >= %s::timestamptz
+                AND delta IS NOT NULL AND stat NOT LIKE 'lint:%%'
             GROUP BY 1 ORDER BY 1""",
-            (days,),
+            (days, DQ_RECONCILED_SINCE),
         ),
         "by_version": _q(
             """SELECT sdv_py_version, sdv_py_sha, stat,
                 count(*)::int AS n, round(avg(delta)::numeric, 2)::float AS mean_delta
             FROM gop.dq_boxscore
-            WHERE ts > now() - make_interval(days => %s) AND delta IS NOT NULL
-                AND stat NOT LIKE 'lint:%%'
+            WHERE ts > now() - make_interval(days => %s) AND ts >= %s::timestamptz
+                AND delta IS NOT NULL AND stat NOT LIKE 'lint:%%'
             GROUP BY 1, 2, 3 ORDER BY max(ts) DESC, 3 LIMIT 60""",
-            (days,),
+            (days, DQ_RECONCILED_SINCE),
         ),
         "worst_games": _q(
             """SELECT d.game_id,
@@ -203,12 +210,12 @@ def _dq(args):
                 count(*) FILTER (WHERE d.delta <> 0)::int AS stats_off
             FROM gop.dq_boxscore d
             LEFT JOIN gop.game_meta gm ON gm.game_id = d.game_id
-            WHERE d.ts > now() - make_interval(days => %s)
+            WHERE d.ts > now() - make_interval(days => %s) AND d.ts >= %s::timestamptz
                 AND d.delta IS NOT NULL AND d.stat NOT LIKE 'lint:%%'
                 -- a reprocessed game writes a fresh batch; only its latest counts
                 AND d.ts = (SELECT max(ts) FROM gop.dq_boxscore WHERE game_id = d.game_id)
             GROUP BY 1, 2 ORDER BY total_abs_delta DESC LIMIT 25""",
-            (days,),
+            (days, DQ_RECONCILED_SINCE),
         ),
         "lints": _q(
             """SELECT stat, count(*) FILTER (WHERE delta > 0)::int AS games_flagged,

--- a/python/tests/test_dq.py
+++ b/python/tests/test_dq.py
@@ -39,64 +39,81 @@ def test_game_meta_row_survives_empty_header():
     assert r["game_id"] == 1 and r["away_abbr"] is None
 
 
-def test_dq_rows_pair_teams_and_compute_deltas():
+def test_dq_rows_derive_official_conventions_from_plays():
+    # One team, plays covering every convention: a rush; a sack (a RUSH
+    # attempt officially, negative yardage); a completion; an incompletion
+    # (no pass yards); a TD run without first_down_created (counts as a
+    # first down officially); an accepted and a declined penalty.
     game = {
         "advBoxScore": {
             "team": [
                 {
                     "pos_team": 2628,
-                    "rushes": 30,
-                    "rush_yards": 120,
-                    "passes": 25,
-                    "pass_yards": 210,
-                    "penalties": 5,
-                    "penalty_yards": -40,
                     "passing_first_downs_created": 8,
                     "rushing_first_downs_created": 6,
+                    "penalty_first_downs_created": 1,
                 },
             ],
             "espn_team": [
                 {
                     "team_id": 2628,
-                    "rushingAttempts": 30,
-                    "rushingYards": 118,
-                    "pass_attempts": 24,
-                    "netPassingYards": 200,
-                    "penalties": 5,
-                    "penalty_yards": 40,
-                    "firstDowns": 16,
+                    "rushingAttempts": 3,
+                    "rushingYards": 4,  # ours: 8 - 7 + 5 = 6 -> delta +2
+                    "completionAttempts": "1/2",
+                    "netPassingYards": 15,
+                    "firstDowns": 16,  # ours: 8 + 6 + 1 + 1 TD = 16 -> delta 0
+                    "penalties": 1,
+                    "penalty_yards": 10,
                 },
             ],
         },
         "plays": [
             {
+                "pos_team": 2628,
+                "rush": True,
+                "statYardage": 8,
                 "scrimmage_play": True,
                 "EPA": None,
                 "wp_before": 0.5,
                 "wp_after": 1.2,
                 "EP_between": -4.0,
             },
+            {"pos_team": 2628, "pass": True, "sack": True, "yds_sacked": -7},
+            {"pos_team": 2628, "pass": True, "completion": True, "statYardage": 15},
+            {"pos_team": 2628, "pass": True, "completion": False, "statYardage": 0},
             {
+                "pos_team": 2628,
+                "rush": True,
+                "statYardage": 5,
                 "scrimmage_play": True,
-                "EPA": 0.3,
-                "wp_before": 0.6,
-                "wp_after": 0.61,
-                "EP_between": 0.0,
+                "touchdown": True,
+                "first_down_created": False,
+                "EPA": 3.1,
+            },
+            {"penalty_flag": True, "penalty_team_id": 2628, "yds_penalty": -10},
+            {
+                "penalty_flag": True,
+                "penalty_declined": True,
+                "penalty_team_id": 2628,
+                "yds_penalty": 5,
             },
         ],
     }
     rows = dq.build_dq_rows(game, 401856766, "0.1.3", "abc123")
     by = {(r["team_id"], r["stat"]): r for r in rows}
+    assert by[(2628, "rush_attempts")]["ours"] == 3.0  # sack included
     assert by[(2628, "rush_yards")]["delta"] == 2.0
-    assert by[(2628, "pass_attempts")]["delta"] == 1.0
-    assert (
-        by[(2628, "first_downs_created")]["ours"] == 14.0
-        and by[(2628, "first_downs_created")]["delta"] == -2.0
-    )
+    assert by[(2628, "pass_attempts")]["ours"] == 2.0  # sack excluded
+    assert by[(2628, "pass_attempts")]["delta"] == 0.0
+    assert by[(2628, "completions")]["delta"] == 0.0
+    assert by[(2628, "pass_yards")]["ours"] == 15.0  # completions only
+    assert by[(2628, "first_downs")]["ours"] == 16.0  # box counts + the TD
+    assert by[(2628, "penalties")]["ours"] == 1.0  # declined not counted
+    assert by[(2628, "penalty_yards")]["ours"] == 10.0  # accepted, absolute
     assert by[(None, "lint:epa_null")]["delta"] == 1.0
     assert by[(None, "lint:wp_oob")]["delta"] == 1.0
     assert by[(None, "lint:ep_between_big")]["delta"] == 1.0
-    assert by[(None, "plays")]["ours"] == 2.0
+    assert by[(None, "plays")]["ours"] == 7.0
     assert all(r["sdv_py_sha"] == "abc123" for r in rows)
 
 


### PR DESCRIPTION
The DQ scorecard was unusable as a regression gate: **rush_yards showed |Δ|>2 in 86% of games** (16.3k of 18.9k checks), penalty_yards 76%, first_downs 61% — and pass_attempts had **zero** exact matches because ESPN's box has no `pass_attempts` key at all (it's the `completionAttempts` "C/A" string), so every one of those 18,934 deltas was silently NULL.

None of that was parser bugs. `advBoxScore.team` columns are **modeling aggregates** (adjusted rush yardage — 214 vs a play-sum of 149 in the worst game — sacks kept with pass plays, penalty first downs split out), while ESPN's box follows official NCAA conventions.

## Change
`build_dq_rows` now derives our side **directly from plays** under official conventions, each verified empirically against 16 team-games from yesterday's slate:

| convention | evidence |
|---|---|
| sacks are rushing attempts; `yds_sacked` (negative) is rushing yardage | rush_att MAD 2.88 → 0.56, 16/16 within 2 |
| pass yards count completions only (`netPassingYards` is gross in CFB) | 13/16 exact |
| attempts/completions parsed from `completionAttempts` "15/21" | pass_att 13/16 exact (was all-NULL); new `completions` stat 15/16 exact |
| a TD counts as a first down | first_downs MAD 4.06 → 1.94 |
| penalties count accepted flags only, attributed via `penalty_team_id` | pen count 16/16 within 2 |

rush_yards mean |Δ| **24.8 → 3.2**. Residuals are spotter-vs-play-text noise; the scorecard's zero/≤2 buckets are now meaningful and a version-aligned shift again means what the dashboard says it means.

`first_downs_created` → `first_downs` (semantics changed: penalty first downs + TDs included). Rows before 2026-09-07 predate the reconciliation; the admin tab explainer says so.

## Tests
New conventions covered play-by-play in `test_dq.py` (sack, completion/incompletion, TD without first_down_created, accepted + declined penalties, C/A parse); 28 python tests pass.

## Summary by Sourcery

Align DQ box-score reconciliation with official NCAA/ESPN conventions so zero-centered deltas provide a meaningful regression signal.

New Features:
- Derive team box-score comparison metrics from play-by-play data using official NCAA/ESPN conventions, including sacks as rushing plays, completion-based passing yards, touchdown first downs, and accepted penalties.
- Parse ESPN completion/attempt totals and add completion comparisons to the DQ scorecard.

Bug Fixes:
- Correct pass-attempt comparisons that previously produced NULL values because ESPN exposes attempts through the completionAttempts field.
- Reduce convention-driven discrepancies in rushing, passing, first-down, penalty, and penalty-yardage DQ metrics.

Enhancements:
- Exclude pre-reconciliation DQ rows from dashboard window and version queries so scorecards reflect comparable data.
- Rename first_downs_created to first_downs to reflect expanded official first-down semantics.
- Update the admin DQ explanation to describe official conventions, meaningful zero targets, and historical data boundaries.

Tests:
- Add play-by-play coverage for sacks, completions and incompletions, touchdown first downs, accepted and declined penalties, and completion/attempt parsing.

## Preview

Before/after scorecard — left is the live table today (18,936 checks/stat), right is the reconciled writer measured on 16 team-games from Saturday's slate:

![before/after DQ scorecard](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr214-dq-scorecard.png)
