### PR TITLE
fix(preview): shared links land on an uncacheable /preview surface

### DIFF
--- a/astro/src/components/Footer.astro
+++ b/astro/src/components/Footer.astro
@@ -7,6 +7,22 @@ const preview = Astro.locals.preview === true;
 {preview && (
   <div style="position:fixed;left:1rem;bottom:1.25rem;z-index:1030" class="badge text-bg-warning" title="Admin preview mode: unreleased features are visible and nothing you load is cached. Turn off in /admin.">PREVIEW</div>
 )}
+{preview && (
+  <script is:inline>
+    // Keep navigation on the uncacheable /preview surface: a publicly cached
+    // URL serves its cached copy without running the Worker, so the preview
+    // cookie is invisible there. Rewrites internal links at click time (the
+    // capture phase, so it wins before any other handler).
+    document.addEventListener('click', (e) => {
+      if (!location.pathname.startsWith('/preview')) return;
+      const a = e.target && e.target.closest && e.target.closest('a[href^="/"]');
+      if (!a) return;
+      const href = a.getAttribute('href');
+      if (href.startsWith('/preview') || href.startsWith('/admin') || href.startsWith('/api')) return;
+      a.setAttribute('href', '/preview' + href);
+    }, true);
+  </script>
+)}
 <div class="container-fluid">
   <div class="row text-center">
   <footer class="blog-footer">

--- a/astro/src/middleware.ts
+++ b/astro/src/middleware.ts
@@ -5,8 +5,8 @@ import {
 } from './utils/telemetry';
 import { checkBasicAuth } from './resources/admin';
 import {
-  PREVIEW_COOKIE, PREVIEW_LINK_PARAM, previewSetCookie, readCookie,
-  verifyPreviewCookie, verifyPreviewLink,
+  PREVIEW_COOKIE, PREVIEW_LINK_PARAM, PREVIEW_PATH_PREFIX, previewSetCookie,
+  readCookie, verifyPreviewCookie, verifyPreviewLink,
 } from './utils/preview';
 import { ADMIN_COOKIE, verifyAdminCookie } from './utils/adminSession';
 import { legacyCfbTarget, staleRedirectTarget } from './utils/legacyCfb';
@@ -30,15 +30,43 @@ export const onRequest = defineMiddleware(async (context, next) => {
   if (linkToken !== null) {
     const clean = new URL(url);
     clean.searchParams.delete(PREVIEW_LINK_PARAM);
-    const headers = new Headers({
-      Location: clean.pathname + clean.search, 'Cache-Control': 'no-store',
-    });
+    // resolve legacy shapes now: /preview/* rewrites straight to routes, so a
+    // legacy path would 404 inside the preview surface
+    const cleanPath = legacyCfbTarget(clean.pathname) ?? staleRedirectTarget(clean.pathname) ?? clean.pathname;
     const secret = getSecret('ADMIN_PASS');
-    if (secret && await verifyPreviewLink(linkToken, secret)) {
+    const valid = !!secret && await verifyPreviewLink(linkToken, secret);
+    // A valid link lands on the /preview/ surface, NOT the clean URL: the
+    // clean URL is publicly cached, and a Workers Caching HIT never runs this
+    // middleware -- the cookie would be ignored and the viewer would see the
+    // public copy (exactly the reported bug). /preview/* is never cached.
+    const headers = new Headers({
+      Location: (valid ? PREVIEW_PATH_PREFIX : '') + cleanPath + clean.search,
+      'Cache-Control': 'no-store',
+    });
+    if (valid && secret) {
       headers.append('Set-Cookie', await previewSetCookie(secret));
     }
     try { (context as any).cache?.set(false); } catch { /* cache provider absent in dev */ }
     return new Response(null, { status: 302, headers });
+  }
+
+  // The preview surface: /preview/<path> renders <path> with preview features
+  // on, and is NEVER cached (path-based, like /admin -- see the guard below).
+  // Cookie required: without one the viewer is bounced to the public path.
+  // Cookie-based preview on normal URLs still works where the Worker runs
+  // (cache misses, no-store pages); this surface is the one place it is
+  // GUARANTEED to run, which is why the magic link and the badge live here.
+  let previewRewrite: string | undefined;
+  if (url.pathname === PREVIEW_PATH_PREFIX || url.pathname.startsWith(PREVIEW_PATH_PREFIX + '/')) {
+    const rest = url.pathname.slice(PREVIEW_PATH_PREFIX.length) || '/';
+    const target = legacyCfbTarget(rest) ?? staleRedirectTarget(rest) ?? rest;
+    const cookieOk = await verifyPreviewCookie(
+      readCookie(context.request.headers.get('cookie'), PREVIEW_COOKIE), getSecret('ADMIN_PASS'));
+    if (!cookieOk) {
+      return context.redirect(target + url.search, 302);
+    }
+    context.locals.preview = true;
+    previewRewrite = target + url.search;
   }
 
 
@@ -89,7 +117,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const key = getSecret('GOP_INGEST_KEY') ?? '';
   const enabled = (getSecret('TELEMETRY_ENABLED') ?? '1') !== '0' && !!key;
   if (!enabled || url.pathname.startsWith('/api/client-log')) {
-    return withPreviewCacheGuard(context, await next());
+    return withPreviewCacheGuard(context, await next(previewRewrite as any));
   }
 
   const collector = createCollector();
@@ -97,7 +125,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const t0 = Date.now();
   let response: Response;
   try {
-    response = await gopStorage.run(collector, () => next());
+    response = await gopStorage.run(collector, () => next(previewRewrite as any));
   } catch (err) {
     collector.render_outcome = 'failed';
     collector.events.push({ table: 'error_log', row: {
@@ -179,9 +207,11 @@ export function withPreviewCacheGuard(context: any, response: Response): Respons
   // path: the redeem intercepts these before render, but if that ever
   // regresses, this keeps a keyed URL out of Workers Caching entirely.
   const carriesPreviewKey = url.searchParams.has(PREVIEW_LINK_PARAM);
-  if (context.locals?.preview === true || isAdmin || spanVariesByViewer || carriesPreviewKey) {
+  const isPreviewPath = url.pathname === PREVIEW_PATH_PREFIX || url.pathname.startsWith(PREVIEW_PATH_PREFIX + '/');
+  if (context.locals?.preview === true || isAdmin || spanVariesByViewer || carriesPreviewKey || isPreviewPath) {
     try { context.cache?.set(false); } catch { /* cache provider absent in dev */ }
     response.headers.set('Cache-Control', 'no-store');
+    if (isPreviewPath) response.headers.set('X-Robots-Tag', 'noindex');
   }
   return response;
 }

--- a/astro/src/middleware.ts
+++ b/astro/src/middleware.ts
@@ -17,10 +17,11 @@ const GAME_ID_RE = /\/game\/(\d+)/;
 export const onRequest = defineMiddleware(async (context, next) => {
   const url = new URL(context.request.url);
 
-  // Preview magic link: ?preview_key=<signed token> on any URL sets the preview
-  // cookie and redirects to the clean URL. One click on any browser, no admin
-  // login. An invalid/expired token still strips the param and redirects (the
-  // page then renders public, and the missing PREVIEW badge is the signal).
+  // Preview magic link: ?preview_key=<signed token> on any URL sets the
+  // preview cookie and lands on the uncacheable /preview surface (the clean
+  // URL is publicly cached, and a cache HIT never runs this middleware). One
+  // click on any browser, no admin login. An invalid/expired token strips the
+  // param and redirects to the PUBLIC path (no badge is the signal).
   // The redirect carries Set-Cookie, so it must never enter Workers Caching --
   // and this block runs FIRST, before the legacy /cfb redirects, because those
   // return 301s that forward the query string with no cache headers: a keyed
@@ -60,6 +61,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
   if (url.pathname === PREVIEW_PATH_PREFIX || url.pathname.startsWith(PREVIEW_PATH_PREFIX + '/')) {
     const rest = url.pathname.slice(PREVIEW_PATH_PREFIX.length) || '/';
     const target = legacyCfbTarget(rest) ?? staleRedirectTarget(rest) ?? rest;
+    // Never rewrite into /admin: the admin auth gate below checks the ORIGINAL
+    // pathname, so a rewrite would carry a view-only preview cookie past it
+    // (Sourcery on #217). Nested /preview is not a route either; both bounce
+    // out to be handled -- and authenticated -- as themselves.
+    if (target.startsWith('/admin') || target.startsWith(PREVIEW_PATH_PREFIX)) {
+      return context.redirect(target + url.search, 302);
+    }
     const cookieOk = await verifyPreviewCookie(
       readCookie(context.request.headers.get('cookie'), PREVIEW_COOKIE), getSecret('ADMIN_PASS'));
     if (!cookieOk) {

--- a/astro/src/utils/preview.ts
+++ b/astro/src/utils/preview.ts
@@ -14,10 +14,11 @@ export const PREVIEW_COOKIE = 'gop_preview';
 // costs nothing. The /admin button always shows the live state.
 export const PREVIEW_TTL_S = 30 * 24 * 60 * 60;
 
-// Magic link: ?preview_key=<token> on ANY site URL. The middleware verifies it,
-// sets the preview cookie, and redirects to the clean URL -- one click for a
-// colleague on any browser, no admin login. The token is purpose-separated from
-// the cookie (different HMAC message) so one can never be replayed as the other.
+// Magic link: ?preview_key=<token> on ANY site URL. The middleware verifies
+// it, sets the preview cookie, and redirects onto the uncacheable /preview
+// surface -- one click for a colleague on any browser, no admin login. The
+// token is purpose-separated from the cookie (different HMAC message) so one
+// can never be replayed as the other.
 export const PREVIEW_LINK_PARAM = 'preview_key';
 // The uncacheable preview surface: /preview/<path> renders <path> with
 // preview features on. Needed because a Workers Caching HIT on a public URL

--- a/astro/src/utils/preview.ts
+++ b/astro/src/utils/preview.ts
@@ -19,6 +19,10 @@ export const PREVIEW_TTL_S = 30 * 24 * 60 * 60;
 // colleague on any browser, no admin login. The token is purpose-separated from
 // the cookie (different HMAC message) so one can never be replayed as the other.
 export const PREVIEW_LINK_PARAM = 'preview_key';
+// The uncacheable preview surface: /preview/<path> renders <path> with
+// preview features on. Needed because a Workers Caching HIT on a public URL
+// never runs the middleware, so a preview cookie is invisible there.
+export const PREVIEW_PATH_PREFIX = '/preview';
 export const PREVIEW_LINK_TTL_S = 14 * 24 * 60 * 60;
 
 async function hmacHex(secret: string, msg: string): Promise<string> {

--- a/astro/test/previewFlow.test.ts
+++ b/astro/test/previewFlow.test.ts
@@ -57,10 +57,13 @@ describe('the preview magic link', () => {
         return (await (onRequest as any)(ctx, async () => new Response('ok'))) as Response;
     }
 
-    test('a valid link 302s to the clean URL with a working preview cookie, uncacheable', async () => {
+    test('a valid link 302s onto the /preview surface with a working cookie, uncacheable', async () => {
+        // NOT the clean URL: that one is publicly cached, and a Workers
+        // Caching HIT never runs the middleware -- the cookie would be
+        // invisible and the viewer would see the public copy
         const res = await redeem(await mintPreviewLink('test-secret'));
         expect(res.status).toBe(302);
-        expect(res.headers.get('Location')).toBe('/game/401752746?span=q3');
+        expect(res.headers.get('Location')).toBe('/preview/game/401752746?span=q3');
         expect(res.headers.get('Cache-Control')).toBe('no-store');
         const setCookie = res.headers.get('Set-Cookie') ?? '';
         expect(setCookie).toContain(`${PREVIEW_COOKIE}=`);
@@ -79,10 +82,12 @@ describe('the preview magic link', () => {
         expect(await verifyPreviewLink(await mintPreviewCookie('test-secret'), 'test-secret')).toBe(false);
     });
 
-    test('a keyed LEGACY URL is redeemed first, not 301-redirected with the key', async () => {
+    test('a keyed LEGACY URL is redeemed first, resolved onto the preview surface', async () => {
         // the legacy /cfb 301s forward the query string with no cache headers;
         // if they ran before the redeem, a heuristically-cacheable redirect
-        // would carry the key (review on #213). Redeem must win.
+        // would carry the key (review on #213). Redeem must win, and the
+        // legacy path resolves BEFORE prefixing: /preview/* rewrites straight
+        // to routes, so an unresolved legacy path would 404 there.
         const token = await mintPreviewLink('test-secret');
         const ctx: any = {
             request: new Request(`https://gameonpaper.com/cfb/game/401752746?span=q3&${PREVIEW_LINK_PARAM}=${token}`),
@@ -92,10 +97,40 @@ describe('the preview magic link', () => {
         };
         const res = await (onRequest as any)(ctx, async () => new Response('ok'));
         expect(res.status).toBe(302);
-        expect(res.headers.get('Location')).toBe('/cfb/game/401752746?span=q3');
+        expect(res.headers.get('Location')).toBe('/preview/game/401752746?span=q3');
         expect(res.headers.get('Location')).not.toContain(PREVIEW_LINK_PARAM);
         expect(res.headers.get('Cache-Control')).toBe('no-store');
         expect(res.headers.get('Set-Cookie')).toContain(PREVIEW_COOKIE);
+    });
+
+    test('the /preview surface rewrites to the real route with preview on, never cached', async () => {
+        let rewrittenTo: unknown = 'not called';
+        const ctx: any = {
+            request: new Request('https://gameonpaper.com/preview/game/401752746?span=q3', {
+                headers: { cookie: `${PREVIEW_COOKIE}=${await mintPreviewCookie('test-secret')}` },
+            }),
+            locals: {},
+            cache: { set: () => {} },
+            redirect: (l: string) => new Response(null, { status: 302, headers: { Location: l } }),
+        };
+        const res = await (onRequest as any)(ctx, async (rw: unknown) => { rewrittenTo = rw; return new Response('page'); });
+        expect(res.status).toBe(200);
+        expect(rewrittenTo).toBe('/game/401752746?span=q3');
+        expect(ctx.locals.preview).toBe(true);
+        expect(res.headers.get('Cache-Control')).toBe('no-store');
+        expect(res.headers.get('X-Robots-Tag')).toBe('noindex');
+    });
+
+    test('the /preview surface without a valid cookie bounces to the public path', async () => {
+        const ctx: any = {
+            request: new Request('https://gameonpaper.com/preview/game/401752746?span=q3'),
+            locals: {},
+            cache: { set: () => {} },
+            redirect: (l: string) => new Response(null, { status: 302, headers: { Location: l } }),
+        };
+        const res = await (onRequest as any)(ctx, async () => new Response('page'));
+        expect(res.status).toBe(302);
+        expect(res.headers.get('Location')).toBe('/game/401752746?span=q3');
     });
 
     test('the cache guard forces no-store on any response for a keyed URL', async () => {

--- a/astro/test/previewFlow.test.ts
+++ b/astro/test/previewFlow.test.ts
@@ -121,6 +121,23 @@ describe('the preview magic link', () => {
         expect(res.headers.get('X-Robots-Tag')).toBe('noindex');
     });
 
+    test('the /preview surface never rewrites into /admin, even with a valid cookie', async () => {
+        // the admin auth gate checks the ORIGINAL pathname; a rewrite would
+        // carry a view-only preview cookie past it (Sourcery on #217)
+        const ctx: any = {
+            request: new Request('https://gameonpaper.com/preview/admin/api/purge-game', {
+                headers: { cookie: `${PREVIEW_COOKIE}=${await mintPreviewCookie('test-secret')}` },
+            }),
+            locals: {},
+            cache: { set: () => {} },
+            redirect: (l: string) => new Response(null, { status: 302, headers: { Location: l } }),
+        };
+        const res = await (onRequest as any)(ctx, async () => new Response('SECRET'));
+        expect(res.status).toBe(302);
+        expect(res.headers.get('Location')).toBe('/admin/api/purge-game');
+        expect(ctx.locals.preview).toBeUndefined();
+    });
+
     test('the /preview surface without a valid cookie bounces to the public path', async () => {
         const ctx: any = {
             request: new Request('https://gameonpaper.com/preview/game/401752746?span=q3'),


### PR DESCRIPTION
## The bug (reported live)
A colleague opening a shared preview link in a fresh/incognito browser gets the **public** page. Reproduced with headless Chrome and header capture:

```
302 /game/<id>?preview_key=…   ← redeem: Set-Cookie ✓, no-store ✓
200 /game/<id>                 ← req cookie: gop_preview=… ✓
                                 cf-cache-status: HIT, age: 49   ← cached PUBLIC copy
```

The redeem works perfectly — but the clean URL it lands on is publicly cached, and a **Workers Caching HIT never runs the Worker**, so the cookie is never evaluated. (curl testing earlier looked fine only because the post-deploy cache was empty.) The same hole has been silently degrading the **admin's own preview toggle** on any publicly-cached page — it only ever worked on cache misses.

## The fix: a path-scoped preview surface
Same pattern as `/admin` — preview moves to URLs that are never cached, instead of fighting the cache on public URLs:

- **`/preview/<path>`** rewrites internally to `<path>` with `locals.preview` forced. A valid preview cookie is still required — without one the viewer bounces to the public path. Hard `no-store` by path + `X-Robots-Tag: noindex`. The rewrite flows through the telemetry chain, so preview views still log.
- **Magic-link redeem** now 302s onto `/preview/<clean path>` (legacy `/cfb` shapes resolved first, since the surface rewrites straight to routes and an unresolved legacy path would 404 there).
- **Navigation stays on the surface**: a capture-phase click handler rendered beside the PREVIEW badge prefixes internal links with `/preview` while browsing there.
- Cookie-based preview on normal URLs is unchanged wherever the Worker actually runs (cache misses, no-store pages); the surface is the one place it's *guaranteed* to run.

## Tests
11 preview-flow tests: redeem lands on `/preview/…`; legacy keyed URLs resolve-then-prefix; the surface rewrites (asserted via the `next()` payload) with preview on, no-store, and noindex; a cookieless visit to the surface bounces to the public path. Full suite: 214 passing.

Known follow-up (separate, pre-existing): the /admin Preview **toggle** still browses normal URLs, so it keeps its cache-miss-only behavior; pointing the admin at `/preview/` links from the panel is a small next step if wanted.

## Summary by Sourcery

Route shared and navigated previews through a dedicated uncacheable surface so preview content is consistently shown instead of publicly cached pages.

New Features:
- Add an uncacheable `/preview/<path>` surface that renders routes with preview features enabled and preserves preview navigation.

Bug Fixes:
- Prevent shared preview links and cookie-based previews from displaying publicly cached pages by redirecting valid redemptions to the preview surface.
- Resolve legacy preview URLs before redirecting and ensure preview paths cannot bypass admin authentication.

Enhancements:
- Require a valid preview cookie on the preview surface, redirecting unauthenticated visitors to the public path.
- Mark preview responses as `no-store` and `noindex` while retaining telemetry coverage.

Tests:
- Expand preview-flow coverage for surface redirects, route rewrites, cache behavior, legacy URL handling, admin protection, and cookieless access.