### PR TITLE
feat(game): shade the active ?span= window on the WP chart

### DIFF
--- a/astro/public/assets/css/base.css
+++ b/astro/public/assets/css/base.css
@@ -245,3 +245,13 @@ Target Matrix
   .site-nav-row .nav-link { white-space: nowrap; }
 }
 
+
+/* Span pills: 44px tap floor on touch devices (v2 mobile audit 2026-09-07 --
+   btn-sm renders 31px tall, under the tap-target floor). */
+@media (pointer: coarse) {
+  .span-pills .btn {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+}

--- a/astro/src/components/charts/WinProbabilityChart.svelte
+++ b/astro/src/components/charts/WinProbabilityChart.svelte
@@ -5,7 +5,7 @@ import { cleanAbbreviation, roundNumber, getNumberWithOrdinal, translateValue, g
 import { SPECIAL_IMAGES, SPECIAL_IMAGES_DARK } from '../../utils/constants'
 import { GradientFillLineController } from '../../resources/chart'
 
-const { id, homeComp, awayComp, gameStatus, homeTeamSpread, overUnder, plays, percentiles, gei } = $props()
+const { id, homeComp, awayComp, gameStatus, homeTeamSpread, overUnder, plays, percentiles, gei, spanShade = null } = $props()
 const homeTeam = homeComp.team;
 const awayTeam = awayComp.team;
 
@@ -51,6 +51,31 @@ function createVerticalLinePlugin(id, title, value, color, lineWidth, xAxisId = 
     return {
         id: id,
         beforeDraw: callback
+    };
+}
+
+// Translucent box over the active ?span= window (chart data stays full-game;
+// a WP chart of one quarter alone is misleading). Same canvas-plugin pattern
+// as createVerticalLinePlugin; indices are positions on the x axis.
+function createSpanShadePlugin(shade, isDarkMode) {
+    return {
+        id: 'span-shade',
+        beforeDatasetsDraw: (chart) => {
+            const xScale = chart.scales.x;
+            if (!xScale) return;
+            const x0 = xScale.getPixelForValue(shade.from);
+            const x1 = xScale.getPixelForValue(shade.to);
+            const { top, bottom } = chart.chartArea;
+            const ctx = chart.ctx;
+            ctx.save();
+            ctx.fillStyle = isDarkMode ? 'rgba(255, 213, 79, 0.10)' : 'rgba(255, 193, 7, 0.14)';
+            ctx.fillRect(x0, top, x1 - x0, bottom - top);
+            ctx.textAlign = 'left';
+            ctx.font = 'bold 10px Helvetica';
+            ctx.fillStyle = isDarkMode ? '#ffd54f' : '#b45309';
+            ctx.fillText(shade.label, x0 + 4, bottom - 6);
+            ctx.restore();
+        },
     };
 }
 
@@ -207,6 +232,7 @@ async function generateChart() {
     var wpChart = new Chart(document.getElementById("wpChart"), {
         type: 'GradientFillLineController',
         plugins: [
+            ...(spanShade ? [createSpanShadePlugin(spanShade, isDarkMode)] : []),
             ...periodMarkers,
             {
                 beforeDatasetDraw: (chart) => {

--- a/astro/src/components/charts/WinProbabilityChart.svelte
+++ b/astro/src/components/charts/WinProbabilityChart.svelte
@@ -64,7 +64,8 @@ function createSpanShadePlugin(shade, isDarkMode) {
             const xScale = chart.scales.x;
             if (!xScale) return;
             const x0 = xScale.getPixelForValue(shade.from);
-            const x1 = xScale.getPixelForValue(shade.to);
+            // a one-play window has from === to; keep the box visible
+            const x1 = Math.max(xScale.getPixelForValue(shade.to), x0 + 3);
             const { top, bottom } = chart.chartArea;
             const ctx = chart.ctx;
             ctx.save();

--- a/astro/src/components/charts/WinProbabilityChart.svelte
+++ b/astro/src/components/charts/WinProbabilityChart.svelte
@@ -64,8 +64,13 @@ function createSpanShadePlugin(shade, isDarkMode) {
             const xScale = chart.scales.x;
             if (!xScale) return;
             const x0 = xScale.getPixelForValue(shade.from);
-            // a one-play window has from === to; keep the box visible
-            const x1 = Math.max(xScale.getPixelForValue(shade.to), x0 + 3);
+            // each play occupies [x(i), x(i+1)): an inclusive-to band ends at
+            // the NEXT play's x, which for a whole quarter is exactly the next
+            // period's marker (QA on #215 -- the edge was one play short).
+            // The last play of the game has no next x; clamp to the axis end.
+            const xEnd = Math.min(shade.to + 1, (chart.data.labels?.length ?? 1) - 1);
+            // a one-play window at the axis end still keeps a visible box
+            const x1 = Math.max(xScale.getPixelForValue(xEnd), x0 + 3);
             const { top, bottom } = chart.chartArea;
             const ctx = chart.ctx;
             ctx.save();

--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -179,12 +179,29 @@ const epPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
 });
 const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
     return {
-        pos_team: p.pos_team, 
+        pos_team: p.pos_team,
         period: p.period,
         winProbability: p.winProbability,
         gameSpreadAvailable: p.gameSpreadAvailable
     }
 });
+// Charts stay full-game under a span (a WP chart of Q3 alone is misleading);
+// the active window is shaded on the full x-axis instead. Indices live in the
+// scrimmage-play sequence -- the WP chart's x-axis. The EP chart is skipped:
+// its x-axis is each team's own play count, so one shaded interval per game
+// does not exist there.
+let spanShade: { from: number, to: number, label: string } | null = null;
+if (activeSpan) {
+    const scrimmage = fullGamePlays.filter((p: any) => p.scrimmage_play == true);
+    let from = -1, to = -1;
+    scrimmage.forEach((p: any, i: number) => {
+        if (activeSpan.test(p)) {
+            if (from === -1) from = i;
+            to = i;
+        }
+    });
+    if (from !== -1) spanShade = { from, to, label: activeSpan.label };
+}
 ---
 <!DOCTYPE html>
 <html>
@@ -271,7 +288,7 @@ const wpPlays = fullGamePlays.filter(p => (p.scrimmage_play == true)).map(p => {
      inside the Svelte charts, and a duplicate id makes getElementById hand
      Chart.js the wrapper div -- both charts then silently never draw. -->
                 <div id="wp-section" class="col-lg-6 ms-sm-auto px-md-4">
-                    <WinProbabilityChart client:only id={id} homeComp={homeComp} awayComp={awayComp} gameStatus={game.header.competitions[0].status} homeTeamSpread={game.homeTeamSpread} overUnder={game.overUnder} plays={wpPlays} percentiles={percentiles} gei={game.gei}>
+                    <WinProbabilityChart client:only id={id} homeComp={homeComp} awayComp={awayComp} gameStatus={game.header.competitions[0].status} homeTeamSpread={game.homeTeamSpread} overUnder={game.overUnder} plays={wpPlays} percentiles={percentiles} gei={game.gei} spanShade={spanShade}>
                         <FallbackSpinner slot="fallback" />
                     </WinProbabilityChart>
                 </div>

--- a/astro/test/gamePage.render.test.ts
+++ b/astro/test/gamePage.render.test.ts
@@ -422,6 +422,18 @@ describe('box-score names jump into the play filter', () => {
     });
 });
 
+// The props of the WinProbabilityChart astro-island. A lazy cross-tag regex
+// can land on a NEIGHBORING island's props attribute, so scope to one tag.
+function wpIslandProps(html: string): string {
+    const tag = [...html.matchAll(/<astro-island[^>]*>/g)]
+        .map((m) => m[0])
+        .find((t) => t.includes('WinProbabilityChart'));
+    expect(tag).toBeTruthy();
+    const props = tag!.match(/ props="([^"]+)"/);
+    expect(props).toBeTruthy();
+    return props![1].replace(/&quot;/g, '"');
+}
+
 describe('the ?span= filter narrows the page to a window', () => {
     test('a Q3 span keeps only third-quarter rows in the All Plays table', async () => {
         const { retrieveProcessedGame } = await import('../src/resources/python');
@@ -440,6 +452,20 @@ describe('the ?span= filter narrows the page to a window', () => {
         expect(spanned).toMatch(/Showing <strong>Q3<\/strong> only/);
         // the charts keep the whole game: the WP chart island still carries all four periods
         expect(spanned).toMatch(/astro-island[^>]+WinProbabilityChart/);
+        // ... and the active window arrives as spanShade indices for the shading plugin
+        const props = wpIslandProps(spanned);
+        expect(props).toMatch(/"spanShade":\[0,\{"from":\[0,\d+\],"to":\[0,\d+\],"label":\[0,"Q3"\]\}\]/);
+    });
+
+    test('no span means a null spanShade on the WP chart island', async () => {
+        const { retrieveProcessedGame } = await import('../src/resources/python');
+        const game: any = await retrieveProcessedGame(GAME_ID, 30);
+        const { default: GamePage } = await import('../src/components/game/GamePage.astro');
+        const plain = await container.renderToString(GamePage, {
+            props: { id: GAME_ID, game },
+            request: new Request(`https://gameonpaper.com/game/${GAME_ID}`),
+        });
+        expect(wpIslandProps(plain)).toContain('"spanShade":[0,null]');
     });
 
     test('the span is forwarded to the python API so the boxes recompute server-side', async () => {


### PR DESCRIPTION
Span-filter plan phase 2 (`plans/2026-09-03-gop-game-page-span-filter.md`): the WP chart deliberately keeps full-game data under `?span=` — a WP chart of Q3 alone is misleading — but nothing showed *where* the active window sat. Now the window is drawn as a translucent amber box with the span label, via the same canvas-plugin pattern as the existing period markers.

- `GamePage.astro` computes `spanShade` `{from, to, label}` as indices into the scrimmage-play sequence (the chart's x-axis), right next to the span filter, and passes it to the WP island; `null` when no span.
- `WinProbabilityChart.svelte` registers a `span-shade` plugin only when the prop is set; dark-mode-aware colors.
- **EP chart intentionally not shaded**: its x-axis is each team's own play count (two scales in one scatter), so a single shaded interval per game does not exist there.

Preview-gated by construction — only the v2 `GamePage` computes and passes the prop; the classic snapshot is untouched.

## Tests
Island-scoped prop assertions (a lazy cross-tag regex was matching the neighboring EP island — the helper scopes to one `<astro-island>` tag): `?span=q3` serializes `spanShade` with from/to/label; no span serializes `null`. Full suite: 199 passed.

## Summary by Sourcery

Show the active span window on full-game win-probability charts without changing the underlying chart data.

New Features:
- Shade the active span-filter window on full-game win-probability charts with a labeled, dark-mode-aware overlay.

Enhancements:
- Preserve full-game chart data while making the selected span visually identifiable; leave expected-points charts unshaded because their axes are incompatible with a single game-wide interval.
- Improve span-pill touch usability by meeting a 44px minimum tap target on coarse pointers.

Tests:
- Add render assertions covering serialized span shading data for Q3 filters and null data when no span is selected.

## Preview

The real plugin drawing over COLO @ TCU's actual WP data (top: no span; bottom: `?span=q3`):

![WP chart with and without the Q3 shade](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr215-wp-shade.png)