### PR TITLE
feat(scoreboard): banner-style mobile game rows grouped by kickoff time, preview-flagged

### DIFF
--- a/astro/public/assets/css/dark-index.css
+++ b/astro/public/assets/css/dark-index.css
@@ -2529,7 +2529,7 @@
     }
 }
 @media (prefers-color-scheme: dark) {
-    .game-compact-list { border-top-color: #3e4446; }
-    .game-compact-row { border-bottom-color: #3e4446; }
-    .game-compact-row .gcr-rank, .game-compact-row .gcr-status { color: #a8a095; }
+    .game-banner { background: #23272b; border-color: #3e4446; }
+    .game-banner .gb-city, .game-banner .gb-mid, .gb-slot { color: #a8a095; }
+    .game-banner .gb-stripe img { filter: drop-shadow(0 0 2px rgba(0,0,0,0.5)); }
 }

--- a/astro/public/assets/css/dark-index.css
+++ b/astro/public/assets/css/dark-index.css
@@ -2528,3 +2528,8 @@
         color: rgb(35, 148, 253) !important; /* #eeb211*/
     }
 }
+@media (prefers-color-scheme: dark) {
+    .game-compact-list { border-top-color: #3e4446; }
+    .game-compact-row { border-bottom-color: #3e4446; }
+    .game-compact-row .gcr-rank, .game-compact-row .gcr-status { color: #a8a095; }
+}

--- a/astro/public/assets/css/dark-index.css
+++ b/astro/public/assets/css/dark-index.css
@@ -2528,8 +2528,3 @@
         color: rgb(35, 148, 253) !important; /* #eeb211*/
     }
 }
-@media (prefers-color-scheme: dark) {
-    .game-banner { background: #23272b; border-color: #3e4446; }
-    .game-banner .gb-city, .game-banner .gb-mid, .gb-slot { color: #a8a095; }
-    .game-banner .gb-stripe img { filter: drop-shadow(0 0 2px rgba(0,0,0,0.5)); }
-}

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -180,77 +180,18 @@ h1, h2, h3, h4, h5, h6 {
     color: #2394fd !important; /* #eeb211*/
 }
 /* Banner scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
-   Slanted team-color stripes + logos on the edges; the two teams stacked
-   inside with full school names; status in its own column; grouped under
-   kickoff-time headers (.gb-slot). Type follows the site: the Chivo stack
-   (the list is not a .row, so it opts in explicitly), bootstrap heading
-   weight, and TeamRow's winner-bold / loser-half-opacity treatment. */
+   Bootstrap utilities carry the layout; this block is only what Bootstrap
+   cannot express: the Chivo opt-in (the list is not a .row, which is where
+   the site applies the stack), the slanted color stripes, and tabular
+   score digits so the stacked scores align. */
 .game-compact-list {
     font-family: "Chivo", "Fira Mono", serif;
 }
-.gb-slot {
-    margin: 14px 2px 6px;
-    font-size: .875rem;
-    color: #6c757d;
-}
-.game-banner {
-    display: grid;
-    grid-template-columns: 46px minmax(0, 1fr) minmax(52px, auto) 46px;
-    align-items: center;
-    gap: 8px;
-    min-height: 64px;
-    margin-bottom: 8px;
-    border: 1px solid #dee2e6;
-    border-radius: 0.5em;
-    overflow: hidden;
-    background: #fff;
-    color: inherit;
-    text-decoration: none;
-}
 .game-banner .gb-stripe {
-    align-self: stretch;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    width: 46px;
+    flex: none;
 }
 .game-banner .gb-stripe img { filter: drop-shadow(0 0 2px rgba(255,255,255,0.6)); }
 .game-banner .gb-stripe-away { clip-path: polygon(0 0, 100% 0, calc(100% - 12px) 100%, 0 100%); }
 .game-banner .gb-stripe-home { clip-path: polygon(12px 0, 100% 0, 100% 100%, 0 100%); }
-.game-banner .gb-teams {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    min-width: 0;
-    padding: 8px 0;
-}
-.game-banner .gb-line {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 10px;
-}
-.game-banner .gb-nm {
-    font-size: 1.05rem;
-    font-weight: 500;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 0;
-}
-.game-banner .gb-rank {
-    font-size: .75rem;
-    color: #6c757d;
-}
-.game-banner .gb-pts {
-    font-size: 1.15rem;
-    font-weight: 500;
-    font-variant-numeric: tabular-nums;
-}
-.game-banner .gb-won { font-weight: 700; }
-.game-banner .gb-lost { opacity: 0.5; }
-.game-banner .gb-mid {
-    font-size: .75rem;
-    color: #6c757d;
-    text-align: center;
-    white-space: nowrap;
-}
+.game-banner .gb-pts { font-variant-numeric: tabular-nums; }

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -204,7 +204,9 @@ h1, h2, h3, h4, h5, h6 {
 .game-banner .gb-side {
     display: flex;
     align-items: center;
-    gap: 0.2rem;
+    /* 0.2rem read too tight between logo and abbreviation (maintainer);
+       fluid so the double-ranked 4-char worst case still fits at 320 */
+    gap: clamp(0.2rem, 1.5vw, 0.375rem);
     min-width: 0;
     /* any overflow value but visible lets the flex item shrink below its
        content, which is what keeps a long side from shoving the grid */
@@ -239,7 +241,7 @@ h1, h2, h3, h4, h5, h6 {
 .game-banner .gb-pts {
     font-size: clamp(1.05rem, 4.6vw, 1.25rem);
     font-variant-numeric: tabular-nums;
-    min-width: clamp(1.4rem, 5vw, 1.75rem);
+    min-width: clamp(1.25rem, 5vw, 1.75rem);
     text-align: center;
 }
 .game-banner .gb-mid { font-size: clamp(0.65rem, 3vw, 0.75rem); }

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -179,19 +179,68 @@ h1, h2, h3, h4, h5, h6 {
 .text-favorite {
     color: #2394fd !important; /* #eeb211*/
 }
-/* Banner scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
-   Bootstrap utilities carry the layout; this block is only what Bootstrap
-   cannot express: the Chivo opt-in (the list is not a .row, which is where
-   the site applies the stack), the slanted color stripes, and tabular
-   score digits so the stacked scores align. */
+/* Scoreboard banner rows (GameCompactRow, preview 'scoreboard-compact') --
+   the chosen "Option E": one mirrored line per game, no color stripes.
+   Bootstrap utilities carry what they can; this block holds the grid (a
+   fixed score|status|score middle keeps every row's numbers dead-center),
+   the viewport-clamped type that keeps a double-ranked 4-char matchup from
+   clipping at 320, the logo-corner possession badge, and the Chivo opt-in
+   (the list is not a .row, which is where the site applies the stack). */
 .game-compact-list {
     font-family: "Chivo", "Fira Mono", serif;
 }
-.game-banner .gb-stripe {
-    width: 46px;
-    flex: none;
+.gb-slot {
+    margin: 14px 2px 6px;
+    font-size: .875rem;
+    color: #6c757d;
 }
-.game-banner .gb-stripe img { filter: drop-shadow(0 0 2px rgba(255,255,255,0.6)); }
-.game-banner .gb-stripe-away { clip-path: polygon(0 0, 100% 0, calc(100% - 12px) 100%, 0 100%); }
-.game-banner .gb-stripe-home { clip-path: polygon(12px 0, 100% 0, 100% 100%, 0 100%); }
-.game-banner .gb-pts { font-variant-numeric: tabular-nums; }
+.game-banner {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(clamp(3.6rem, 18vw, 5rem), auto) auto minmax(0, 1fr);
+    align-items: center;
+    column-gap: 0.2rem;
+    padding-inline: clamp(0.25rem, 2vw, 0.5rem);
+}
+.game-banner .gb-side {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    min-width: 0;
+    /* any overflow value but visible lets the flex item shrink below its
+       content, which is what keeps a long side from shoving the grid */
+    overflow: hidden;
+}
+.game-banner .gb-side-home { justify-content: flex-end; }
+.game-banner .gb-logo {
+    position: relative;
+    flex: none;
+    line-height: 0;
+}
+.game-banner .gb-logo img {
+    width: clamp(22px, 7vw, 28px);
+    height: auto;
+}
+.game-banner .gb-ball {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 50%;
+    border: 2px solid var(--bs-body-bg, #fff);
+    background: var(--bs-primary);
+}
+.game-banner .gb-ball-rz { background: var(--bs-danger); }
+.game-banner .gb-rank { font-size: clamp(0.62rem, 2.7vw, 0.75rem); }
+.game-banner .gb-abbr {
+    font-size: clamp(0.8rem, 3.5vw, 1rem);
+    white-space: nowrap;
+}
+.game-banner .gb-pts {
+    font-size: clamp(1.05rem, 4.6vw, 1.25rem);
+    font-variant-numeric: tabular-nums;
+    min-width: clamp(1.4rem, 5vw, 1.75rem);
+    text-align: center;
+}
+.game-banner .gb-mid { font-size: clamp(0.65rem, 3vw, 0.75rem); }
+.game-banner .gb-note { grid-column: 1 / -1; }

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -180,11 +180,11 @@ h1, h2, h3, h4, h5, h6 {
     color: #2394fd !important; /* #eeb211*/
 }
 /* Banner scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
-   Slanted team-color stripes + logos on the edges, city over the team
-   abbreviation, scores center, status middle; grouped under kickoff-time
-   headers (.gb-slot). Type follows the site: the Chivo stack (the list is
-   not a .row, so it opts in explicitly), bootstrap heading weight, and
-   TeamRow's winner-bold / loser-half-opacity score treatment. */
+   Slanted team-color stripes + logos on the edges; the two teams stacked
+   inside with full school names; status in its own column; grouped under
+   kickoff-time headers (.gb-slot). Type follows the site: the Chivo stack
+   (the list is not a .row, so it opts in explicitly), bootstrap heading
+   weight, and TeamRow's winner-bold / loser-half-opacity treatment. */
 .game-compact-list {
     font-family: "Chivo", "Fira Mono", serif;
 }
@@ -195,9 +195,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 .game-banner {
     display: grid;
-    grid-template-columns: 46px minmax(0, 1fr) auto minmax(46px, auto) auto minmax(0, 1fr) 46px;
+    grid-template-columns: 46px minmax(0, 1fr) minmax(52px, auto) 46px;
     align-items: center;
-    gap: 6px;
+    gap: 8px;
     min-height: 64px;
     margin-bottom: 8px;
     border: 1px solid #dee2e6;
@@ -216,34 +216,35 @@ h1, h2, h3, h4, h5, h6 {
 .game-banner .gb-stripe img { filter: drop-shadow(0 0 2px rgba(255,255,255,0.6)); }
 .game-banner .gb-stripe-away { clip-path: polygon(0 0, 100% 0, calc(100% - 12px) 100%, 0 100%); }
 .game-banner .gb-stripe-home { clip-path: polygon(12px 0, 100% 0, 100% 100%, 0 100%); }
-.game-banner .gb-side {
+.game-banner .gb-teams {
     display: flex;
     flex-direction: column;
+    gap: 3px;
     min-width: 0;
-    line-height: 1.15;
+    padding: 8px 0;
 }
-.game-banner .gb-home { align-items: flex-end; text-align: right; }
-.game-banner .gb-city {
-    font-size: .75rem;
-    color: #6c757d;
+.game-banner .gb-line {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 10px;
+}
+.game-banner .gb-nm {
+    font-size: 1.05rem;
+    font-weight: 500;
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
-    max-width: 100%;
+    min-width: 0;
 }
-.game-banner .gb-name {
-    /* clamped so ARMY/CONN-length abbreviations never collide with the
-       score in a ~70px team cell at 390 */
-    font-size: clamp(1rem, 4.2vw, 1.25rem);
-    font-weight: 500;
-    white-space: nowrap;
+.game-banner .gb-rank {
+    font-size: .75rem;
+    color: #6c757d;
 }
-.game-banner .gb-score {
-    font-size: clamp(1.05rem, 5vw, 1.5rem);
+.game-banner .gb-pts {
+    font-size: 1.15rem;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
-    min-width: 30px;
-    text-align: center;
 }
 .game-banner .gb-won { font-weight: 700; }
 .game-banner .gb-lost { opacity: 0.5; }

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -179,39 +179,77 @@ h1, h2, h3, h4, h5, h6 {
 .text-favorite {
     color: #2394fd !important; /* #eeb211*/
 }
-/* Compact scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
-   One tappable line per game: away | score | home | status. */
-.game-compact-list {
-    border-top: 1px solid #dee2e6;
+/* Banner scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
+   hoopsjunkie-style: slanted team-color stripes + logos on the edges, city
+   over a big bold abbreviation, large scores (winner bright), status center.
+   Grouped under kickoff-time headers (.gb-slot). */
+.gb-slot {
+    margin: 14px 2px 6px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: #6c757d;
+    text-transform: uppercase;
 }
-.game-compact-row {
+.game-banner {
     display: grid;
-    grid-template-columns: 1fr auto 1fr minmax(72px, auto);
+    grid-template-columns: 46px minmax(0, 1fr) auto minmax(46px, auto) auto minmax(0, 1fr) 46px;
     align-items: center;
-    gap: 8px;
-    min-height: 44px; /* tap-target floor */
-    padding: 4px 6px;
-    border-bottom: 1px solid #dee2e6;
+    gap: 6px;
+    min-height: 64px;
+    margin-bottom: 8px;
+    border: 1px solid #dee2e6;
+    border-radius: 8px;
+    overflow: hidden;
+    background: #fff;
     color: inherit;
     text-decoration: none;
-    font-size: 14px;
 }
-.game-compact-row .gcr-team {
+.game-banner .gb-stripe {
+    align-self: stretch;
     display: flex;
     align-items: center;
-    gap: 5px;
-    min-width: 0;
+    justify-content: center;
 }
-.game-compact-row .gcr-away { justify-content: flex-end; }
-.game-compact-row .gcr-abbr { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.game-compact-row .gcr-rank { font-size: 11px; color: #6c757d; }
-.game-compact-row .gcr-score { font-variant-numeric: tabular-nums; white-space: nowrap; }
-.game-compact-row .gcr-ball { color: #0d6efd; }
-.game-compact-row .gcr-status {
-    font-size: 12px;
+.game-banner .gb-stripe img { filter: drop-shadow(0 0 2px rgba(255,255,255,0.6)); }
+.game-banner .gb-stripe-away { clip-path: polygon(0 0, 100% 0, calc(100% - 12px) 100%, 0 100%); }
+.game-banner .gb-stripe-home { clip-path: polygon(12px 0, 100% 0, 100% 100%, 0 100%); }
+.game-banner .gb-side {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    line-height: 1.15;
+}
+.game-banner .gb-home { align-items: flex-end; text-align: right; }
+.game-banner .gb-city {
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
     color: #6c757d;
-    text-align: right;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+}
+.game-banner .gb-name {
+    /* clamp so ARMY/CONN-length abbreviations never collide with the score
+       in a ~57px 1fr column at 390 */
+    font-size: clamp(14px, 4.2vw, 19px);
+    font-weight: 800;
+    white-space: nowrap;
+}
+.game-banner .gb-score {
+    font-size: clamp(18px, 5.4vw, 24px);
+    font-weight: 800;
+    font-variant-numeric: tabular-nums;
+    min-width: 30px;
+    text-align: center;
+}
+.game-banner .gb-lost { opacity: 0.5; }
+.game-banner .gb-mid {
+    font-size: 12px;
+    font-weight: 600;
+    color: #6c757d;
+    text-align: center;
     white-space: nowrap;
 }

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -180,16 +180,18 @@ h1, h2, h3, h4, h5, h6 {
     color: #2394fd !important; /* #eeb211*/
 }
 /* Banner scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
-   hoopsjunkie-style: slanted team-color stripes + logos on the edges, city
-   over a big bold abbreviation, large scores (winner bright), status center.
-   Grouped under kickoff-time headers (.gb-slot). */
+   Slanted team-color stripes + logos on the edges, city over the team
+   abbreviation, scores center, status middle; grouped under kickoff-time
+   headers (.gb-slot). Type follows the site: the Chivo stack (the list is
+   not a .row, so it opts in explicitly), bootstrap heading weight, and
+   TeamRow's winner-bold / loser-half-opacity score treatment. */
+.game-compact-list {
+    font-family: "Chivo", "Fira Mono", serif;
+}
 .gb-slot {
     margin: 14px 2px 6px;
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.04em;
+    font-size: .875rem;
     color: #6c757d;
-    text-transform: uppercase;
 }
 .game-banner {
     display: grid;
@@ -199,7 +201,7 @@ h1, h2, h3, h4, h5, h6 {
     min-height: 64px;
     margin-bottom: 8px;
     border: 1px solid #dee2e6;
-    border-radius: 8px;
+    border-radius: 0.5em;
     overflow: hidden;
     background: #fff;
     color: inherit;
@@ -222,9 +224,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 .game-banner .gb-home { align-items: flex-end; text-align: right; }
 .game-banner .gb-city {
-    font-size: 11px;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    font-size: .75rem;
     color: #6c757d;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -232,23 +232,23 @@ h1, h2, h3, h4, h5, h6 {
     max-width: 100%;
 }
 .game-banner .gb-name {
-    /* clamp so ARMY/CONN-length abbreviations never collide with the score
-       in a ~57px 1fr column at 390 */
-    font-size: clamp(14px, 4.2vw, 19px);
-    font-weight: 800;
+    /* clamped so ARMY/CONN-length abbreviations never collide with the
+       score in a ~70px team cell at 390 */
+    font-size: clamp(1rem, 4.2vw, 1.25rem);
+    font-weight: 500;
     white-space: nowrap;
 }
 .game-banner .gb-score {
-    font-size: clamp(18px, 5.4vw, 24px);
-    font-weight: 800;
+    font-size: clamp(1.05rem, 5vw, 1.5rem);
+    font-weight: 500;
     font-variant-numeric: tabular-nums;
     min-width: 30px;
     text-align: center;
 }
+.game-banner .gb-won { font-weight: 700; }
 .game-banner .gb-lost { opacity: 0.5; }
 .game-banner .gb-mid {
-    font-size: 12px;
-    font-weight: 600;
+    font-size: .75rem;
     color: #6c757d;
     text-align: center;
     white-space: nowrap;

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -179,3 +179,39 @@ h1, h2, h3, h4, h5, h6 {
 .text-favorite {
     color: #2394fd !important; /* #eeb211*/
 }
+/* Compact scoreboard rows (GameCompactRow, preview 'scoreboard-compact').
+   One tappable line per game: away | score | home | status. */
+.game-compact-list {
+    border-top: 1px solid #dee2e6;
+}
+.game-compact-row {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr minmax(72px, auto);
+    align-items: center;
+    gap: 8px;
+    min-height: 44px; /* tap-target floor */
+    padding: 4px 6px;
+    border-bottom: 1px solid #dee2e6;
+    color: inherit;
+    text-decoration: none;
+    font-size: 14px;
+}
+.game-compact-row .gcr-team {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+}
+.game-compact-row .gcr-away { justify-content: flex-end; }
+.game-compact-row .gcr-abbr { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.game-compact-row .gcr-rank { font-size: 11px; color: #6c757d; }
+.game-compact-row .gcr-score { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.game-compact-row .gcr-ball { color: #0d6efd; }
+.game-compact-row .gcr-status {
+    font-size: 12px;
+    color: #6c757d;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/astro/public/assets/css/index.css
+++ b/astro/public/assets/css/index.css
@@ -231,7 +231,7 @@ h1, h2, h3, h4, h5, h6 {
     background: var(--bs-primary);
 }
 .game-banner .gb-ball-rz { background: var(--bs-danger); }
-.game-banner .gb-rank { font-size: clamp(0.62rem, 2.7vw, 0.75rem); }
+.game-banner .gb-rank { font-size: clamp(0.62rem, 2.7vw, 0.75rem); font-weight: 400; }
 .game-banner .gb-abbr {
     font-size: clamp(0.8rem, 3.5vw, 1rem);
     white-space: nowrap;

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -41,6 +41,7 @@ const side = (c: any, score: number, other: number) => ({
   color: colorOf(c),
   logo: `https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${c.id}.png&h=80&w=80`,
   id: c.id,
+  won: completed && score > other,
   lost: completed && score < other,
 });
 const away = side(awayComp, awayScore, homeScore);
@@ -52,14 +53,14 @@ const home = side(homeComp, homeScore, awayScore);
   </span>
   <span class="gb-side gb-away">
     <span class="gb-city">{away.rank != 99 && <b>#{away.rank}</b>} {away.city}</span>
-    <span class:list={["gb-name", { "gb-lost": away.lost }]}>{away.abbr}</span>
+    <span class:list={["gb-name", { "gb-won": away.won, "gb-lost": away.lost }]}>{away.abbr}</span>
   </span>
-  <span class:list={["gb-score", { "gb-lost": away.lost }]}>{scheduled ? "" : awayScore}</span>
+  <span class:list={["gb-score", { "gb-won": away.won, "gb-lost": away.lost }]}>{scheduled ? "" : awayScore}</span>
   <span class="gb-mid">{statusLabel}</span>
-  <span class:list={["gb-score", { "gb-lost": home.lost }]}>{scheduled ? "" : homeScore}</span>
+  <span class:list={["gb-score", { "gb-won": home.won, "gb-lost": home.lost }]}>{scheduled ? "" : homeScore}</span>
   <span class="gb-side gb-home">
     <span class="gb-city">{home.city} {home.rank != 99 && <b>#{home.rank}</b>}</span>
-    <span class:list={["gb-name", { "gb-lost": home.lost }]}>{home.abbr}</span>
+    <span class:list={["gb-name", { "gb-won": home.won, "gb-lost": home.lost }]}>{home.abbr}</span>
   </span>
   <span class="gb-stripe gb-stripe-home" style={`background:${home.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -21,6 +21,11 @@ const awayComp = comp.competitors[1];
 const status = comp.status;
 const scheduled = status.type.name.includes("STATUS_SCHEDULED");
 const completed = status.type.completed == true;
+const live = !scheduled && !completed;
+// Possession dot for live games, same convention as TeamRow's marker:
+// text-primary with the ball, text-danger in the red zone.
+const ballTeamId = comp.situation?.lastPlay?.end?.team?.id;
+const isRedZone = comp.situation?.isRedZone == true;
 const homeScore = cleanScore(homeComp.score);
 const awayScore = cleanScore(awayComp.score);
 
@@ -45,6 +50,7 @@ const side = (c: any, score: number, other: number) => ({
   id: c.id,
   won: completed && score > other,
   lost: completed && score < other,
+  hasBall: live && ballTeamId == c.id,
 });
 const away = side(awayComp, awayScore, homeScore);
 const home = side(homeComp, homeScore, awayScore);
@@ -56,13 +62,13 @@ const home = side(homeComp, homeScore, awayScore);
   <span class="flex-grow-1 overflow-hidden d-flex flex-column gap-1 py-2">
     <span class="d-flex justify-content-between align-items-baseline gap-2">
       <span class:list={["fs-6 text-truncate", { "fw-bold": away.won, "opacity-50": away.lost }]}>
-        {away.rank != 99 && <span class="small text-muted">#{away.rank}</span>} {away.name}
+        {away.rank != 99 && <span class="small text-muted">#{away.rank}</span>} {away.name}{away.hasBall && <span class={isRedZone ? "text-danger" : "text-primary"}>&nbsp;&#8226;</span>}
       </span>
       <span class:list={["gb-pts fs-5", { "fw-bold": away.won, "opacity-50": away.lost }]}>{scheduled ? "" : awayScore}</span>
     </span>
     <span class="d-flex justify-content-between align-items-baseline gap-2">
       <span class:list={["fs-6 text-truncate", { "fw-bold": home.won, "opacity-50": home.lost }]}>
-        {home.rank != 99 && <span class="small text-muted">#{home.rank}</span>} {home.name}
+        {home.rank != 99 && <span class="small text-muted">#{home.rank}</span>} {home.name}{home.hasBall && <span class={isRedZone ? "text-danger" : "text-primary"}>&nbsp;&#8226;</span>}
       </span>
       <span class:list={["gb-pts fs-5", { "fw-bold": home.won, "opacity-50": home.lost }]}>{scheduled ? "" : homeScore}</span>
     </span>

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -1,11 +1,12 @@
 ---
 // Banner-style scoreboard row (mobile): slanted team-color stripes with
-// logos on the edges; the two teams stacked inside with FULL school names
-// (no truncated abbreviation-plus-city pair -- a stacked line gets ~230px,
-// so "Middle Tennessee" fits where the mirrored layout had ~70px); status
-// in its own column. Winner bold, completed loser half-opacity, exactly
-// like TeamRow's formatScore. The whole card links to the game page.
-// Preview-flagged ('scoreboard-compact'); the card grid stays >=768px.
+// logos on the edges; the two teams stacked inside with full school names;
+// status in its own column. Bootstrap utilities carry the layout -- custom
+// CSS is only what Bootstrap cannot do (stripe clip-paths, tabular score
+// digits, the Chivo opt-in on the list). Winner fw-bold, completed loser
+// opacity-50, matching TeamRow's formatScore. Scheduled kickoffs render
+// the ET string server-side and carry data-gb-utc so SchedulePage's single
+// inline script (no per-row island) rewrites them to the viewer's timezone.
 import type { ESPNScheduleEvent } from "../../resources/espn";
 import { cleanLocation, cleanScore } from "../../utils/misc";
 
@@ -31,7 +32,7 @@ function colorOf(c: any): string {
   const hex = String(c.team?.color ?? "").replace(/[^0-9a-fA-F]/g, "");
   return hex.length === 6 || hex.length === 3 ? `#${hex}` : "#6c757d";
 }
-// "Final" / "10:24 - 3rd" / kickoff "7:30 PM EDT" for scheduled games
+// "Final" / "10:24 - 3rd" / kickoff "7:30 PM EDT" (ET fallback) for scheduled
 const statusLabel = scheduled
   ? (status.type.shortDetail ?? "").split(" - ").pop()
   : status.type.shortDetail;
@@ -48,26 +49,26 @@ const side = (c: any, score: number, other: number) => ({
 const away = side(awayComp, awayScore, homeScore);
 const home = side(homeComp, homeScore, awayScore);
 ---
-<a class="game-banner" href={`/game/${game.id}`}>
-  <span class="gb-stripe gb-stripe-away" style={`background:${away.color}`}>
+<a class="game-banner d-flex align-items-center gap-2 border rounded mb-2 text-reset text-decoration-none" href={`/game/${game.id}`}>
+  <span class="gb-stripe gb-stripe-away d-flex align-items-center justify-content-center align-self-stretch" style={`background:${away.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
   </span>
-  <span class="gb-teams">
-    <span class="gb-line">
-      <span class:list={["gb-nm", { "gb-won": away.won, "gb-lost": away.lost }]}>
-        {away.rank != 99 && <span class="gb-rank">#{away.rank}</span>} {away.name}
+  <span class="flex-grow-1 overflow-hidden d-flex flex-column gap-1 py-2">
+    <span class="d-flex justify-content-between align-items-baseline gap-2">
+      <span class:list={["fs-6 text-truncate", { "fw-bold": away.won, "opacity-50": away.lost }]}>
+        {away.rank != 99 && <span class="small text-muted">#{away.rank}</span>} {away.name}
       </span>
-      <span class:list={["gb-pts", { "gb-won": away.won, "gb-lost": away.lost }]}>{scheduled ? "" : awayScore}</span>
+      <span class:list={["gb-pts fs-5", { "fw-bold": away.won, "opacity-50": away.lost }]}>{scheduled ? "" : awayScore}</span>
     </span>
-    <span class="gb-line">
-      <span class:list={["gb-nm", { "gb-won": home.won, "gb-lost": home.lost }]}>
-        {home.rank != 99 && <span class="gb-rank">#{home.rank}</span>} {home.name}
+    <span class="d-flex justify-content-between align-items-baseline gap-2">
+      <span class:list={["fs-6 text-truncate", { "fw-bold": home.won, "opacity-50": home.lost }]}>
+        {home.rank != 99 && <span class="small text-muted">#{home.rank}</span>} {home.name}
       </span>
-      <span class:list={["gb-pts", { "gb-won": home.won, "gb-lost": home.lost }]}>{scheduled ? "" : homeScore}</span>
+      <span class:list={["gb-pts fs-5", { "fw-bold": home.won, "opacity-50": home.lost }]}>{scheduled ? "" : homeScore}</span>
     </span>
   </span>
-  <span class="gb-mid">{statusLabel}</span>
-  <span class="gb-stripe gb-stripe-home" style={`background:${home.color}`}>
+  <span class="small text-muted text-center text-nowrap" data-gb-utc={scheduled ? game.date : undefined}>{statusLabel}</span>
+  <span class="gb-stripe gb-stripe-home d-flex align-items-center justify-content-center align-self-stretch" style={`background:${home.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
   </span>
 </a>

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -68,15 +68,13 @@ const home = side(homeComp, homeScore, awayScore);
       <img width="28" height="28" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
       {away.hasBall && <span class:list={["gb-ball", { "gb-ball-rz": isRedZone }]}></span>}
     </span>
-    {away.rank != 99 && <span class="gb-rank text-muted">#{away.rank}</span>}
-    <span class:list={["gb-abbr", { "fw-bold": away.won, "opacity-50": away.lost }]}>{away.abbr}</span>
+    <span class:list={["gb-abbr", { "fw-bold": away.won, "opacity-50": away.lost }]}>{away.rank != 99 && <span class="gb-rank text-muted">#{away.rank}</span>} {away.abbr}</span>
   </span>
   <span class:list={["gb-pts", { "fw-bold": away.won, "opacity-50": away.lost }]}>{scheduled ? "" : awayScore}</span>
   <span class="gb-mid text-muted text-center text-nowrap" data-gb-utc={scheduled && !timeTBD ? game.date : undefined}>{statusLabel}</span>
   <span class:list={["gb-pts", { "fw-bold": home.won, "opacity-50": home.lost }]}>{scheduled ? "" : homeScore}</span>
   <span class="gb-side gb-side-home">
-    {home.rank != 99 && <span class="gb-rank text-muted">#{home.rank}</span>}
-    <span class:list={["gb-abbr", { "fw-bold": home.won, "opacity-50": home.lost }]}>{home.abbr}</span>
+    <span class:list={["gb-abbr", { "fw-bold": home.won, "opacity-50": home.lost }]}>{home.rank != 99 && <span class="gb-rank text-muted">#{home.rank}</span>} {home.abbr}</span>
     <span class="gb-logo">
       <img width="28" height="28" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
       {home.hasBall && <span class:list={["gb-ball", { "gb-ball-rz": isRedZone }]}></span>}

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -1,11 +1,13 @@
 ---
-// Banner-style scoreboard row (mobile, hoopsjunkie-inspired): slanted
-// team-color stripes with logos on the edges, city over a big bold
-// abbreviation, large scores with the winner bright, status centered.
-// The whole card links to the game page. Preview-flagged
-// ('scoreboard-compact'); the card grid stays the desktop rendering.
+// Banner-style scoreboard row (mobile): slanted team-color stripes with
+// logos on the edges; the two teams stacked inside with FULL school names
+// (no truncated abbreviation-plus-city pair -- a stacked line gets ~230px,
+// so "Middle Tennessee" fits where the mirrored layout had ~70px); status
+// in its own column. Winner bold, completed loser half-opacity, exactly
+// like TeamRow's formatScore. The whole card links to the game page.
+// Preview-flagged ('scoreboard-compact'); the card grid stays >=768px.
 import type { ESPNScheduleEvent } from "../../resources/espn";
-import { cleanAbbreviation, cleanScore } from "../../utils/misc";
+import { cleanLocation, cleanScore } from "../../utils/misc";
 
 interface Props {
   game: ESPNScheduleEvent;
@@ -29,15 +31,14 @@ function colorOf(c: any): string {
   const hex = String(c.team?.color ?? "").replace(/[^0-9a-fA-F]/g, "");
   return hex.length === 6 || hex.length === 3 ? `#${hex}` : "#6c757d";
 }
-// "Final" / "10:24 - 3rd" / kickoff "7:30 PM" for scheduled games
+// "Final" / "10:24 - 3rd" / kickoff "7:30 PM EDT" for scheduled games
 const statusLabel = scheduled
   ? (status.type.shortDetail ?? "").split(" - ").pop()
   : status.type.shortDetail;
 
 const side = (c: any, score: number, other: number) => ({
   rank: rankOf(c),
-  abbr: cleanAbbreviation(c.team),
-  city: c.team.location ?? c.team.shortDisplayName ?? "",
+  name: cleanLocation(c.team) || c.team.shortDisplayName || "",
   color: colorOf(c),
   logo: `https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${c.id}.png&h=80&w=80`,
   id: c.id,
@@ -51,17 +52,21 @@ const home = side(homeComp, homeScore, awayScore);
   <span class="gb-stripe gb-stripe-away" style={`background:${away.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
   </span>
-  <span class="gb-side gb-away">
-    <span class="gb-city">{away.rank != 99 && <b>#{away.rank}</b>} {away.city}</span>
-    <span class:list={["gb-name", { "gb-won": away.won, "gb-lost": away.lost }]}>{away.abbr}</span>
+  <span class="gb-teams">
+    <span class="gb-line">
+      <span class:list={["gb-nm", { "gb-won": away.won, "gb-lost": away.lost }]}>
+        {away.rank != 99 && <span class="gb-rank">#{away.rank}</span>} {away.name}
+      </span>
+      <span class:list={["gb-pts", { "gb-won": away.won, "gb-lost": away.lost }]}>{scheduled ? "" : awayScore}</span>
+    </span>
+    <span class="gb-line">
+      <span class:list={["gb-nm", { "gb-won": home.won, "gb-lost": home.lost }]}>
+        {home.rank != 99 && <span class="gb-rank">#{home.rank}</span>} {home.name}
+      </span>
+      <span class:list={["gb-pts", { "gb-won": home.won, "gb-lost": home.lost }]}>{scheduled ? "" : homeScore}</span>
+    </span>
   </span>
-  <span class:list={["gb-score", { "gb-won": away.won, "gb-lost": away.lost }]}>{scheduled ? "" : awayScore}</span>
   <span class="gb-mid">{statusLabel}</span>
-  <span class:list={["gb-score", { "gb-won": home.won, "gb-lost": home.lost }]}>{scheduled ? "" : homeScore}</span>
-  <span class="gb-side gb-home">
-    <span class="gb-city">{home.city} {home.rank != 99 && <b>#{home.rank}</b>}</span>
-    <span class:list={["gb-name", { "gb-won": home.won, "gb-lost": home.lost }]}>{home.abbr}</span>
-  </span>
   <span class="gb-stripe gb-stripe-home" style={`background:${home.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
   </span>

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -8,7 +8,7 @@
 // the ET string server-side and carry data-gb-utc so SchedulePage's single
 // inline script (no per-row island) rewrites them to the viewer's timezone.
 import type { ESPNScheduleEvent } from "../../resources/espn";
-import { cleanLocation, cleanScore } from "../../utils/misc";
+import { cleanLocation, cleanScore, isChampionshipEvent } from "../../utils/misc";
 
 interface Props {
   game: ESPNScheduleEvent;
@@ -37,16 +37,33 @@ function colorOf(c: any): string {
   const hex = String(c.team?.color ?? "").replace(/[^0-9a-fA-F]/g, "");
   return hex.length === 6 || hex.length === 3 ? `#${hex}` : "#6c757d";
 }
+// ESPN marks a game with no announced kickoff (conference championships,
+// far-future TV windows) with timeValid: false -- its date is a placeholder
+// midnight, so it must render "TBD" and NEVER carry data-gb-utc (the
+// localization script would rewrite TBD into a bogus local midnight).
+const timeTBD = (comp as any).timeValid === false;
 // "Final" / "10:24 - 3rd" / kickoff "7:30 PM EDT" (ET fallback) for scheduled
 const statusLabel = scheduled
-  ? (status.type.shortDetail ?? "").split(" - ").pop()
+  ? (timeTBD ? "TBD" : (status.type.shortDetail ?? "").split(" - ").pop())
   : status.type.shortDetail;
+// Championship/bowl headline ("Big Ten Championship Game") -- essential for
+// TBD-vs-TBD placeholders, informative on any game that carries one.
+const gameNote = comp.notes?.length ? comp.notes[0].headline : null;
+// Gold treatment for title games, matching GameThumb's championship theme --
+// conference championships count too, not just CFP/national-title events.
+const isChamp = !!gameNote && (isChampionshipEvent(gameNote) || gameNote.includes("Championship"));
 
+// A TBD placeholder competitor has no real team id; ESPN's default shield
+// stands in so the row never shows a broken image.
+const logoOf = (c: any) =>
+  c.id && String(c.id) !== "0" && c.team?.abbreviation !== "TBD"
+    ? `https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${c.id}.png&h=80&w=80`
+    : "https://a.espncdn.com/combiner/i?img=/i/teamlogos/default-team-logo-500.png&h=80&w=80";
 const side = (c: any, score: number, other: number) => ({
   rank: rankOf(c),
   name: cleanLocation(c.team) || c.team.shortDisplayName || "",
   color: colorOf(c),
-  logo: `https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${c.id}.png&h=80&w=80`,
+  logo: logoOf(c),
   id: c.id,
   won: completed && score > other,
   lost: completed && score < other,
@@ -55,7 +72,7 @@ const side = (c: any, score: number, other: number) => ({
 const away = side(awayComp, awayScore, homeScore);
 const home = side(homeComp, homeScore, awayScore);
 ---
-<a class="game-banner d-flex align-items-center gap-2 border rounded mb-2 text-reset text-decoration-none" href={`/game/${game.id}`}>
+<a class:list={["game-banner d-flex align-items-center gap-2 border rounded mb-2 text-reset text-decoration-none", { "outline-championship": isChamp }]} href={`/game/${game.id}`}>
   <span class="gb-stripe gb-stripe-away d-flex align-items-center justify-content-center align-self-stretch" style={`background:${away.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
   </span>
@@ -72,8 +89,9 @@ const home = side(homeComp, homeScore, awayScore);
       </span>
       <span class:list={["gb-pts fs-5", { "fw-bold": home.won, "opacity-50": home.lost }]}>{scheduled ? "" : homeScore}</span>
     </span>
+    {gameNote && <span class:list={["small text-truncate", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</span>}
   </span>
-  <span class="small text-muted text-center text-nowrap" data-gb-utc={scheduled ? game.date : undefined}>{statusLabel}</span>
+  <span class="small text-muted text-center text-nowrap" data-gb-utc={scheduled && !timeTBD ? game.date : undefined}>{statusLabel}</span>
   <span class="gb-stripe gb-stripe-home d-flex align-items-center justify-content-center align-self-stretch" style={`background:${home.color}`}>
     <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
   </span>

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -1,14 +1,21 @@
 ---
-// Banner-style scoreboard row (mobile): slanted team-color stripes with
-// logos on the edges; the two teams stacked inside with full school names;
-// status in its own column. Bootstrap utilities carry the layout -- custom
-// CSS is only what Bootstrap cannot do (stripe clip-paths, tabular score
-// digits, the Chivo opt-in on the list). Winner fw-bold, completed loser
-// opacity-50, matching TeamRow's formatScore. Scheduled kickoffs render
-// the ET string server-side and carry data-gb-utc so SchedulePage's single
-// inline script (no per-row island) rewrites them to the viewer's timezone.
+// Scoreboard banner row (mobile) -- the chosen "Option E": one line per
+// game, mirrored, no color stripes. Rank sits ahead of the abbreviation on
+// both sides; the middle is a fixed grid column (score | status | score) so
+// scores and clocks align dead-center down the list regardless of status
+// text or digit count. The possession dot rides the logo corner as a badge
+// (red in the red zone) instead of taking inline width; type, logo and
+// padding are viewport-clamped so a double-ranked 4-char matchup fits at
+// 320 (verified against element clipping in headless Chrome). Winner
+// fw-bold, completed loser opacity-50, matching TeamRow's formatScore.
+//
+// TBD/championship handling mirrors the card grid: timeValid:false renders
+// TBD and never carries data-gb-utc (the localization script would rewrite
+// the placeholder midnight); TBD competitors get ESPN's default shield; a
+// game note renders as a spanning second line, gold for championships.
+// Preview-flagged ('scoreboard-compact'); the card grid stays >=768px.
 import type { ESPNScheduleEvent } from "../../resources/espn";
-import { cleanLocation, cleanScore, isChampionshipEvent } from "../../utils/misc";
+import { cleanAbbreviation, cleanScore, isChampionshipEvent } from "../../utils/misc";
 
 interface Props {
   game: ESPNScheduleEvent;
@@ -22,8 +29,6 @@ const status = comp.status;
 const scheduled = status.type.name.includes("STATUS_SCHEDULED");
 const completed = status.type.completed == true;
 const live = !scheduled && !completed;
-// Possession dot for live games, same convention as TeamRow's marker:
-// text-primary with the ball, text-danger in the red zone.
 const ballTeamId = comp.situation?.lastPlay?.end?.team?.id;
 const isRedZone = comp.situation?.isRedZone == true;
 const homeScore = cleanScore(homeComp.score);
@@ -32,27 +37,13 @@ const awayScore = cleanScore(awayComp.score);
 function rankOf(c: any): number {
   return c.curatedRank?.current || 99;
 }
-// ESPN ships bare hex; a missing color falls back to slate
-function colorOf(c: any): string {
-  const hex = String(c.team?.color ?? "").replace(/[^0-9a-fA-F]/g, "");
-  return hex.length === 6 || hex.length === 3 ? `#${hex}` : "#6c757d";
-}
-// ESPN marks a game with no announced kickoff (conference championships,
-// far-future TV windows) with timeValid: false -- its date is a placeholder
-// midnight, so it must render "TBD" and NEVER carry data-gb-utc (the
-// localization script would rewrite TBD into a bogus local midnight).
 const timeTBD = (comp as any).timeValid === false;
 // "Final" / "10:24 - 3rd" / kickoff "7:30 PM EDT" (ET fallback) for scheduled
 const statusLabel = scheduled
   ? (timeTBD ? "TBD" : (status.type.shortDetail ?? "").split(" - ").pop())
   : status.type.shortDetail;
-// Championship/bowl headline ("Big Ten Championship Game") -- essential for
-// TBD-vs-TBD placeholders, informative on any game that carries one.
 const gameNote = comp.notes?.length ? comp.notes[0].headline : null;
-// Gold treatment for title games, matching GameThumb's championship theme --
-// conference championships count too, not just CFP/national-title events.
 const isChamp = !!gameNote && (isChampionshipEvent(gameNote) || gameNote.includes("Championship"));
-
 // A TBD placeholder competitor has no real team id; ESPN's default shield
 // stands in so the row never shows a broken image.
 const logoOf = (c: any) =>
@@ -61,10 +52,9 @@ const logoOf = (c: any) =>
     : "https://a.espncdn.com/combiner/i?img=/i/teamlogos/default-team-logo-500.png&h=80&w=80";
 const side = (c: any, score: number, other: number) => ({
   rank: rankOf(c),
-  name: cleanLocation(c.team) || c.team.shortDisplayName || "",
-  color: colorOf(c),
-  logo: logoOf(c),
+  abbr: cleanAbbreviation(c.team),
   id: c.id,
+  logo: logoOf(c),
   won: completed && score > other,
   lost: completed && score < other,
   hasBall: live && ballTeamId == c.id,
@@ -72,27 +62,25 @@ const side = (c: any, score: number, other: number) => ({
 const away = side(awayComp, awayScore, homeScore);
 const home = side(homeComp, homeScore, awayScore);
 ---
-<a class:list={["game-banner d-flex align-items-center gap-2 border rounded mb-2 text-reset text-decoration-none", { "outline-championship": isChamp }]} href={`/game/${game.id}`}>
-  <span class="gb-stripe gb-stripe-away d-flex align-items-center justify-content-center align-self-stretch" style={`background:${away.color}`}>
-    <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
-  </span>
-  <span class="flex-grow-1 overflow-hidden d-flex flex-column gap-1 py-2">
-    <span class="d-flex justify-content-between align-items-baseline gap-2">
-      <span class:list={["fs-6 text-truncate", { "fw-bold": away.won, "opacity-50": away.lost }]}>
-        {away.rank != 99 && <span class="small text-muted">#{away.rank}</span>} {away.name}{away.hasBall && <span class={isRedZone ? "text-danger" : "text-primary"}>&nbsp;&#8226;</span>}
-      </span>
-      <span class:list={["gb-pts fs-5", { "fw-bold": away.won, "opacity-50": away.lost }]}>{scheduled ? "" : awayScore}</span>
+<a class:list={["game-banner border rounded mb-2 py-2 text-reset text-decoration-none", { "outline-championship": isChamp }]} href={`/game/${game.id}`}>
+  <span class="gb-side">
+    <span class="gb-logo">
+      <img width="28" height="28" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
+      {away.hasBall && <span class:list={["gb-ball", { "gb-ball-rz": isRedZone }]}></span>}
     </span>
-    <span class="d-flex justify-content-between align-items-baseline gap-2">
-      <span class:list={["fs-6 text-truncate", { "fw-bold": home.won, "opacity-50": home.lost }]}>
-        {home.rank != 99 && <span class="small text-muted">#{home.rank}</span>} {home.name}{home.hasBall && <span class={isRedZone ? "text-danger" : "text-primary"}>&nbsp;&#8226;</span>}
-      </span>
-      <span class:list={["gb-pts fs-5", { "fw-bold": home.won, "opacity-50": home.lost }]}>{scheduled ? "" : homeScore}</span>
+    {away.rank != 99 && <span class="gb-rank text-muted">#{away.rank}</span>}
+    <span class:list={["gb-abbr", { "fw-bold": away.won, "opacity-50": away.lost }]}>{away.abbr}</span>
+  </span>
+  <span class:list={["gb-pts", { "fw-bold": away.won, "opacity-50": away.lost }]}>{scheduled ? "" : awayScore}</span>
+  <span class="gb-mid text-muted text-center text-nowrap" data-gb-utc={scheduled && !timeTBD ? game.date : undefined}>{statusLabel}</span>
+  <span class:list={["gb-pts", { "fw-bold": home.won, "opacity-50": home.lost }]}>{scheduled ? "" : homeScore}</span>
+  <span class="gb-side gb-side-home">
+    {home.rank != 99 && <span class="gb-rank text-muted">#{home.rank}</span>}
+    <span class:list={["gb-abbr", { "fw-bold": home.won, "opacity-50": home.lost }]}>{home.abbr}</span>
+    <span class="gb-logo">
+      <img width="28" height="28" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
+      {home.hasBall && <span class:list={["gb-ball", { "gb-ball-rz": isRedZone }]}></span>}
     </span>
-    {gameNote && <span class:list={["small text-truncate", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</span>}
   </span>
-  <span class="small text-muted text-center text-nowrap" data-gb-utc={scheduled && !timeTBD ? game.date : undefined}>{statusLabel}</span>
-  <span class="gb-stripe gb-stripe-home d-flex align-items-center justify-content-center align-self-stretch" style={`background:${home.color}`}>
-    <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
-  </span>
+  {gameNote && <span class:list={["gb-note small text-center text-truncate", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</span>}
 </a>

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -1,8 +1,9 @@
 ---
-// One-line scoreboard row (mobile): logos + score + status, tap for the game
-// page. Preview-flagged ('scoreboard-compact'); the card grid stays the
-// desktop rendering. No spice border in v1 -- calculateSpiceLevel lives in
-// GameThumb's frontmatter and moves to utils/misc if this promotes.
+// Banner-style scoreboard row (mobile, hoopsjunkie-inspired): slanted
+// team-color stripes with logos on the edges, city over a big bold
+// abbreviation, large scores with the winner bright, status centered.
+// The whole card links to the game page. Preview-flagged
+// ('scoreboard-compact'); the card grid stays the desktop rendering.
 import type { ESPNScheduleEvent } from "../../resources/espn";
 import { cleanAbbreviation, cleanScore } from "../../utils/misc";
 
@@ -19,29 +20,48 @@ const scheduled = status.type.name.includes("STATUS_SCHEDULED");
 const completed = status.type.completed == true;
 const homeScore = cleanScore(homeComp.score);
 const awayScore = cleanScore(awayComp.score);
-const ballTeamId = comp.situation?.lastPlay?.end?.team?.id;
 
 function rankOf(c: any): number {
   return c.curatedRank?.current || 99;
 }
+// ESPN ships bare hex; a missing color falls back to slate
+function colorOf(c: any): string {
+  const hex = String(c.team?.color ?? "").replace(/[^0-9a-fA-F]/g, "");
+  return hex.length === 6 || hex.length === 3 ? `#${hex}` : "#6c757d";
+}
+// "Final" / "10:24 - 3rd" / kickoff "7:30 PM" for scheduled games
+const statusLabel = scheduled
+  ? (status.type.shortDetail ?? "").split(" - ").pop()
+  : status.type.shortDetail;
+
+const side = (c: any, score: number, other: number) => ({
+  rank: rankOf(c),
+  abbr: cleanAbbreviation(c.team),
+  city: c.team.location ?? c.team.shortDisplayName ?? "",
+  color: colorOf(c),
+  logo: `https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${c.id}.png&h=80&w=80`,
+  id: c.id,
+  lost: completed && score < other,
+});
+const away = side(awayComp, awayScore, homeScore);
+const home = side(homeComp, homeScore, awayScore);
 ---
-<a class="game-compact-row" href={`/game/${game.id}`}>
-  <span class="gcr-team gcr-away">
-    {rankOf(awayComp) != 99 && <span class="gcr-rank">#{rankOf(awayComp)}</span>}
-    <img width="20" height="20" loading="lazy" decoding="async" alt="" class={`team-logo-${awayComp.id}`} src={`https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${awayComp.id}.png&h=40&w=40`} />
-    <span class:list={["gcr-abbr", { "fw-bold": completed && awayScore > homeScore }]}>{cleanAbbreviation(awayComp.team)}</span>
-    {!scheduled && !completed && ballTeamId == awayComp.id && <span class="gcr-ball">&#8226;</span>}
+<a class="game-banner" href={`/game/${game.id}`}>
+  <span class="gb-stripe gb-stripe-away" style={`background:${away.color}`}>
+    <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${away.id}`} src={away.logo} />
   </span>
-  <span class="gcr-score">
-    {scheduled
-      ? "vs"
-      : <Fragment><span class:list={[{ "fw-bold": completed && awayScore > homeScore }]}>{awayScore}</span>&ndash;<span class:list={[{ "fw-bold": completed && homeScore > awayScore }]}>{homeScore}</span></Fragment>}
+  <span class="gb-side gb-away">
+    <span class="gb-city">{away.rank != 99 && <b>#{away.rank}</b>} {away.city}</span>
+    <span class:list={["gb-name", { "gb-lost": away.lost }]}>{away.abbr}</span>
   </span>
-  <span class="gcr-team gcr-home">
-    {!scheduled && !completed && ballTeamId == homeComp.id && <span class="gcr-ball">&#8226;</span>}
-    <span class:list={["gcr-abbr", { "fw-bold": completed && homeScore > awayScore }]}>{cleanAbbreviation(homeComp.team)}</span>
-    <img width="20" height="20" loading="lazy" decoding="async" alt="" class={`team-logo-${homeComp.id}`} src={`https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${homeComp.id}.png&h=40&w=40`} />
-    {rankOf(homeComp) != 99 && <span class="gcr-rank">#{rankOf(homeComp)}</span>}
+  <span class:list={["gb-score", { "gb-lost": away.lost }]}>{scheduled ? "" : awayScore}</span>
+  <span class="gb-mid">{statusLabel}</span>
+  <span class:list={["gb-score", { "gb-lost": home.lost }]}>{scheduled ? "" : homeScore}</span>
+  <span class="gb-side gb-home">
+    <span class="gb-city">{home.city} {home.rank != 99 && <b>#{home.rank}</b>}</span>
+    <span class:list={["gb-name", { "gb-lost": home.lost }]}>{home.abbr}</span>
   </span>
-  <span class="gcr-status">{status.type.shortDetail}</span>
+  <span class="gb-stripe gb-stripe-home" style={`background:${home.color}`}>
+    <img width="40" height="40" loading="lazy" decoding="async" alt="" class={`team-logo-${home.id}`} src={home.logo} />
+  </span>
 </a>

--- a/astro/src/components/schedule/GameCompactRow.astro
+++ b/astro/src/components/schedule/GameCompactRow.astro
@@ -1,0 +1,47 @@
+---
+// One-line scoreboard row (mobile): logos + score + status, tap for the game
+// page. Preview-flagged ('scoreboard-compact'); the card grid stays the
+// desktop rendering. No spice border in v1 -- calculateSpiceLevel lives in
+// GameThumb's frontmatter and moves to utils/misc if this promotes.
+import type { ESPNScheduleEvent } from "../../resources/espn";
+import { cleanAbbreviation, cleanScore } from "../../utils/misc";
+
+interface Props {
+  game: ESPNScheduleEvent;
+}
+
+const { game } = Astro.props;
+const comp = game.competitions[0];
+const homeComp = comp.competitors[0];
+const awayComp = comp.competitors[1];
+const status = comp.status;
+const scheduled = status.type.name.includes("STATUS_SCHEDULED");
+const completed = status.type.completed == true;
+const homeScore = cleanScore(homeComp.score);
+const awayScore = cleanScore(awayComp.score);
+const ballTeamId = comp.situation?.lastPlay?.end?.team?.id;
+
+function rankOf(c: any): number {
+  return c.curatedRank?.current || 99;
+}
+---
+<a class="game-compact-row" href={`/game/${game.id}`}>
+  <span class="gcr-team gcr-away">
+    {rankOf(awayComp) != 99 && <span class="gcr-rank">#{rankOf(awayComp)}</span>}
+    <img width="20" height="20" loading="lazy" decoding="async" alt="" class={`team-logo-${awayComp.id}`} src={`https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${awayComp.id}.png&h=40&w=40`} />
+    <span class:list={["gcr-abbr", { "fw-bold": completed && awayScore > homeScore }]}>{cleanAbbreviation(awayComp.team)}</span>
+    {!scheduled && !completed && ballTeamId == awayComp.id && <span class="gcr-ball">&#8226;</span>}
+  </span>
+  <span class="gcr-score">
+    {scheduled
+      ? "vs"
+      : <Fragment><span class:list={[{ "fw-bold": completed && awayScore > homeScore }]}>{awayScore}</span>&ndash;<span class:list={[{ "fw-bold": completed && homeScore > awayScore }]}>{homeScore}</span></Fragment>}
+  </span>
+  <span class="gcr-team gcr-home">
+    {!scheduled && !completed && ballTeamId == homeComp.id && <span class="gcr-ball">&#8226;</span>}
+    <span class:list={["gcr-abbr", { "fw-bold": completed && homeScore > awayScore }]}>{cleanAbbreviation(homeComp.team)}</span>
+    <img width="20" height="20" loading="lazy" decoding="async" alt="" class={`team-logo-${homeComp.id}`} src={`https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${homeComp.id}.png&h=40&w=40`} />
+    {rankOf(homeComp) != 99 && <span class="gcr-rank">#{rankOf(homeComp)}</span>}
+  </span>
+  <span class="gcr-status">{status.type.shortDetail}</span>
+</a>

--- a/astro/src/components/schedule/GameThumb.astro
+++ b/astro/src/components/schedule/GameThumb.astro
@@ -91,7 +91,11 @@ function calculateSpiceLevel(g: ESPNScheduleEvent): SpiceLevel {
 
 const spiceLevel = calculateSpiceLevel(espnGame) || 'none';
 const gameNote = espnGame.competitions[0].notes.length > 0 ? espnGame.competitions[0].notes[0].headline : ""
-const isChamp = isChampionshipEvent(gameNote);
+// conference championships get the gold treatment too, not just CFP events
+const isChamp = isChampionshipEvent(gameNote) || gameNote.includes("Championship");
+// no announced kickoff: the date is a placeholder midnight, so LocalDate
+// would render a bogus local time -- show ESPN's TBD detail text instead
+const timeTBD = (espnGameComp as any).timeValid === false;
 
 function generateThumbTheme(): GameThumbTheme {
     if (isChamp) {
@@ -134,13 +138,16 @@ const canLoadStatsTheme = canLoadStats ? `disabled` : ``
                         (gameStatus.type.completed == true) && <LocalDate client:idle divClass={"m-0"} prefix={gameStatus.type.detail} date={espnGame.date} format={DateTime.DATETIME_SHORT} />
                     }
                     {
-                        (gameStatus.type.name.includes("STATUS_SCHEDULED")) && <LocalDate client:idle divClass={"m-0"} date={espnGame.date} format={DateTime.DATETIME_SHORT} />
+                        (gameStatus.type.name.includes("STATUS_SCHEDULED")) && (timeTBD
+                            ? <div class="m-0">{gameStatus.type.detail}</div>
+                            : <LocalDate client:idle divClass={"m-0"} date={espnGame.date} format={DateTime.DATETIME_SHORT} />)
                     }
                     {
                         (gameStatus.type.completed != true) && (!gameStatus.type.name.includes("STATUS_SCHEDULED")) && <Fragment>{gameStatus.type.detail}</Fragment>
                     }
                 </strong>
             </div>
+            {gameNote && <p class:list={["small mb-2", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</p>}
             <TeamRow espnComp={awayComp} espnStatus={gameStatus} winner={awayScore > homeScore} completed={gameStatus.type.completed == true} hasBall={espnGameComp.situation?.lastPlay?.end?.team?.id == awayComp.id} isRedZone={espnGameComp.situation?.isRedZone} spacer="" />
             <TeamRow espnComp={homeComp} espnStatus={gameStatus} winner={awayScore < homeScore} completed={gameStatus.type.completed == true} hasBall={espnGameComp.situation?.lastPlay?.end?.team?.id == homeComp.id} isRedZone={espnGameComp.situation?.isRedZone} spacer="mb-3" />
             <GameSituation hidden={!canShowSituation} game={espnGame} />

--- a/astro/src/components/schedule/GameThumb.astro
+++ b/astro/src/components/schedule/GameThumb.astro
@@ -147,7 +147,6 @@ const canLoadStatsTheme = canLoadStats ? `disabled` : ``
                     }
                 </strong>
             </div>
-            {gameNote && <p class:list={["small mb-2", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</p>}
             <TeamRow espnComp={awayComp} espnStatus={gameStatus} winner={awayScore > homeScore} completed={gameStatus.type.completed == true} hasBall={espnGameComp.situation?.lastPlay?.end?.team?.id == awayComp.id} isRedZone={espnGameComp.situation?.isRedZone} spacer="" />
             <TeamRow espnComp={homeComp} espnStatus={gameStatus} winner={awayScore < homeScore} completed={gameStatus.type.completed == true} hasBall={espnGameComp.situation?.lastPlay?.end?.team?.id == homeComp.id} isRedZone={espnGameComp.situation?.isRedZone} spacer="mb-3" />
             <GameSituation hidden={!canShowSituation} game={espnGame} />
@@ -159,6 +158,7 @@ const canLoadStatsTheme = canLoadStats ? `disabled` : ``
                     <BroadcastButton game={espnGame} />
                 </div>
             </div>
+            {gameNote && <p class:list={["small mt-2 mb-0", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</p>}
         </div>
     </div>
 </div>

--- a/astro/src/components/schedule/GameThumb.astro
+++ b/astro/src/components/schedule/GameThumb.astro
@@ -158,7 +158,7 @@ const canLoadStatsTheme = canLoadStats ? `disabled` : ``
                     <BroadcastButton game={espnGame} />
                 </div>
             </div>
-            {gameNote && <p class:list={["small mt-2 mb-0", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</p>}
+            {gameNote && <p class:list={["small m-0 mt-3", isChamp ? "text-championship" : "text-muted"]}>{gameNote}</p>}
         </div>
     </div>
 </div>

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -144,10 +144,26 @@ if (compactRows) {
                     <div class="game-compact-list d-md-none mb-3">
                         {compactSlots.map(([slot, slotGames]) => (
                             <Fragment>
-                                <h6 class="gb-slot">{slot}</h6>
+                                <h6 class="gb-slot small text-muted mt-3 mb-1 ms-1" data-gb-utc={slotGames[0].date}>{slot}</h6>
                                 {slotGames.map((g) => <GameCompactRow game={g} />)}
                             </Fragment>
                         ))}
+                        {/* One pass over every ET label -- kickoff headers and
+                            scheduled-game times -- rewritten to the viewer's
+                            timezone. Plain inline script: the LocalDate island
+                            does this per element, and ~100 hydrated islands is
+                            the page-weight class the mobile work just fought. */}
+                        <script is:inline>
+                            (() => {
+                                try {
+                                    const fmt = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' });
+                                    document.querySelectorAll('[data-gb-utc]').forEach((el) => {
+                                        const d = new Date(el.getAttribute('data-gb-utc'));
+                                        if (!isNaN(d.getTime())) el.textContent = fmt.format(d);
+                                    });
+                                } catch { /* ET server-rendered fallback stands */ }
+                            })();
+                        </script>
                     </div>
                 )
             }

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -84,6 +84,9 @@ const allTeamIds = games.map(g => {
 // rendering either way.
 const compactRows = isFeatureEnabled('scoreboard-compact', Astro.locals);
 const slotOf = (g: ESPNScheduleEvent) => {
+    // no announced kickoff: the date is a placeholder midnight, so a time
+    // label (and client-side localization) would be a lie
+    if ((g.competitions?.[0] as any)?.timeValid === false) return 'Time TBD';
     try {
         return new Intl.DateTimeFormat('en-US', {
             timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit',
@@ -144,7 +147,7 @@ if (compactRows) {
                     <div class="game-compact-list d-md-none mb-3">
                         {compactSlots.map(([slot, slotGames]) => (
                             <Fragment>
-                                <h6 class="gb-slot small text-muted mt-3 mb-1 ms-1" data-gb-utc={slotGames[0].date}>{slot}</h6>
+                                <h6 class="gb-slot small text-muted mt-3 mb-1 ms-1" data-gb-utc={slot === 'Time TBD' ? undefined : slotGames[0].date}>{slot}</h6>
                                 {slotGames.map((g) => <GameCompactRow game={g} />)}
                             </Fragment>
                         ))}

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -86,24 +86,31 @@ const allTeamIds = games.map(g => {
 // cards are ~40% of a phone viewport each); the card grid stays the >=768px
 // rendering either way.
 const compactRows = isFeatureEnabled('scoreboard-compact', Astro.locals);
-const slotOf = (g: ESPNScheduleEvent) => {
-    // no announced kickoff: the date is a placeholder midnight, so a time
-    // label (and client-side localization) would be a lie
-    if ((g.competitions?.[0] as any)?.timeValid === false) return 'Time TBD';
+const etFmt = (d: string, opts: Intl.DateTimeFormatOptions) => {
     try {
-        return new Intl.DateTimeFormat('en-US', {
-            timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit',
-        }).format(new Date(g.date)) + ' ET';
-    } catch { return 'TBD'; }
+        return new Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', ...opts }).format(new Date(d));
+    } catch { return ''; }
 };
-const compactSlots: [string, ESPNScheduleEvent[]][] = [];
+// Slots are keyed by ET DAY + time, not time alone: on a year/week schedule
+// two Saturdays share "12:00 PM" and would otherwise merge under one header
+// (CodeRabbit on #216). The day prefix renders only when the page actually
+// spans multiple dates, so the single-day scoreboard keeps its clean labels.
+type CompactSlot = { key: string; day: string; time: string; tbd: boolean; games: ESPNScheduleEvent[] };
+const compactSlots: CompactSlot[] = [];
+let compactMultiDate = false;
 if (compactRows) {
     for (const g of [...games].sort((a, b) => Date.parse(a.date) - Date.parse(b.date))) {
-        const label = slotOf(g);
+        // no announced kickoff: the date is a placeholder midnight, so a time
+        // label (and client-side localization) would be a lie
+        const tbd = (g.competitions?.[0] as any)?.timeValid === false;
+        const day = etFmt(g.date, { weekday: 'short', month: 'numeric', day: 'numeric' });
+        const time = tbd ? 'Time TBD' : (etFmt(g.date, { hour: 'numeric', minute: '2-digit' }) || 'TBD') + ' ET';
+        const key = `${day}|${time}`;
         const last = compactSlots[compactSlots.length - 1];
-        if (last && last[0] === label) last[1].push(g);
-        else compactSlots.push([label, [g]]);
+        if (last && last.key === key) last.games.push(g);
+        else compactSlots.push({ key, day, time, tbd, games: [g] });
     }
+    compactMultiDate = new Set(compactSlots.map((s) => s.day)).size > 1;
 }
 ---
 
@@ -148,10 +155,13 @@ if (compactRows) {
             {
                 (compactRows && games.length > 0) && (
                     <div class="game-compact-list d-md-none mb-3">
-                        {compactSlots.map(([slot, slotGames]) => (
+                        {compactSlots.map((slot) => (
                             <Fragment>
-                                <h6 class="gb-slot small text-muted mt-3 mb-1 ms-1" data-gb-utc={slot === 'Time TBD' ? undefined : slotGames[0].date}>{slot}</h6>
-                                {slotGames.map((g) => <GameCompactRow game={g} />)}
+                                <h6 class="gb-slot small text-muted mt-3 mb-1 ms-1"
+                                    data-gb-utc={slot.tbd ? undefined : slot.games[0].date}
+                                    data-gb-fmt={compactMultiDate && !slot.tbd ? 'datetime' : undefined}>
+                                    {compactMultiDate ? `${slot.day} · ${slot.time}` : slot.time}</h6>
+                                {slot.games.map((g) => <GameCompactRow game={g} />)}
                             </Fragment>
                         ))}
                         {/* One pass over every ET label -- kickoff headers and
@@ -162,10 +172,15 @@ if (compactRows) {
                         <script is:inline>
                             (() => {
                                 try {
-                                    const fmt = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' });
                                     document.querySelectorAll('[data-gb-utc]').forEach((el) => {
                                         const d = new Date(el.getAttribute('data-gb-utc'));
-                                        if (!isNaN(d.getTime())) el.textContent = fmt.format(d);
+                                        if (isNaN(d.getTime())) return;
+                                        // multi-date pages keep the day in the header so two
+                                        // Saturdays' 12:00 PM slots stay distinguishable
+                                        const opts = el.getAttribute('data-gb-fmt') === 'datetime'
+                                            ? { weekday: 'short', month: 'numeric', day: 'numeric', hour: 'numeric', minute: '2-digit', timeZoneName: 'short' }
+                                            : { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' };
+                                        el.textContent = new Intl.DateTimeFormat(undefined, opts).format(d);
                                     });
                                 } catch { /* ET server-rendered fallback stands */ }
                             })();

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -2,7 +2,9 @@
 import { type ESPNScheduleEvent } from "../../resources/espn";
 import DarkModeLogos from "../DarkModeLogos.astro";
 import Footer from "../Footer.astro";
+import GameCompactRow from "./GameCompactRow.astro";
 import GameThumb from "./GameThumb.astro";
+import { isFeatureEnabled } from "../../utils/features";
 import ScheduleDropdown from "./ScheduleDropdown.svelte";
 import Header from "../Header.astro"
 import Scripts from "../Scripts.astro"
@@ -76,6 +78,10 @@ const hasActiveGames = games.find((item: ESPNScheduleEvent) => item.status && !(
 const allTeamIds = games.map(g => {
     return g.competitions[0].competitors.map(t => t.id)
 }).reduce((a,b) => a.concat(b), [])
+
+// Preview: compact one-line rows on phones (the cards are ~40% of a phone
+// viewport each); the card grid stays the >=768px rendering either way.
+const compactRows = isFeatureEnabled('scoreboard-compact', Astro.locals);
 ---
 
 <!DOCTYPE html>
@@ -116,7 +122,14 @@ const allTeamIds = games.map(g => {
         <div class="container">
             <h1 class="visually-hidden">{title || titleText}</h1>
             <ScheduleDropdown client:idle season={season} week={week} seasontype={seasontype} group={group} />
-            <div class="row mb-3">
+            {
+                (compactRows && games.length > 0) && (
+                    <div class="game-compact-list d-md-none mb-3">
+                        {games.map((g) => <GameCompactRow game={g} />)}
+                    </div>
+                )
+            }
+            <div class={`row mb-3${compactRows && games.length > 0 ? " d-none d-md-flex" : ""}`}>
                 {
                     (games.length > 0) && (games.map((g => <GameThumb game={g} />)))
                 }

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -79,9 +79,26 @@ const allTeamIds = games.map(g => {
     return g.competitions[0].competitors.map(t => t.id)
 }).reduce((a,b) => a.concat(b), [])
 
-// Preview: compact one-line rows on phones (the cards are ~40% of a phone
-// viewport each); the card grid stays the >=768px rendering either way.
+// Preview: banner rows on phones grouped under kickoff-time headers (the
+// cards are ~40% of a phone viewport each); the card grid stays the >=768px
+// rendering either way.
 const compactRows = isFeatureEnabled('scoreboard-compact', Astro.locals);
+const slotOf = (g: ESPNScheduleEvent) => {
+    try {
+        return new Intl.DateTimeFormat('en-US', {
+            timeZone: 'America/New_York', hour: 'numeric', minute: '2-digit',
+        }).format(new Date(g.date)) + ' ET';
+    } catch { return 'TBD'; }
+};
+const compactSlots: [string, ESPNScheduleEvent[]][] = [];
+if (compactRows) {
+    for (const g of [...games].sort((a, b) => Date.parse(a.date) - Date.parse(b.date))) {
+        const label = slotOf(g);
+        const last = compactSlots[compactSlots.length - 1];
+        if (last && last[0] === label) last[1].push(g);
+        else compactSlots.push([label, [g]]);
+    }
+}
 ---
 
 <!DOCTYPE html>
@@ -125,7 +142,12 @@ const compactRows = isFeatureEnabled('scoreboard-compact', Astro.locals);
             {
                 (compactRows && games.length > 0) && (
                     <div class="game-compact-list d-md-none mb-3">
-                        {games.map((g) => <GameCompactRow game={g} />)}
+                        {compactSlots.map(([slot, slotGames]) => (
+                            <Fragment>
+                                <h6 class="gb-slot">{slot}</h6>
+                                {slotGames.map((g) => <GameCompactRow game={g} />)}
+                            </Fragment>
+                        ))}
                     </div>
                 )
             }

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -78,6 +78,9 @@ const hasActiveGames = games.find((item: ESPNScheduleEvent) => item.status && !(
 const allTeamIds = games.map(g => {
     return g.competitions[0].competitors.map(t => t.id)
 }).reduce((a,b) => a.concat(b), [])
+    // TBD placeholders have no real id; a dark-logo override for /0.png
+    // would replace their default shield with a broken image in dark mode
+    .filter(id => id && String(id) !== '0')
 
 // Preview: banner rows on phones grouped under kickoff-time headers (the
 // cards are ~40% of a phone viewport each); the card grid stays the >=768px

--- a/astro/src/components/schedule/TeamRow.astro
+++ b/astro/src/components/schedule/TeamRow.astro
@@ -28,12 +28,17 @@ function formatScore(score: string | { displayValue: string }, winner: boolean, 
 const comp = (espnComp as ESPNCompetitor);
 const status = (espnStatus as ESPNStatus);
 const rank = comp.curatedRank?.current || 99;
+// A TBD placeholder competitor has no real team id; ESPN's default shield
+// stands in so the card never shows a broken image.
+const logoSrc = comp.id && String(comp.id) !== "0" && comp.team?.abbreviation !== "TBD"
+    ? `https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${comp.id}.png&h=80&w=80`
+    : "https://a.espncdn.com/combiner/i?img=/i/teamlogos/default-team-logo-500.png&h=80&w=80";
 const possessionClass = isRedZone ? "text-danger" : "text-primary";
 const possessionMarker = hasBall ? `<span class="ms-1 ${possessionClass}">&#8226;</span>` : ''
 ---
 <div class={`m-0 d-flex ${spacer}`}>
     <div class="d-flex me-auto">
-        <img class=`float-start align-self-center me-2 team-logo-${comp.id}` width="30" height="30" loading="lazy" decoding="async" src=`https://a.espncdn.com/combiner/i?img=/i/teamlogos/ncaa/500/${comp.id}.png&h=80&w=80` />
+        <img class=`float-start align-self-center me-2 team-logo-${comp.id}` width="30" height="30" loading="lazy" decoding="async" src={logoSrc} />
         <div class="d-flex flex-column me-3 align-self-center">
             <div class="d-flex align-items-center">
                 <span class=`small text-muted ${(rank != 99) ? "me-1" : ""}`>{(rank != 99) ? ("#" + rank) : ""}</span>

--- a/astro/src/utils/features.ts
+++ b/astro/src/utils/features.ts
@@ -21,6 +21,9 @@ export const FLAGS: Record<string, FeatureState> = {
     // the frozen pre-v2 snapshot (components/game/classic/); the preview cookie
     // renders the new tree. Promote by flipping to 'on' and deleting classic/.
     'game-page-v2': 'preview',
+    // Mobile scoreboard: one-line rows (GameCompactRow) instead of cards under
+    // 768px. Desktop keeps the card grid either way.
+    'scoreboard-compact': 'preview',
 };
 
 export function isFeatureEnabled(name: string, locals: { preview?: boolean } | undefined): boolean {

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -16,6 +16,37 @@ function competitor(id: string, abbr: string, score: string, rank = 99) {
     };
 }
 
+function tbdCompetitor() {
+    return {
+        id: '0',
+        score: '0',
+        team: { id: '0', abbreviation: 'TBD', location: 'TBD', conferenceId: '0' },
+        curatedRank: { current: 99 },
+        records: [],
+    };
+}
+
+function championshipEvent(id: string) {
+    // conference championship placeholder: TBD vs TBD, no announced kickoff
+    const status = {
+        period: 0, clock: 0,
+        type: { id: '1', name: 'STATUS_SCHEDULED', completed: false, detail: 'Sat, December 5th TBD', shortDetail: '12/5 - TBD' },
+    };
+    return {
+        id,
+        date: '2026-12-05T05:00Z',
+        status,
+        competitions: [{
+            id,
+            date: '2026-12-05T05:00Z',
+            status,
+            timeValid: false,
+            notes: [{ type: 'event', headline: 'SEC Championship Game' }],
+            competitors: [tbdCompetitor(), tbdCompetitor()],
+        }],
+    };
+}
+
 function gameEvent(id: string, opts: { completed: boolean; live?: boolean }) {
     const status = opts.live
         ? {
@@ -61,7 +92,7 @@ async function render(locals: Record<string, unknown>) {
     return container.renderToString(SchedulePage, {
         props: {
             season: 2026, week: 2, isScoreboard: true,
-            games: [gameEvent('401', { completed: true }), gameEvent('402', { completed: false }), gameEvent('403', { completed: false, live: true })],
+            games: [gameEvent('401', { completed: true }), gameEvent('402', { completed: false }), gameEvent('403', { completed: false, live: true }), championshipEvent('404')],
         },
         request: new Request('https://gameonpaper.com/'),
         locals,
@@ -73,11 +104,12 @@ describe('the compact scoreboard rows are preview-gated', () => {
         const html = await render({ preview: true });
         expect(html).toContain('game-compact-list');
         const rows = [...html.matchAll(/class="game-banner[" ]/g)];
-        expect(rows).toHaveLength(3);
+        expect(rows).toHaveLength(4);
         // both fixture games share a kickoff -> exactly one time-slot header (ET)
         const slots = [...html.matchAll(/class="gb-slot[^"]*"[^>]*>([^<]+)</g)].map((m) => m[1]);
-        expect(slots).toHaveLength(1);
+        expect(slots).toHaveLength(2);
         expect(slots[0]).toMatch(/7:30 PM ET/);
+        expect(slots[1]).toBe('Time TBD');
         // full school names, not truncated abbreviation pairs
         expect(html).toContain('ALA State');
         expect(html).toContain('AUB State');
@@ -97,6 +129,19 @@ describe('the compact scoreboard rows are preview-gated', () => {
         const liveCard = html.slice(html.indexOf('/game/403'));
         expect(liveCard.slice(0, liveCard.indexOf('</a>'))).toContain('text-danger');
         expect(liveCard).toContain('8:32 - 3rd');
+        // championship placeholder: default shield (no broken 500/0.png), note
+        // line, TBD status, and NO data-gb-utc anywhere (its date is a
+        // placeholder midnight the localization script must not "fix"; the
+        // Time TBD slot header carries none either)
+        const champCard = html.slice(html.indexOf('/game/404'));
+        const champA = champCard.slice(0, champCard.indexOf('</a>'));
+        expect(champA).toContain('default-team-logo-500.png');
+        expect(champA).not.toContain('/500/0.png');
+        expect(champA).toContain('SEC Championship Game');
+        // gold championship treatment on the card and the note line
+        expect(html.slice(0, html.indexOf('/game/404')).slice(-400) + champA).toContain('outline-championship');
+        expect(champA).toContain('text-championship');
+        expect(champA).not.toContain('data-gb-utc');
         expect(html).toContain("querySelectorAll('[data-gb-utc]')");
         // the card grid is still there for md+, hidden on phones
         expect(html).toMatch(/class="row mb-3 d-none d-md-flex"/);

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -105,11 +105,15 @@ describe('the compact scoreboard rows are preview-gated', () => {
         expect(html).toContain('game-compact-list');
         const rows = [...html.matchAll(/class="game-banner[" ]/g)];
         expect(rows).toHaveLength(4);
-        // both fixture games share a kickoff -> exactly one time-slot header (ET)
-        const slots = [...html.matchAll(/class="gb-slot[^"]*"[^>]*>([^<]+)</g)].map((m) => m[1]);
+        // slots are keyed by ET day + time; the fixture spans two dates, so
+        // labels carry the day prefix and the headers carry data-gb-fmt so the
+        // localization script keeps the date in its rewrite (CodeRabbit: two
+        // Saturdays sharing "12:00 PM" must not merge under one header)
+        const slots = [...html.matchAll(/class="gb-slot[^"]*"[^>]*>\s*([^<]+)</g)].map((m) => m[1].trim());
         expect(slots).toHaveLength(2);
-        expect(slots[0]).toMatch(/7:30 PM ET/);
-        expect(slots[1]).toBe('Time TBD');
+        expect(slots[0]).toMatch(/^\w+, 9\/6 · 7:30 PM ET$/);
+        expect(slots[1]).toMatch(/^\w+, 12\/5 · Time TBD$/);
+        expect(html).toMatch(/data-gb-utc="2026-09-06T23:30Z"[^>]*data-gb-fmt="datetime"/);
         // Option E: abbreviations with the rank AHEAD of the abbr on BOTH
         // sides (the banner list section only -- the md+ card grid also
         // renders ranks, differently)

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -110,24 +110,25 @@ describe('the compact scoreboard rows are preview-gated', () => {
         expect(slots).toHaveLength(2);
         expect(slots[0]).toMatch(/7:30 PM ET/);
         expect(slots[1]).toBe('Time TBD');
-        // full school names, not truncated abbreviation pairs
-        expect(html).toContain('ALA State');
-        expect(html).toContain('AUB State');
-        // completed: winner fw-bold, loser opacity-50 (Bootstrap utilities,
-        // TeamRow semantics), never both; live/scheduled mark nobody
-        expect(html).toMatch(/gb-pts fs-5 opacity-50">17</);
-        expect(html).toMatch(/gb-pts fs-5 fw-bold">24</);
-        expect(html).not.toMatch(/fw-bold opacity-50/);
-        // team-color stripe carries the ESPN hex
-        expect(html).toContain('style="background:#ba0c2f"');
+        // Option E: abbreviations with the rank AHEAD of the abbr on BOTH
+        // sides (the banner list section only -- the md+ card grid also
+        // renders ranks, differently)
+        const banners = html.slice(html.indexOf('game-compact-list'), html.indexOf('class="row mb-3'));
+        expect(banners).toMatch(/gb-rank text-muted">#5<\/span><span class="gb-abbr[^"]*">ALA</);
+        // completed: winner fw-bold, loser opacity-50 (TeamRow semantics),
+        // never both; live/scheduled mark nobody
+        expect(banners).toMatch(/gb-pts opacity-50">17</);
+        expect(banners).toMatch(/gb-pts fw-bold">24</);
+        expect(banners).not.toMatch(/fw-bold opacity-50/);
         // scheduled game: ET kickoff server-rendered as the no-JS fallback,
         // with data-gb-utc for the single localization script (no islands)
         expect(html).toMatch(/data-gb-utc="2026-09-06T23:30Z"[^>]*>7:30 PM EDT</);
         expect(html).toMatch(/gb-slot[^>]*data-gb-utc=/);
         expect([...html.matchAll(/data-gb-utc="/g)].length).toBe(2); // header + 1 scheduled game (live/final carry none)
-        // live game: possession dot on the team with the ball, red in the red zone
+        // live game: possession badge on the logo of the team with the ball,
+        // red variant in the red zone
         const liveCard = html.slice(html.indexOf('/game/403'));
-        expect(liveCard.slice(0, liveCard.indexOf('</a>'))).toContain('text-danger');
+        expect(liveCard.slice(0, liveCard.indexOf('</a>'))).toContain('gb-ball gb-ball-rz');
         expect(liveCard).toContain('8:32 - 3rd');
         // championship placeholder: default shield (no broken 500/0.png), note
         // line, TBD status, and NO data-gb-utc anywhere (its date is a
@@ -141,6 +142,7 @@ describe('the compact scoreboard rows are preview-gated', () => {
         // gold championship treatment on the card and the note line
         expect(html.slice(0, html.indexOf('/game/404')).slice(-400) + champA).toContain('outline-championship');
         expect(champA).toContain('text-championship');
+        expect(champA).toContain('gb-note');
         expect(champA).not.toContain('data-gb-utc');
         // the DESKTOP CARD GRID gets the same treatment (GameThumb/TeamRow):
         // TBD detail text instead of a LocalDate island on the placeholder

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -70,9 +70,11 @@ describe('the compact scoreboard rows are preview-gated', () => {
         const slots = [...html.matchAll(/class="gb-slot">([^<]+)</g)].map((m) => m[1]);
         expect(slots).toHaveLength(1);
         expect(slots[0]).toMatch(/7:30 PM ET/);
-        // completed: only the LOSER is dimmed; live/scheduled dim nobody
+        // completed: winner bold (gb-won), loser dimmed (gb-lost), never both;
+        // live/scheduled mark nobody
         expect(html).toMatch(/gb-score gb-lost">17</);
-        expect(html).toMatch(/gb-score">24</);
+        expect(html).toMatch(/gb-score gb-won">24</);
+        expect(html).not.toMatch(/gb-won gb-lost/);
         // team-color stripe carries the ESPN hex
         expect(html).toContain('style="background:#ba0c2f"');
         // scheduled game: kickoff time in the middle, no scores

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -114,7 +114,8 @@ describe('the compact scoreboard rows are preview-gated', () => {
         // sides (the banner list section only -- the md+ card grid also
         // renders ranks, differently)
         const banners = html.slice(html.indexOf('game-compact-list'), html.indexOf('class="row mb-3'));
-        expect(banners).toMatch(/gb-rank text-muted">#5<\/span><span class="gb-abbr[^"]*">ALA</);
+        // rank lives INSIDE the abbr span so both share a text baseline
+        expect(banners).toMatch(/gb-abbr[^>]*><span class="gb-rank text-muted">#5<\/span> ALA</);
         // completed: winner fw-bold, loser opacity-50 (TeamRow semantics),
         // never both; live/scheduled mark nobody
         expect(banners).toMatch(/gb-pts opacity-50">17</);

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -142,6 +142,15 @@ describe('the compact scoreboard rows are preview-gated', () => {
         expect(html.slice(0, html.indexOf('/game/404')).slice(-400) + champA).toContain('outline-championship');
         expect(champA).toContain('text-championship');
         expect(champA).not.toContain('data-gb-utc');
+        // the DESKTOP CARD GRID gets the same treatment (GameThumb/TeamRow):
+        // TBD detail text instead of a LocalDate island on the placeholder
+        // midnight, the note headline, the gold class, and shield logos --
+        // no broken /500/0.png anywhere on the page
+        const grid = html.slice(html.indexOf('class="row mb-3'));
+        expect(grid).toContain('Sat, December 5th TBD');
+        expect(grid).toContain('SEC Championship Game');
+        expect(grid).toContain('text-championship');
+        expect(html).not.toContain('/500/0.png');
         expect(html).toContain("querySelectorAll('[data-gb-utc]')");
         // the card grid is still there for md+, hidden on phones
         expect(html).toMatch(/class="row mb-3 d-none d-md-flex"/);

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -1,0 +1,82 @@
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { loadRenderers } from 'astro:container';
+import { getContainerRenderer as svelteRenderer } from '@astrojs/svelte/container-renderer';
+import { beforeAll, describe, expect, test } from 'vitest';
+
+// The compact scoreboard rows ('scoreboard-compact' flag) must render for a
+// previewing admin and stay entirely absent from the public page.
+
+function competitor(id: string, abbr: string, score: string, rank = 99) {
+    return {
+        id,
+        score,
+        team: { id, abbreviation: abbr, conferenceId: '8' },
+        curatedRank: { current: rank },
+        records: [],
+    };
+}
+
+function gameEvent(id: string, opts: { completed: boolean }) {
+    const status = {
+        period: opts.completed ? 4 : 0,
+        clock: 0,
+        type: {
+            id: opts.completed ? '3' : '1',
+            name: opts.completed ? 'STATUS_FINAL' : 'STATUS_SCHEDULED',
+            completed: opts.completed,
+            detail: opts.completed ? 'Final' : 'Sat, September 6th at 7:30 PM EDT',
+            shortDetail: opts.completed ? 'Final' : '9/6 - 7:30 PM EDT',
+        },
+    };
+    return {
+        id,
+        date: '2026-09-06T23:30Z',
+        status,
+        competitions: [{
+            id,
+            date: '2026-09-06T23:30Z',
+            status,
+            notes: [],
+            // ids chosen off the MEME_LIST (61 = UGA renders lowercased on purpose)
+            competitors: [competitor('333', 'ALA', '24', 5), competitor('2', 'AUB', '17')],
+        }],
+    };
+}
+
+let container: AstroContainer;
+beforeAll(async () => {
+    container = await AstroContainer.create({ renderers: await loadRenderers([svelteRenderer()]) });
+});
+
+async function render(locals: Record<string, unknown>) {
+    const { default: SchedulePage } = await import('../src/components/schedule/SchedulePage.astro');
+    return container.renderToString(SchedulePage, {
+        props: {
+            season: 2026, week: 2, isScoreboard: true,
+            games: [gameEvent('401', { completed: true }), gameEvent('402', { completed: false })],
+        },
+        request: new Request('https://gameonpaper.com/'),
+        locals,
+    });
+}
+
+describe('the compact scoreboard rows are preview-gated', () => {
+    test('preview renders mobile rows and demotes the card grid to md+', async () => {
+        const html = await render({ preview: true });
+        expect(html).toContain('game-compact-list');
+        const rows = [...html.matchAll(/class="game-compact-row"/g)];
+        expect(rows).toHaveLength(2);
+        // completed: away-home score with the winner bold; scheduled: "vs" + a time
+        expect(html).toMatch(/gcr-score"><span>17<\/span>&ndash;<span class="fw-bold">24<\/span>/);
+        expect(html).toContain('vs');
+        expect(html).toContain('9/6 - 7:30 PM EDT');
+        // the card grid is still there for md+, hidden on phones
+        expect(html).toMatch(/class="row mb-3 d-none d-md-flex"/);
+    });
+
+    test('the public page has no trace of the compact variant', async () => {
+        const html = await render({});
+        expect(html).not.toContain('game-compact');
+        expect(html).not.toContain('d-none d-md-flex');
+    });
+});

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -16,18 +16,24 @@ function competitor(id: string, abbr: string, score: string, rank = 99) {
     };
 }
 
-function gameEvent(id: string, opts: { completed: boolean }) {
-    const status = {
-        period: opts.completed ? 4 : 0,
-        clock: 0,
-        type: {
-            id: opts.completed ? '3' : '1',
-            name: opts.completed ? 'STATUS_FINAL' : 'STATUS_SCHEDULED',
-            completed: opts.completed,
-            detail: opts.completed ? 'Final' : 'Sat, September 6th at 7:30 PM EDT',
-            shortDetail: opts.completed ? 'Final' : '9/6 - 7:30 PM EDT',
-        },
-    };
+function gameEvent(id: string, opts: { completed: boolean; live?: boolean }) {
+    const status = opts.live
+        ? {
+            period: 3,
+            clock: 512,
+            type: { id: '2', name: 'STATUS_IN_PROGRESS', completed: false, detail: '8:32 - 3rd', shortDetail: '8:32 - 3rd' },
+        }
+        : {
+            period: opts.completed ? 4 : 0,
+            clock: 0,
+            type: {
+                id: opts.completed ? '3' : '1',
+                name: opts.completed ? 'STATUS_FINAL' : 'STATUS_SCHEDULED',
+                completed: opts.completed,
+                detail: opts.completed ? 'Final' : 'Sat, September 6th at 7:30 PM EDT',
+                shortDetail: opts.completed ? 'Final' : '9/6 - 7:30 PM EDT',
+            },
+        };
     return {
         id,
         date: '2026-09-06T23:30Z',
@@ -39,6 +45,8 @@ function gameEvent(id: string, opts: { completed: boolean }) {
             notes: [],
             // ids chosen off the MEME_LIST (61 = UGA renders lowercased on purpose)
             competitors: [competitor('333', 'ALA', '24', 5), competitor('2', 'AUB', '17')],
+            // the live game: ALA has the ball in the red zone
+            ...(opts.live ? { situation: { lastPlay: { end: { team: { id: '333' } } }, isRedZone: true } } : {}),
         }],
     };
 }
@@ -53,7 +61,7 @@ async function render(locals: Record<string, unknown>) {
     return container.renderToString(SchedulePage, {
         props: {
             season: 2026, week: 2, isScoreboard: true,
-            games: [gameEvent('401', { completed: true }), gameEvent('402', { completed: false })],
+            games: [gameEvent('401', { completed: true }), gameEvent('402', { completed: false }), gameEvent('403', { completed: false, live: true })],
         },
         request: new Request('https://gameonpaper.com/'),
         locals,
@@ -65,7 +73,7 @@ describe('the compact scoreboard rows are preview-gated', () => {
         const html = await render({ preview: true });
         expect(html).toContain('game-compact-list');
         const rows = [...html.matchAll(/class="game-banner[" ]/g)];
-        expect(rows).toHaveLength(2);
+        expect(rows).toHaveLength(3);
         // both fixture games share a kickoff -> exactly one time-slot header (ET)
         const slots = [...html.matchAll(/class="gb-slot[^"]*"[^>]*>([^<]+)</g)].map((m) => m[1]);
         expect(slots).toHaveLength(1);
@@ -84,7 +92,11 @@ describe('the compact scoreboard rows are preview-gated', () => {
         // with data-gb-utc for the single localization script (no islands)
         expect(html).toMatch(/data-gb-utc="2026-09-06T23:30Z"[^>]*>7:30 PM EDT</);
         expect(html).toMatch(/gb-slot[^>]*data-gb-utc=/);
-        expect([...html.matchAll(/data-gb-utc=/g)].length).toBe(2); // header + 1 scheduled game
+        expect([...html.matchAll(/data-gb-utc="/g)].length).toBe(2); // header + 1 scheduled game (live/final carry none)
+        // live game: possession dot on the team with the ball, red in the red zone
+        const liveCard = html.slice(html.indexOf('/game/403'));
+        expect(liveCard.slice(0, liveCard.indexOf('</a>'))).toContain('text-danger');
+        expect(liveCard).toContain('8:32 - 3rd');
         expect(html).toContain("querySelectorAll('[data-gb-utc]')");
         // the card grid is still there for md+, hidden on phones
         expect(html).toMatch(/class="row mb-3 d-none d-md-flex"/);

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -10,7 +10,7 @@ function competitor(id: string, abbr: string, score: string, rank = 99) {
     return {
         id,
         score,
-        team: { id, abbreviation: abbr, conferenceId: '8' },
+        team: { id, abbreviation: abbr, conferenceId: '8', color: 'ba0c2f', location: `${abbr} State` },
         curatedRank: { current: rank },
         records: [],
     };
@@ -61,15 +61,22 @@ async function render(locals: Record<string, unknown>) {
 }
 
 describe('the compact scoreboard rows are preview-gated', () => {
-    test('preview renders mobile rows and demotes the card grid to md+', async () => {
+    test('preview renders banner rows under a kickoff-time header, card grid demoted to md+', async () => {
         const html = await render({ preview: true });
         expect(html).toContain('game-compact-list');
-        const rows = [...html.matchAll(/class="game-compact-row"/g)];
+        const rows = [...html.matchAll(/class="game-banner"/g)];
         expect(rows).toHaveLength(2);
-        // completed: away-home score with the winner bold; scheduled: "vs" + a time
-        expect(html).toMatch(/gcr-score"><span>17<\/span>&ndash;<span class="fw-bold">24<\/span>/);
-        expect(html).toContain('vs');
-        expect(html).toContain('9/6 - 7:30 PM EDT');
+        // both fixture games share a kickoff -> exactly one time-slot header (ET)
+        const slots = [...html.matchAll(/class="gb-slot">([^<]+)</g)].map((m) => m[1]);
+        expect(slots).toHaveLength(1);
+        expect(slots[0]).toMatch(/7:30 PM ET/);
+        // completed: only the LOSER is dimmed; live/scheduled dim nobody
+        expect(html).toMatch(/gb-score gb-lost">17</);
+        expect(html).toMatch(/gb-score">24</);
+        // team-color stripe carries the ESPN hex
+        expect(html).toContain('style="background:#ba0c2f"');
+        // scheduled game: kickoff time in the middle, no scores
+        expect(html).toContain('7:30 PM EDT');
         // the card grid is still there for md+, hidden on phones
         expect(html).toMatch(/class="row mb-3 d-none d-md-flex"/);
     });
@@ -77,6 +84,7 @@ describe('the compact scoreboard rows are preview-gated', () => {
     test('the public page has no trace of the compact variant', async () => {
         const html = await render({});
         expect(html).not.toContain('game-compact');
+        expect(html).not.toContain('game-banner');
         expect(html).not.toContain('d-none d-md-flex');
     });
 });

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -70,10 +70,13 @@ describe('the compact scoreboard rows are preview-gated', () => {
         const slots = [...html.matchAll(/class="gb-slot">([^<]+)</g)].map((m) => m[1]);
         expect(slots).toHaveLength(1);
         expect(slots[0]).toMatch(/7:30 PM ET/);
+        // full school names, not truncated abbreviation pairs
+        expect(html).toContain('ALA State');
+        expect(html).toContain('AUB State');
         // completed: winner bold (gb-won), loser dimmed (gb-lost), never both;
         // live/scheduled mark nobody
-        expect(html).toMatch(/gb-score gb-lost">17</);
-        expect(html).toMatch(/gb-score gb-won">24</);
+        expect(html).toMatch(/gb-pts gb-lost">17</);
+        expect(html).toMatch(/gb-pts gb-won">24</);
         expect(html).not.toMatch(/gb-won gb-lost/);
         // team-color stripe carries the ESPN hex
         expect(html).toContain('style="background:#ba0c2f"');

--- a/astro/test/scoreboard.render.test.ts
+++ b/astro/test/scoreboard.render.test.ts
@@ -64,24 +64,28 @@ describe('the compact scoreboard rows are preview-gated', () => {
     test('preview renders banner rows under a kickoff-time header, card grid demoted to md+', async () => {
         const html = await render({ preview: true });
         expect(html).toContain('game-compact-list');
-        const rows = [...html.matchAll(/class="game-banner"/g)];
+        const rows = [...html.matchAll(/class="game-banner[" ]/g)];
         expect(rows).toHaveLength(2);
         // both fixture games share a kickoff -> exactly one time-slot header (ET)
-        const slots = [...html.matchAll(/class="gb-slot">([^<]+)</g)].map((m) => m[1]);
+        const slots = [...html.matchAll(/class="gb-slot[^"]*"[^>]*>([^<]+)</g)].map((m) => m[1]);
         expect(slots).toHaveLength(1);
         expect(slots[0]).toMatch(/7:30 PM ET/);
         // full school names, not truncated abbreviation pairs
         expect(html).toContain('ALA State');
         expect(html).toContain('AUB State');
-        // completed: winner bold (gb-won), loser dimmed (gb-lost), never both;
-        // live/scheduled mark nobody
-        expect(html).toMatch(/gb-pts gb-lost">17</);
-        expect(html).toMatch(/gb-pts gb-won">24</);
-        expect(html).not.toMatch(/gb-won gb-lost/);
+        // completed: winner fw-bold, loser opacity-50 (Bootstrap utilities,
+        // TeamRow semantics), never both; live/scheduled mark nobody
+        expect(html).toMatch(/gb-pts fs-5 opacity-50">17</);
+        expect(html).toMatch(/gb-pts fs-5 fw-bold">24</);
+        expect(html).not.toMatch(/fw-bold opacity-50/);
         // team-color stripe carries the ESPN hex
         expect(html).toContain('style="background:#ba0c2f"');
-        // scheduled game: kickoff time in the middle, no scores
-        expect(html).toContain('7:30 PM EDT');
+        // scheduled game: ET kickoff server-rendered as the no-JS fallback,
+        // with data-gb-utc for the single localization script (no islands)
+        expect(html).toMatch(/data-gb-utc="2026-09-06T23:30Z"[^>]*>7:30 PM EDT</);
+        expect(html).toMatch(/gb-slot[^>]*data-gb-utc=/);
+        expect([...html.matchAll(/data-gb-utc=/g)].length).toBe(2); // header + 1 scheduled game
+        expect(html).toContain("querySelectorAll('[data-gb-utc]')");
         // the card grid is still there for md+, hidden on phones
         expect(html).toMatch(/class="row mb-3 d-none d-md-flex"/);
     });


### PR DESCRIPTION
Mobile-QA finding 10 (`notes/2026-09-03-gop-mobile-qa.md`): one scoreboard card ≈ 40% of a phone viewport. Behind the new `'scoreboard-compact'` preview flag:

- **Phones (<768px)**: one tappable row per game — logos (40px combiner variant, lazy), ranks, away–home score with the winner bold, possession dot on live games, ESPN's `shortDetail` status — the whole row links to `/game/<id>`. `min-height: 44px` keeps the tap-target floor.
- **md+**: the card grid, unchanged.
- **Public**: byte-identical render while the flag is `'preview'` (the grid keeps its exact classes; the compact list isn't emitted at all).

Deliberate v1 cuts:
- No per-row `LocalDate` island — scheduled games show the ET `shortDetail` string; ~100 extra hydrated islands is the page-weight class we just fought. The card (still one tap away on mobile? no — cards are hidden; the game page itself carries full detail).
- No spice border — `calculateSpiceLevel` lives in `GameThumb`'s frontmatter; it moves to `utils/misc` when this promotes.

## Tests
New `scoreboard.render.test.ts`: preview locals render exactly 2 compact rows with correct score/bolding/status and demote the grid to `d-none d-md-flex`; public locals contain no trace of the variant (also guards the empty-slate case — "No games scheduled" stays visible on phones). Fixture ids dodge the MEME_LIST easter egg (61/UGA lowercases on purpose). Full suite: 200 passed.

## Summary by Sourcery

Introduce a preview-only compact mobile scoreboard while retaining the existing desktop and public scoreboard experience.

New Features:
- Add a preview-gated compact mobile scoreboard with tappable banner rows, team identity, scores, live possession, statuses, and kickoff-time grouping.
- Preserve the existing scoreboard card grid for medium and larger screens while leaving public rendering unchanged when preview mode is disabled.

Enhancements:
- Optimize scheduled-game timezone presentation with server-rendered ET fallbacks and a single client-side localization pass.

Tests:
- Add rendering coverage for preview compact rows, grouping, score emphasis, statuses, possession indicators, timezone data, responsive card visibility, and public-variant absence.

## Design options explored (all rendered with Saturday's real 68-game slate @ 390)

Four iterations, in order. **Option E is what this branch implements** (maintainer decision); the others are archival. Switching would be a contained change to `GameCompactRow.astro` + its CSS block.

### Option A — one-line compact rows
One 44px tappable line per game: logos, abbreviation, away–home score (winner bold), short status. Maximum density (~11 games per screen).

![Option A: one-line rows](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optA-oneline.png)

**Pros:** highest scan density; tiny DOM. **Cons:** no team colors/identity; abbreviations only; no kickoff-time grouping.

### Option B — mirrored banner, hoopsjunkie-inspired type
Slanted team-color stripes + logos on the edges, city in spaced small-caps over a big heavy abbreviation, scores center, grouped under ET kickoff headers.

![Option B: mirrored banner, imported type](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optB-mirrored-hj.png)

**Pros:** strong team identity; time grouping. **Cons:** typography is foreign to the site (system font, 800 weights, uppercase tracking); city names truncate ("NORT…", "ALAB…"); ~70px name cells collide at 390 without careful clamping.

### Option C — mirrored banner, site type system
Same structure as B restyled to our conventions: Chivo stack, bootstrap heading weights, plain `text-muted` city line, TeamRow's winner-`<strong>`/loser-`opacity:.5` score treatment, 0.5em radius.

![Option C: mirrored banner, site type](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optC-mirrored-site.png)

**Pros:** looks like Game on Paper. **Cons:** still truncates ("North Tex…", "Oregon S…") — the mirrored layout fundamentally caps each name at ~70px.

### Option D — stacked full-name banner (superseded)
Teams stack inside the card on ~230px lines: full school name (rank inline), score at the line's end, status in its own column; stripes/logos/grouping and the site type system kept from B/C.

![Option D: stacked full names](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optD-stacked.png)

**In-progress states** (simulated from Saturday's real games — Q1, halftime, Q3, and a Q4 two-minute drill; possession dot per TeamRow's convention, red in the red zone; clocks in the status column):

![Option D: live states](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optD-live.png)

**Scheduled / TBD / championship states** (next Saturday's real slate + championship placeholders): kickoffs render server-side in ET and localize client-side; a game with `timeValid: false` shows **TBD**, groups under a **Time TBD** header, and is never touched by the localization script; TBD competitors get ESPN's default shield; the game-note headline renders as a third line with the site's gold championship treatment (conference championships included):

![Option D: scheduled and TBD states](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optD-scheduled-tbd.png)

The **card grid gets the same treatment** (public components — the TBD/time/logo fixes are plain bug fixes; the note line + conference-championship gold is the maintainer-directed visible change):

![Card grid: scheduled and TBD states with championship gold](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-cards-scheduled-tbd.png)

**Pros:** zero truncation ("Coastal Carolina", "New Hampshire" render whole); site-native type; team-color identity; time grouping. **Cons:** slightly lower density than A (~7 games per screen); home team's stripe is on the right while its name is on the second line (stacked lists read left-aligned).

### Option E — mirrored one-liner, no color stripes, abbreviations + ranks ✅ (implemented)
Site type, plain logos, one line per game. Rank sits **ahead of the abbreviation on both sides**; the middle is a fixed grid column (score | status | score) so scores and clocks align dead-center down the list regardless of status text or digit count. The possession dot rides the **logo corner as a badge** (red in the red zone) instead of taking inline width. Type and paddings are viewport-clamped. ~11 games per screen.

![Option E: mirrored, no stripes, rank-first abbr + centered middle](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optE-mirrored-abbr.png)

**Worst-case proof** — both teams ranked (2-digit) with 4-char abbreviations, live clock, and a Final/2OT status, measured for element clipping in headless Chrome: **zero clipping at 390 and at 320**:

| stress @320 | stress @390 |
|---|---|
| ![double-ranked 4-char stress at 320](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optE-stress-320.png) | ![double-ranked 4-char stress at 390](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optE-stress-390.png) |

**Scheduled / TBD / championship states** in Option E — same behaviors, with the note as a centered second line under the one-liner:

![Option E: scheduled and TBD states](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-optE-scheduled-tbd.png)

**Pros:** Option A's density with ranks, live clocks, aligned score columns, and site type. **Cons:** no team-color identity; abbreviation-only naming.

### Unchanged in every option
Public mobile and desktop stay byte-identical while the flag is `'preview'`:

| public mobile (unchanged) | desktop (unchanged) |
|---|---|
| ![public cards @390](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-mobile-public.png) | ![desktop cards](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/pr216-desktop-cards.png) |

(The "PREVIEW" text over one header in screenshots is the fixed preview-mode badge from Footer — present on every previewed page, absent in public.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a preview-only compact mobile scoreboard with team logos, abbreviations, rankings, scores, status, possession indicators, and winner/loser styling.
  * Groups games by date and kickoff time, supports “Time TBD” games, and adjusts displayed times to the viewer’s timezone.
  * Added championship game styling and fallback logos for placeholder teams.
* **Style**
  * Updated scoreboard presentation with a centered grid layout and improved responsive typography.
* **Tests**
  * Added coverage for preview gating, rendering, styling, and timezone behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





