### PR TITLE
feat(api): ?spans=all window boxes; fix the silently-broken span box source

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -319,6 +319,19 @@ def process(game_id: int):
         # processed_game, and everything after `return` is dead code -- which is
         # exactly where the DQ emit sat unnoticed until CodeRabbit flagged the
         # ordering (gop.dq_boxscore had zero rows since #192 merged).
+        # ?spans=all: every standard window's box in one response
+        # (advBoxScoreSpans), independent of the singular ?span= swap --
+        # the data layer for in-place span switching on the game page.
+        if request.args.get("spans") == "all":
+            try:
+                boxes = span_box.all_span_boxes(game)
+                if boxes:
+                    processed_game["advBoxScoreSpans"] = boxes
+            except Exception as e:  # a bad window must never cost the page
+                logging.getLogger("root").warning(
+                    f"all-span boxes failed for {game_id}: {e}"
+                )
+
         raw_span = request.args.get("span")
         if raw_span:
             try:

--- a/python/app.py
+++ b/python/app.py
@@ -319,18 +319,17 @@ def process(game_id: int):
         # processed_game, and everything after `return` is dead code -- which is
         # exactly where the DQ emit sat unnoticed until CodeRabbit flagged the
         # ordering (gop.dq_boxscore had zero rows since #192 merged).
-        # ?spans=all: every standard window's box in one response
-        # (advBoxScoreSpans), independent of the singular ?span= swap --
-        # the data layer for in-place span switching on the game page.
-        if request.args.get("spans") == "all":
-            try:
-                boxes = span_box.all_span_boxes(game)
-                if boxes:
-                    processed_game["advBoxScoreSpans"] = boxes
-            except Exception as e:  # a bad window must never cost the page
-                logging.getLogger("root").warning(
-                    f"all-span boxes failed for {game_id}: {e}"
-                )
+        # Every standard window's box ships on every response
+        # (advBoxScoreSpans), so the frontend switches spans in place without
+        # a reload. The singular ?span= swap below stays for deep links.
+        try:
+            boxes = span_box.all_span_boxes(game)
+            if boxes:
+                processed_game["advBoxScoreSpans"] = boxes
+        except Exception as e:  # a bad window must never cost the page
+            logging.getLogger("root").warning(
+                f"all-span boxes failed for {game_id}: {e}"
+            )
 
         raw_span = request.args.get("span")
         if raw_span:

--- a/python/span_box.py
+++ b/python/span_box.py
@@ -51,14 +51,63 @@ def parse_span(raw):
     return None
 
 
+def _plays_frame(game):
+    """The enriched polars frame, or None.
+
+    sdv-py's run_processing ends with ``self.plays_json = plays_json.to_dicts()``
+    and app.py then MUTATES those records (nesting start/end, deleting the flat
+    dotted columns create_box_score needs) -- so ``.filter`` threw on every
+    ?span= request and the fail-open except silently kept the full box
+    (advBoxScoreSpan was never set) from #206 until 2026-09-07. sdv-py now
+    retains the pre-conversion frame as ``plays_frame`` (sdv-py #464); reading
+    anything else here is wrong by construction.
+    """
+    frame = getattr(game, "plays_frame", None)
+    if isinstance(frame, pl.DataFrame):
+        return frame
+    plays = getattr(game, "plays_json", None)
+    return plays if isinstance(plays, pl.DataFrame) else None
+
+
 def spanned_box(game, raw_span):
     """Recompute advBoxScore over the window. Returns (box_dict, key) or (None, None)
     when the span is invalid or selects no plays (caller keeps the full box)."""
     parsed = parse_span(raw_span)
-    if parsed is None or getattr(game, "plays_json", None) is None:
+    if parsed is None:
+        return None, None
+    frame = _plays_frame(game)
+    if frame is None:
         return None, None
     key, expr = parsed
-    sliced = game.plays_json.filter(expr)
+    box = _box_for(game, frame, expr)
+    return (box, key) if box is not None else (None, None)
+
+
+def _box_for(game, frame, expr):
+    sliced = frame.filter(expr)
     if sliced.height == 0:
-        return None, None
-    return game.create_box_score(sliced), key
+        return None
+    return game.create_box_score(sliced)
+
+
+# render order for the standard windows; a window absent from the game
+# (no OT, or a live game still in Q1) is simply omitted
+_ALL_KEYS = ("q1", "q2", "h1", "q3", "q4", "h2", "ot")
+
+
+def all_span_boxes(game):
+    """Every standard window's box in ONE response, for in-place span
+    switching on the game page (no per-span navigation, no per-span API
+    round trips). The EP/WP pipeline already ran full-game; each window is
+    only a filter + re-aggregation. Windows with no plays are omitted.
+    Returns {} when plays are unavailable."""
+    frame = _plays_frame(game)
+    if frame is None:
+        return {}
+    out = {}
+    for key in _ALL_KEYS:
+        _, expr = parse_span(key)
+        box = _box_for(game, frame, expr)
+        if box is not None:
+            out[key] = box
+    return out

--- a/python/span_box.py
+++ b/python/span_box.py
@@ -15,6 +15,8 @@ What cannot be windowed, ever:
   classes; a Q3 box against full-game distributions is a category error.
 """
 
+import logging
+
 import polars as pl
 
 _PERIODS = {
@@ -107,7 +109,11 @@ def all_span_boxes(game):
     out = {}
     for key in _ALL_KEYS:
         _, expr = parse_span(key)
-        box = _box_for(game, frame, expr)
+        try:
+            box = _box_for(game, frame, expr)
+        except Exception as e:  # one bad window must not cost the others
+            logging.getLogger("root").warning(f"span window {key} failed: {e}")
+            continue
         if box is not None:
             out[key] = box
     return out

--- a/python/tests/test_span_box.py
+++ b/python/tests/test_span_box.py
@@ -99,3 +99,18 @@ def test_windows_read_plays_frame_not_the_mutated_list():
 
     assert span_box.spanned_box(ListOnly(), "q2") == (None, None)
     assert span_box.all_span_boxes(ListOnly()) == {}
+
+
+def test_all_span_boxes_survives_one_bad_window():
+    # a window whose aggregation raises is skipped; the rest still compute
+    class G:
+        plays_frame = frame()
+
+        def create_box_score(self, df):
+            if df["period"].to_list() == [2]:  # q2's slice
+                raise ValueError("boom")
+            return {"n": df.height}
+
+    boxes = span_box.all_span_boxes(G())
+    assert "q2" not in boxes
+    assert boxes["q1"] == {"n": 1} and boxes["h2"] == {"n": 2}

--- a/python/tests/test_span_box.py
+++ b/python/tests/test_span_box.py
@@ -45,3 +45,57 @@ def test_spanned_box_falls_back_when_empty_or_invalid():
     assert span_box.spanned_box(g, "nope") == (None, None)
     g.plays_json = frame().filter(pl.col("period") > 90)
     assert span_box.spanned_box(g, "q2") == (None, None)
+
+
+def test_all_span_boxes_only_played_windows():
+    class G:
+        plays_json = frame()
+
+        def create_box_score(self, df):
+            return {"n": df.height, "periods": sorted(df["period"].to_list())}
+
+    boxes = span_box.all_span_boxes(G())
+    # every standard window has plays in the fixture (one play per period + OT)
+    assert sorted(boxes) == ["h1", "h2", "ot", "q1", "q2", "q3", "q4"]
+    assert boxes["h1"] == {"n": 2, "periods": [1, 2]}
+    assert boxes["ot"] == {"n": 1, "periods": [5]}
+    # matches the singular path window-for-window
+    assert boxes["q3"] == span_box.spanned_box(G(), "q3")[0]
+
+
+def test_all_span_boxes_omits_empty_windows_and_missing_plays():
+    class G:
+        plays_json = frame().filter(pl.col("period") <= 2)
+
+        def create_box_score(self, df):
+            return {"n": df.height}
+
+    boxes = span_box.all_span_boxes(G())
+    assert sorted(boxes) == ["h1", "q1", "q2"]  # no h2/q3/q4/ot in a half-played game
+
+    class NoPlays:
+        plays_json = None
+
+    assert span_box.all_span_boxes(NoPlays()) == {}
+
+
+def test_windows_read_plays_frame_not_the_mutated_list():
+    # production shape: sdv-py converts plays_json to a LIST at the end of
+    # run_processing (and app.py mutates it); the retained plays_frame
+    # (sdv-py #464) is the only re-aggregable source
+    class G:
+        plays_frame = frame()
+        plays_json = [{"mutated": True}]  # what app.py leaves behind
+
+        def create_box_score(self, df):
+            return {"n": df.height}
+
+    assert span_box.spanned_box(G(), "q2") == ({"n": 1}, "q2")
+    boxes = span_box.all_span_boxes(G())
+    assert boxes["h2"] == {"n": 2}
+
+    class ListOnly:
+        plays_json = [{"mutated": True}]  # old sdv-py: no frame retained
+
+    assert span_box.spanned_box(ListOnly(), "q2") == (None, None)
+    assert span_box.all_span_boxes(ListOnly()) == {}


### PR DESCRIPTION
Two changes, one root cause — built as the data layer for the in-place span switching Akshay sketched in the #218 discussion ("team stats block per period... recalculate / swap out").

## The bug (production, since #206)
The `?span=` advanced-box recompute **never worked**. sdv-py's `run_processing_pipeline` ends with `plays_json.to_dicts()`, and app.py then mutates those records (nesting `start`/`end`, deleting the flat dotted columns) — so `plays_json.filter(...)` threw `'list' object has no attribute 'filter'` on every span request, swallowed by the fail-open except. `advBoxScoreSpan` was never set; the page looked plausible because astro windows the play-derived tables itself. Verified against a real game before/after.

Fix: [sdv-py #464](https://github.com/sportsdataverse/sportsdataverse-py/pull/464) retains the enriched frame as `plays_frame`; `span_box` now reads only that (reading anything else is wrong by construction — documented in the helper).

## `?spans=all`
One response carrying `advBoxScoreSpans`: `{q1, q2, h1, q3, q4, h2, ot}` → each the same shape as `advBoxScore`, **played windows only** (this game has no OT → key omitted). The EP/WP pipeline still runs once, full-game; each window is filter + re-aggregation. Enables the team-stats-per-period swap without per-span navigations or API round trips.

**Measured** (401756914, uncached local): payload 2.98 → 3.21MB (**+0.23MB, +7.7%**), compute +~2.8s for six extra `create_box_score` runs. Opt-in by query param, so only renders that want in-place switching pay; the Workers cache keys the param automatically. Verified: the `q3` slice in `advBoxScoreSpans` is identical to the singular `?span=q3` box.

## Merge order
sdv-py #464 first — GOP rebuilds sdv-py main at image build, so the next deploy after both merges carries the pair. Until then this PR is inert-safe: without `plays_frame` both paths cleanly no-op exactly as today.

Tests: span_box unit tests cover the plays_frame contract (frame preferred over the mutated list, old-sdv-py no-op) — 32 python passing; sdv-py side pins the retention contract offline.

## Summary by Sourcery

Provide reliable span-specific advanced box scores and optionally preload all played windows for seamless in-place period switching.

New Features:
- Add all available standard period and overtime advanced box scores to game responses for in-place span switching.
- Retain singular span responses for deep links and existing span navigation.

Bug Fixes:
- Restore span-specific advanced box score recomputation by using the preserved enriched play data instead of the mutated serialized records.

Enhancements:
- Gracefully omit unavailable windows and isolate failures so an invalid or failing span does not prevent the game page or other box scores from rendering.

Tests:
- Add coverage for played-window generation, empty-window omission, preserved-frame precedence, legacy-data no-op behavior, and per-window failure isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Processed game responses now include available span box scores automatically.
  * Span box results support standard game windows, including quarters, halves, and overtime.
  * Windows without available plays are omitted from the response.

* **Bug Fixes**
  * Improved span box generation when play data is transformed during processing.
  * Errors affecting individual windows no longer prevent other span boxes or game rendering from completing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

> **Update (per maintainer review):** the span maps are no longer gated behind `?spans=all` — every `/process` response ships them, so the frontend switches spans in place without a reload. `?span=` deep links unchanged.
