### PR TITLE
feat(admin): ops-framework tail — watchlist, guard inspector, audit log, 403 strip

### DIFF
--- a/astro/src/env.d.ts
+++ b/astro/src/env.d.ts
@@ -14,6 +14,8 @@ declare namespace App {
     interface Locals {
         preview?: boolean;
         adminAuthed?: boolean;
+        /** vetted audit identity: basic-auth username or "admin-cookie" */
+        adminActor?: string;
     }
   interface SessionData {
     favorites?: {

--- a/astro/src/middleware.ts
+++ b/astro/src/middleware.ts
@@ -119,7 +119,16 @@ export const onRequest = defineMiddleware(async (context, next) => {
       }
       return context.redirect('/admin/login', 302);
     }
-    if (cookieOk || basicOk) context.locals.adminAuthed = true;
+    if (cookieOk || basicOk) {
+      context.locals.adminAuthed = true;
+      // vetted here, where auth is actually verified: the audit log must not
+      // trust a raw Authorization header a cookie-authed caller could forge
+      let actor = 'admin-cookie';
+      if (basicOk) {
+        try { actor = atob((context.request.headers.get('authorization') ?? '').slice(6)).split(':')[0] || 'basic'; } catch { actor = 'basic'; }
+      }
+      context.locals.adminActor = actor;
+    }
   }
 
   const key = getSecret('GOP_INGEST_KEY') ?? '';

--- a/astro/src/pages/admin/api/[name].ts
+++ b/astro/src/pages/admin/api/[name].ts
@@ -3,7 +3,7 @@ import { getSecret } from 'astro:env/server';
 
 export const prerender = false;
 
-const ALLOWED = ['overview', 'games', 'upstream', 'errors', 'traffic', 'system', 'page', 'dq'];
+const ALLOWED = ['overview', 'games', 'upstream', 'errors', 'traffic', 'system', 'page', 'dq', 'audit'];
 
 export const GET: APIRoute = async ({ params, url }) => {
   const name = params.name ?? '';

--- a/astro/src/pages/admin/api/guards.ts
+++ b/astro/src/pages/admin/api/guards.ts
@@ -12,8 +12,17 @@ export const prerender = false;
 export const GET: APIRoute = async () => {
     const marks: Record<string, unknown>[] = [];
     try {
-        const listing = await env.ESPN_API_CACHE.list({ prefix: 'gamestate:', limit: 200 });
-        for (const k of listing.keys) {
+        // follow the cursor: KV pages at 1000 keys, and past-game marks live a
+        // full day, so a Saturday can exceed one page. Hard cap keeps the
+        // endpoint bounded either way.
+        const keys: { name: string }[] = [];
+        let cursor: string | undefined;
+        do {
+            const page: any = await env.ESPN_API_CACHE.list({ prefix: 'gamestate:', cursor });
+            keys.push(...page.keys);
+            cursor = page.list_complete ? undefined : page.cursor;
+        } while (cursor && keys.length < 2000);
+        for (const k of keys) {
             const gameId = k.name.slice('gamestate:'.length);
             try {
                 const state = await env.ESPN_API_CACHE.get(k.name, 'json') as Record<string, unknown> | null;

--- a/astro/src/pages/admin/api/guards.ts
+++ b/astro/src/pages/admin/api/guards.ts
@@ -1,0 +1,30 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+
+export const prerender = false;
+
+// Regression-guard inspector: the per-game high-water marks the game-state
+// guard keeps in Workers KV (resources/espn.ts, gamestate:<id>). A stale or
+// inflated mark makes every honest ESPN payload look like a regression, which
+// renders that page uncached on every request -- this makes those marks
+// visible, next to what they recorded. Reset = the existing purge-game?ids=
+// (which deletes the mark alongside the page). Behind /admin via middleware.
+export const GET: APIRoute = async () => {
+    const marks: Record<string, unknown>[] = [];
+    try {
+        const listing = await env.ESPN_API_CACHE.list({ prefix: 'gamestate:', limit: 200 });
+        for (const k of listing.keys) {
+            const gameId = k.name.slice('gamestate:'.length);
+            try {
+                const state = await env.ESPN_API_CACHE.get(k.name, 'json') as Record<string, unknown> | null;
+                marks.push({ game_id: gameId, ...(state ?? {}) });
+            } catch {
+                marks.push({ game_id: gameId, error: 'unreadable' });
+            }
+        }
+    } catch (e: any) {
+        return Response.json({ ok: false, error: String(e?.message ?? e) },
+            { status: 500, headers: { 'Cache-Control': 'no-store' } });
+    }
+    return Response.json({ ok: true, marks }, { headers: { 'Cache-Control': 'no-store' } });
+};

--- a/astro/src/pages/admin/api/preview-link.ts
+++ b/astro/src/pages/admin/api/preview-link.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSecret } from 'astro:env/server';
 import { PREVIEW_LINK_PARAM, PREVIEW_LINK_TTL_S, mintPreviewLink } from '../../../utils/preview';
+import { auditAdmin } from '../../../utils/telemetry';
 
 export const prerender = false;
 
@@ -23,6 +24,7 @@ export const POST: APIRoute = async ({ request }) => {
         return Response.json({ ok: false, error: 'path must be a same-site path starting with a single "/"' }, { status: 400 });
     }
     const origin = new URL(request.url).origin;
+    auditAdmin(request, 'preview-link', path, true);
     const token = await mintPreviewLink(secret);
     const target = new URL(path, origin);
     if (target.origin !== origin) {

--- a/astro/src/pages/admin/api/preview-link.ts
+++ b/astro/src/pages/admin/api/preview-link.ts
@@ -9,7 +9,7 @@ export const prerender = false;
 // auth via the middleware. POST {"path": "/game/401..."} (default "/") returns
 // a URL that, opened in any browser, sets the preview cookie via the
 // middleware redeem and redirects to the clean path.
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
     const secret = getSecret('ADMIN_PASS');
     if (!secret) return Response.json({ ok: false, error: 'ADMIN_PASS not set' }, { status: 500 });
     let path = '/';
@@ -24,12 +24,14 @@ export const POST: APIRoute = async ({ request }) => {
         return Response.json({ ok: false, error: 'path must be a same-site path starting with a single "/"' }, { status: 400 });
     }
     const origin = new URL(request.url).origin;
-    auditAdmin(request, 'preview-link', path, true);
     const token = await mintPreviewLink(secret);
     const target = new URL(path, origin);
     if (target.origin !== origin) {
+        auditAdmin(locals, 'preview-link', `${path} (rejected: off-site)`, false);
         return Response.json({ ok: false, error: 'path resolved off-site' }, { status: 400 });
     }
+    // audited only once the mint and the origin check have both succeeded
+    auditAdmin(locals, 'preview-link', path, true);
     target.searchParams.set(PREVIEW_LINK_PARAM, token);
     return Response.json({
         ok: true,

--- a/astro/src/pages/admin/api/preview.ts
+++ b/astro/src/pages/admin/api/preview.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { getSecret } from 'astro:env/server';
 import { PREVIEW_COOKIE, previewSetCookie, readCookie, verifyPreviewCookie } from '../../../utils/preview';
+import { auditAdmin } from '../../../utils/telemetry';
 
 export const prerender = false;
 
@@ -24,6 +25,7 @@ export const POST: APIRoute = async ({ request }) => {
     const cookie = on
         ? await previewSetCookie(secret)
         : `${PREVIEW_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
+    auditAdmin(request, 'preview-toggle', on ? 'on' : 'off', true);
     return Response.json({ ok: true, enabled: on }, {
         headers: { 'Set-Cookie': cookie, 'Cache-Control': 'no-store' },
     });

--- a/astro/src/pages/admin/api/preview.ts
+++ b/astro/src/pages/admin/api/preview.ts
@@ -14,7 +14,7 @@ export const GET: APIRoute = async ({ request }) => {
     return Response.json({ enabled }, { headers: { 'Cache-Control': 'no-store' } });
 };
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }) => {
     const secret = getSecret('ADMIN_PASS');
     if (!secret) return Response.json({ ok: false, error: 'ADMIN_PASS not set' }, { status: 500 });
     let on: unknown;
@@ -25,7 +25,7 @@ export const POST: APIRoute = async ({ request }) => {
     const cookie = on
         ? await previewSetCookie(secret)
         : `${PREVIEW_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
-    auditAdmin(request, 'preview-toggle', on ? 'on' : 'off', true);
+    auditAdmin(locals, 'preview-toggle', on ? 'on' : 'off', true);
     return Response.json({ ok: true, enabled: on }, {
         headers: { 'Set-Cookie': cookie, 'Cache-Control': 'no-store' },
     });

--- a/astro/src/pages/admin/api/purge-game.ts
+++ b/astro/src/pages/admin/api/purge-game.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
+import { auditAdmin } from '../../../utils/telemetry';
 
 export const prerender = false;
 
@@ -59,6 +60,9 @@ async function purge(context: Parameters<APIRoute>[0]): Promise<Response> {
         }
     }
     context.cache.set(false);
-    return Response.json({ ok: Object.values(results).every((v) => v === 'purged'), results },
+    const allOk = Object.values(results).every((v) => v === 'purged');
+    auditAdmin(context.request, 'purge-game',
+        `ids=[${ids.join(',')}] tags=[${tags.join(',')}]`, allOk);
+    return Response.json({ ok: allOk, results },
         { headers: { 'Cache-Control': 'no-store' } });
 }

--- a/astro/src/pages/admin/api/purge-game.ts
+++ b/astro/src/pages/admin/api/purge-game.ts
@@ -61,7 +61,7 @@ async function purge(context: Parameters<APIRoute>[0]): Promise<Response> {
     }
     context.cache.set(false);
     const allOk = Object.values(results).every((v) => v === 'purged');
-    auditAdmin(context.request, 'purge-game',
+    auditAdmin(context.locals, 'purge-game',
         `ids=[${ids.join(',')}] tags=[${tags.join(',')}]`, allOk);
     return Response.json({ ok: allOk, results },
         { headers: { 'Cache-Control': 'no-store' } });

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -56,8 +56,14 @@ const subtitle = "Operational dashboards for Game on Paper";
       <div class="card"><h6 class="admin-label mt-0">Status mix · 1h</h6><div class="bars" id="statusbars"></div><div class="legend" id="statuslegend"></div><div id="ov-services"></div></div>
     </div>
     <div class="card mt-2"><h6 class="admin-label mt-0">Latency percentiles (ms)</h6><canvas id="c-pct" height="150"></canvas></div>
+    <h6 class="admin-label">Recent admin actions</h6>
+    <div class="card twrap"><table class="table table-sm mb-0" id="t-audit"></table></div>
   </section>
   <section id="games">
+    <h6 class="admin-label">Live now · watchlist</h6>
+    <div class="card twrap"><table class="table table-sm mb-0" id="t-watchlist"></table></div>
+    <h6 class="admin-label">Regression-guard marks (KV high-water; a stale mark renders that page uncached on every request)</h6>
+    <div class="card twrap"><table class="table table-sm mb-0" id="t-guards"></table></div>
     <h6 class="admin-label">Games with activity · last 30 min (click a row for page detail)</h6>
     <div class="card twrap"><table class="table table-sm mb-0" id="t-games"></table></div>
     <div id="page-detail"></div>
@@ -301,7 +307,38 @@ const subtitle = "Operational dashboards for Game on Paper";
   }
 
   async function refreshGames() {
-    const d = await api('games');
+    const [d, guards] = await Promise.all([
+      api('games'),
+      fetch('/admin/api/guards').then((r) => r.json()).catch(() => ({ marks: [] })),
+    ]);
+    const markBy = Object.fromEntries((guards.marks ?? []).map((m) => [String(m.game_id), m]));
+    table('t-watchlist', ['Game', 'Score', 'Status', 'Req 30m', 'Render', 'Cache intent', 'ESPN fetch', 'DQ lints', 'Guard'],
+      (d.watchlist ?? []).map((w) => {
+        const m = markBy[String(w.game_id)];
+        return { cells: [
+          `<a href="/game/${esc(w.game_id)}" target="_blank">${esc(w.matchup ?? w.game_id)}</a>`,
+          `${fmt(w.away_score)}–${fmt(w.home_score)}`, esc(w.status ?? '—'),
+          w.req_30m ?? 0, esc(w.render_outcome ?? 'ok'),
+          esc((w.cache_status ?? '—').slice(0, 24)),
+          w.espn_status == null ? '—' : `<span class="mono">${esc(w.espn_status)} · ${fmt(w.espn_ms)} ms</span>`,
+          w.lints_flagged || '0',
+          m ? `<span class="mono">Q${m.period ?? '?'} · ${m.plays ?? '?'} plays</span>` : '—'] };
+      }));
+    table('t-guards', ['Game', 'Period', 'Plays', 'Scores', 'Done', ''],
+      (guards.marks ?? []).map((m) => ({ cells: [
+        `<a href="/game/${esc(m.game_id)}" target="_blank"><span class="mono">${esc(m.game_id)}</span></a>`,
+        m.period ?? '—', m.plays ?? '—', esc((m.scores ?? []).join('–') || '—'),
+        m.completed ? 'yes' : 'no',
+        `<button class="btn btn-sm btn-outline-danger" data-guard-reset="${esc(m.game_id)}" title="Purge this page + delete its high-water mark">Reset</button>`] })));
+    document.querySelectorAll('#t-guards [data-guard-reset]').forEach((b) =>
+      b.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        b.disabled = true;
+        try {
+          await fetch(`/admin/api/purge-game?ids=${b.dataset.guardReset}`, { method: 'POST' });
+          b.textContent = 'Reset ✓';
+        } catch { b.textContent = 'Failed'; b.disabled = false; }
+      }));
     const fetchBy = Object.fromEntries(d.lastFetch.map((f) => [f.game_id, f]));
     table('t-games', ['Game ID', 'Req 30m', 'p95 ms', 'Cache hit', 'Degraded', 'Failed', 'Last ESPN fetch'],
       d.gamesAgg.map((g) => ({ attr: ` data-game="${esc(g.game_id)}"`, cells: [
@@ -333,13 +370,21 @@ const subtitle = "Operational dashboards for Game on Paper";
       { n: 'failed', v: oc.failed, c: STATUS.crit }]);
   }
 
+  async function refreshAudit() {
+    const d = await api('audit');
+    table('t-audit', ['When', 'Actor', 'Action', 'Detail', 'OK'],
+      (d.recent ?? []).map((a) => ({ cells: [`<span class="mono">${hhmm(a.ts)}</span>`,
+        esc(a.actor ?? '—'), esc(a.action), esc(a.detail ?? ''), a.ok === false ? '✗' : '✓'] })));
+  }
+
   async function refreshUpstream() {
     const d = await api('upstream');
     table('t-targets', ['Target', 'p50 ms', 'p95 ms', 'Success 24h', 'Calls'],
       d.targets.map((t) => ({ cells: [`<span class="mono">${esc(t.target)}</span>`, fmt(t.p50), fmt(t.p95), t.success == null ? '—' : fmt(100 * t.success, 2) + '%', t.total] })));
     line('c-fail', d.failures.map((f) => hhmm(f.h)), [
       { label: '5xx', data: d.failures.map((f) => f.s5xx), borderColor: S[1] },
-      { label: 'timeout', data: d.failures.map((f) => f.timeouts), borderColor: S[3] }]);
+      { label: 'timeout', data: d.failures.map((f) => f.timeouts), borderColor: S[3] },
+      { label: '403/429 blocked', data: d.failures.map((f) => f.blocked ?? 0), borderColor: S[2] }]);
     table('t-slowest', ['When', 'Target', 'Game', 'ms', 'Status'],
       d.slowest.map((s) => ({ cells: [`<span class="mono">${hhmm(s.ts)}</span>`, `<span class="mono">${esc(s.target)}</span>`,
         s.game_id ? `<a href="/game/${esc(s.game_id)}" target="_blank">${esc(s.matchup ?? s.game_id)}</a>` : '—',
@@ -461,7 +506,7 @@ const subtitle = "Operational dashboards for Game on Paper";
   }
   document.getElementById('st-probe').addEventListener('click', () => probeStaleness().catch((e) => console.error(e)));
 
-  const refreshers = { overview: refreshOverview, games: refreshGames, upstream: refreshUpstream, errors: refreshErrors, dq: refreshDq, traffic: refreshTraffic, system: refreshSystem, staleness: refreshStaleness };
+  const refreshers = { overview: () => Promise.all([refreshOverview(), refreshAudit()]), games: refreshGames, upstream: refreshUpstream, errors: refreshErrors, dq: refreshDq, traffic: refreshTraffic, system: refreshSystem, staleness: refreshStaleness };
   let active = 'overview';
   document.getElementById('tabs').addEventListener('click', (e) => {
     const b = e.target.closest('button');

--- a/astro/src/pages/admin/index.astro
+++ b/astro/src/pages/admin/index.astro
@@ -335,7 +335,9 @@ const subtitle = "Operational dashboards for Game on Paper";
         e.stopPropagation();
         b.disabled = true;
         try {
-          await fetch(`/admin/api/purge-game?ids=${b.dataset.guardReset}`, { method: 'POST' });
+          const r = await fetch(`/admin/api/purge-game?ids=${b.dataset.guardReset}`, { method: 'POST' });
+          const j = await r.json().catch(() => ({}));
+          if (!r.ok || j.ok !== true) throw new Error(j.error ?? r.status);
           b.textContent = 'Reset ✓';
         } catch { b.textContent = 'Failed'; b.disabled = false; }
       }));

--- a/astro/src/utils/telemetry.ts
+++ b/astro/src/utils/telemetry.ts
@@ -56,6 +56,23 @@ export async function sendToIngest(events: GopEvent[], cfg: IngestConfig): Promi
   }
 }
 
+// Audit trail for privileged admin POSTs (purge, preview toggle, link mint).
+// Rides the request's collector, so it ships with the middleware's normal
+// ingest batch; a request outside the collector (dev) is silently dropped,
+// matching the rest of telemetry's fail-open posture.
+export function auditAdmin(request: Request, action: string, detail: string, ok: boolean): void {
+    const c = gopStorage.getStore();
+    if (!c) return;
+    const auth = request.headers.get('authorization') ?? '';
+    let actor = 'admin-cookie';
+    if (auth.startsWith('Basic ')) {
+        try { actor = atob(auth.slice(6)).split(':')[0] || 'basic'; } catch { actor = 'basic'; }
+    }
+    c.events.push({ table: 'admin_audit', row: {
+        actor, action, detail: detail.slice(0, 500), ok,
+    } });
+}
+
 export type TimedFetchExtra = { game_id?: string | null; pythonBase?: string; summaryBase?: string };
 
 export async function wrappedFetch(url: string, init?: RequestInit): Promise<Response> {

--- a/astro/src/utils/telemetry.ts
+++ b/astro/src/utils/telemetry.ts
@@ -6,7 +6,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
 export type GopEvent = {
-  table: 'request_log' | 'upstream_log' | 'error_log' | 'client_event';
+  table: 'request_log' | 'upstream_log' | 'error_log' | 'client_event' | 'admin_audit';
   row: Record<string, unknown>;
 };
 
@@ -60,16 +60,13 @@ export async function sendToIngest(events: GopEvent[], cfg: IngestConfig): Promi
 // Rides the request's collector, so it ships with the middleware's normal
 // ingest batch; a request outside the collector (dev) is silently dropped,
 // matching the rest of telemetry's fail-open posture.
-export function auditAdmin(request: Request, action: string, detail: string, ok: boolean): void {
+export function auditAdmin(locals: { adminActor?: string }, action: string, detail: string, ok: boolean): void {
     const c = gopStorage.getStore();
     if (!c) return;
-    const auth = request.headers.get('authorization') ?? '';
-    let actor = 'admin-cookie';
-    if (auth.startsWith('Basic ')) {
-        try { actor = atob(auth.slice(6)).split(':')[0] || 'basic'; } catch { actor = 'basic'; }
-    }
+    // the actor is vetted by the middleware at auth time -- never parsed from
+    // a raw header here, which a cookie-authed caller could forge
     c.events.push({ table: 'admin_audit', row: {
-        actor, action, detail: detail.slice(0, 500), ok,
+        actor: locals.adminActor ?? 'admin-cookie', action, detail: detail.slice(0, 500), ok,
     } });
 }
 

--- a/python/gop_routes.py
+++ b/python/gop_routes.py
@@ -109,6 +109,40 @@ def _overview(args):
 
 def _games(args):
     return {
+        # one row per live game: matchup, last render outcome, cache intent,
+        # ESPN fetch health, and DQ lints flagged today -- the "is tonight
+        # healthy" screen. Guard marks are merged in by the panel from the
+        # astro-side /admin/api/guards (they live in Workers KV).
+        "watchlist": _q("""SELECT gm.game_id,
+                gm.away_abbr || ' @ ' || gm.home_abbr AS matchup,
+                gm.away_score, gm.home_score, gm.status, gm.last_seen,
+                r.req_30m, r.last_req, r.render_outcome, r.cache_status,
+                f.espn_status, f.espn_ms,
+                coalesce(l.lints_flagged, 0) AS lints_flagged
+            FROM gop.game_meta gm
+            LEFT JOIN LATERAL (
+                SELECT count(*)::int AS req_30m, max(ts) AS last_req,
+                    (array_agg(render_outcome ORDER BY ts DESC))[1] AS render_outcome,
+                    (array_agg(cache_status ORDER BY ts DESC))[1] AS cache_status
+                FROM gop.request_log
+                WHERE game_id = gm.game_id::text AND ts > now() - interval '30 minutes'
+            ) r ON true
+            LEFT JOIN LATERAL (
+                SELECT status AS espn_status, duration_ms AS espn_ms
+                FROM gop.upstream_log
+                WHERE game_id = gm.game_id::text AND target = 'espn_pbp'
+                ORDER BY ts DESC LIMIT 1
+            ) f ON true
+            LEFT JOIN LATERAL (
+                SELECT count(*) FILTER (WHERE delta > 0)::int AS lints_flagged
+                FROM gop.dq_boxscore
+                WHERE game_id = gm.game_id AND stat LIKE 'lint:%%'
+                    AND ts > now() - interval '12 hours'
+            ) l ON true
+            WHERE gm.status IN ('STATUS_IN_PROGRESS', 'STATUS_HALFTIME',
+                'STATUS_END_PERIOD', 'STATUS_DELAYED')
+                AND gm.last_seen > now() - interval '6 hours'
+            ORDER BY r.req_30m DESC NULLS LAST LIMIT 40"""),
         "gamesAgg": _q("""SELECT game_id, count(*)::int AS req_30m,
                 percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms) AS p95_ms,
                 max(ts) AS last_req,
@@ -136,7 +170,10 @@ def _upstream(args):
             GROUP BY target ORDER BY target"""),
         "failures": _q("""SELECT date_trunc('hour', ts) AS h,
                 count(*) FILTER (WHERE status >= 500)::int AS s5xx,
-                count(*) FILTER (WHERE status IS NULL AND ok = false)::int AS timeouts
+                count(*) FILTER (WHERE status IS NULL AND ok = false)::int AS timeouts,
+                -- the Akamai denial signature: 403/429 episodes stand out as
+                -- version-aligned cliffs the way parser regressions do on DQ
+                count(*) FILTER (WHERE status IN (403, 429))::int AS blocked
             FROM gop.upstream_log WHERE ts > now() - interval '24 hours' GROUP BY 1 ORDER BY 1"""),
         "slowest": _q("""SELECT u.ts, u.target, u.game_id, u.duration_ms, u.status,
                 gm.away_abbr || ' @ ' || gm.home_abbr AS matchup FROM gop.upstream_log u LEFT JOIN gop.game_meta gm ON gm.game_id::text = u.game_id
@@ -237,6 +274,13 @@ def _dq(args):
     }
 
 
+def _audit(args):
+    return {
+        "recent": _q("""SELECT ts, actor, action, detail, ok
+            FROM gop.admin_audit ORDER BY ts DESC LIMIT 100"""),
+    }
+
+
 def _traffic(args):
     return {
         "routes": _q("""SELECT route_pattern, count(*)::int AS n,
@@ -307,6 +351,7 @@ _ADMIN = {
     "upstream": _upstream,
     "errors": _errors,
     "dq": _dq,
+    "audit": _audit,
     "traffic": _traffic,
     "system": _system,
     "page": _page,

--- a/python/sql/2026-09-07_admin_audit.sql
+++ b/python/sql/2026-09-07_admin_audit.sql
@@ -1,0 +1,17 @@
+-- Admin action audit log: every privileged POST (purge, preview toggle,
+-- preview-link mint) with who/what/when/result. Rendered on /admin.
+-- Apply as the postgres superuser:  sudo -u sdv psql -d sportsdataverse -f <this file>
+
+CREATE TABLE IF NOT EXISTS gop.admin_audit (
+    id      bigserial PRIMARY KEY,
+    ts      timestamptz NOT NULL DEFAULT now(),
+    actor   text,           -- basic-auth username, or 'admin-cookie'
+    action  text NOT NULL,  -- purge-game | preview-toggle | preview-link
+    detail  text,           -- ids/tags purged, minted path, on/off
+    ok      boolean
+);
+CREATE INDEX IF NOT EXISTS admin_audit_ts_idx ON gop.admin_audit (ts DESC);
+
+GRANT INSERT ON gop.admin_audit TO gop_writer;
+GRANT USAGE ON SEQUENCE gop.admin_audit_id_seq TO gop_writer;
+GRANT SELECT ON gop.admin_audit TO gop_reader;

--- a/python/telemetry.py
+++ b/python/telemetry.py
@@ -54,6 +54,13 @@ _TABLES = {
         "kickoff_ts",
         "last_seen",
     ],
+    "admin_audit": [
+        "ts",
+        "actor",
+        "action",
+        "detail",
+        "ok",
+    ],
     "dq_boxscore": [
         "ts",
         "game_id",

--- a/python/tests/test_gop_routes.py
+++ b/python/tests/test_gop_routes.py
@@ -60,6 +60,20 @@ def test_ingest_accepts_valid_and_skips_unknown_tables(client):
     assert [t for t, _ in client.tel.pushed] == ["request_log", "client_event"]
 
 
+def test_ingest_accepts_admin_audit_rows(client):
+    resp = client.post(
+        "/gop/ingest",
+        headers={"X-GOP-Key": "k"},
+        json={"events": [
+            {"table": "admin_audit", "row": {
+                "actor": "saiem", "action": "purge-game",
+                "detail": "ids=[401856766] tags=[]", "ok": True}},
+        ]},
+    )
+    assert resp.status_code == 202
+    assert resp.get_json()["accepted"] == 1
+
+
 def test_ingest_strips_client_supplied_ts(client):
     client.post(
         "/gop/ingest",


### PR DESCRIPTION
The four remaining items from the ranked admin proposal (`notes/2026-09-02-gop-admin-dq-proposal.md` §3), now that the PR train is clear.

## Live-game watchlist (Live games tab)
One row per in-progress game (from `game_meta`, 6h window): matchup-named and linked, score, last render outcome, cache intent, latest ESPN pbp fetch status/latency, DQ lints flagged in the last 12h, and the regression-guard mark merged in client-side. The "is tonight healthy" screen for Saturdays.

## Regression-guard inspector
`GET /admin/api/guards` lists the `gamestate:<id>` high-water marks straight from Workers KV (period · plays · scores · completed). A stale/inflated mark makes every honest ESPN payload "regress", which renders that page **uncached on every request** — now visible instead of inferred. Each row's **Reset** button rides the existing `purge-game?ids=` path, which already deletes the mark alongside the cached page.

## Admin action audit log
`gop.admin_audit` (migration in `python/sql/`, **applied live**, grants for `gop_writer`/`gop_reader`). Written through the normal telemetry ingest — `auditAdmin()` rides the request's collector batch, fail-open like the rest of telemetry — by `purge-game`, the preview toggle, and preview-link mints. Actor = basic-auth username or `admin-cookie`. Rendered as "Recent admin actions" on the Overview tab.

## Upstream 403 strip
The failures-per-hour chart gains a **403/429 blocked** series — the Akamai denial signature that motivated the ESPN relay, now visible as the version-aligned cliff it is instead of buried in per-target success rates.

Deferred from the proposal's list, per its own advice: role split (until someone beyond the two of you gets access) and the client-error rollup (until volume warrants).

## Tests
Ingest accepts `admin_audit` rows (and still skips unknown tables); python 29 passing, astro 209 passing. The watchlist/audit queries follow `_q`'s fail-open contract — an empty DB yields empty tables, never a broken tab.

## Summary by Sourcery

Expand the admin operations dashboard with live-game monitoring, regression-guard visibility, privileged-action auditing, and upstream blocking metrics.

New Features:
- Add a live-game watchlist showing game health, rendering, upstream fetch, data-quality, and regression-guard status.
- Add an admin regression-guard inspector with visibility into Workers KV high-water marks and reset actions.
- Add a recent admin action audit log covering game purges, preview toggles, and preview-link creation.
- Expose upstream 403/429 blocked responses as a distinct failures-per-hour metric.

Enhancements:
- Preserve verified admin identity for audit records and keep new admin data views fail-open when database queries are unavailable.

Deployment:
- Add the live admin-audit database schema, indexes, and reader/writer grants.

Tests:
- Verify telemetry ingestion accepts admin-audit records while continuing to skip unknown tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Admin Overview dashboard showing recent administrative activity, live-game watchlists, regression-guard marks, and per-game reset controls.
  - Added detailed live-game health information, including render/cache status, play-by-play health, and data-quality counts.
  - Added upstream failure reporting for blocked requests.
  - Added administrative audit logging for game purges, preview changes, and preview-link creation.
  - Added an admin endpoint for viewing regression-guard data and audit history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->