### PR TITLE
feat(game): Catch me up recap + key-plays filter

### DIFF
--- a/astro/src/components/game/GamePage.astro
+++ b/astro/src/components/game/GamePage.astro
@@ -168,6 +168,27 @@ const mostImpPlays = game.plays.toSorted((a, b) => {
 }).slice(0, 10)
 
 
+// Key plays: scoring plays plus the biggest win-probability swings. Marked by
+// mutation (same pattern as three_and_out) so PlayRow can stamp data-key-play
+// without threading a prop through every table.
+const keyIds = new Set([
+    ...mostImpPlays.map((p: any) => p.game_play_number),
+    ...game.scoringPlays.map((p: any) => p.game_play_number),
+]);
+for (const p of game.plays) {
+    if (keyIds.has(p.game_play_number)) (p as any).key_play = true;
+}
+
+// "Catch me up": the three plays that most changed the game so far, plus the
+// last score -- the block a mid-game visitor reads before anything else.
+const lastScore: any = game.scoringPlays.at(-1);
+const catchUpPlays = mostImpPlays.slice(0, 3);
+const fmtClock = (p: any) => p.period > 4 ? (p.period == 5 ? "OT" : `${p.period - 4}OT`) : `Q${p.period} ${p.clock?.displayValue ?? ""}`;
+const fmtSwing = (p: any) => {
+    const v = Math.abs(Number(p.winProbability?.added ?? 0) * 100);
+    return `${v < 1 ? "<1" : Math.round(v)}% WP swing`;
+};
+
 let gameDrives = game.drives.current ? (game.drives.previous ?? []).concat([game.drives.current]) : (game.drives.previous ?? []);
 gameDrives = deduplicateByKey(gameDrives, "id");
 // under a span, only drives that intersect the window
@@ -273,6 +294,27 @@ if (activeSpan) {
                         <div class="alert alert-info py-1 small" role="alert">
                             Showing <strong>{activeSpan.label}</strong> only for play-derived tables.
                         </div>
+                    </div>
+                </div>
+            )}
+            {catchUpPlays.length > 0 && (
+                <div class="row mb-2">
+                    <div class="col-md-12 ms-sm-auto col-lg-12 px-md-4">
+                        <details class="card p-0" open={gameStatus.type.completed != true}>
+                            <summary class="card-header py-2 fw-bold">Catch me up</summary>
+                            <div class="card-body py-2">
+                                <p class="small mb-1">{latestSubtitle}</p>
+                                {lastScore && (
+                                    <p class="small mb-1"><span class="text-muted">Last score:</span> {fmtClock(lastScore)} — {lastScore.text}</p>
+                                )}
+                                <p class="small mb-1 text-muted">Plays that changed the game:</p>
+                                <ul class="small mb-0 ps-4">
+                                    {catchUpPlays.map((p: any) => (
+                                        <li>{fmtClock(p)} — {p.text} <span class="text-muted">({fmtSwing(p)})</span></li>
+                                    ))}
+                                </ul>
+                            </div>
+                        </details>
                     </div>
                 </div>
             )}
@@ -560,7 +602,7 @@ if (activeSpan) {
                             {
                                 (game.plays.length > 0) && (
                                     <div class="mt-2 d-flex flex-wrap justify-content-between">
-                                        <PlayFilters target="all" periods={periodsPlayed} newestFirst={gameStatus.type.completed != true} />
+                                        <PlayFilters target="all" periods={periodsPlayed} newestFirst={gameStatus.type.completed != true} keyToggle={true} />
                                     
                                         <PlayFocus target="all" plays={game.plays}
                                             teams={game.advBoxScore.team.map((t: any) => t.pos_team)}

--- a/astro/src/components/game/plays/PlayFilters.astro
+++ b/astro/src/components/game/plays/PlayFilters.astro
@@ -16,8 +16,10 @@ interface Props {
     periods: number[];
     /** Live games read newest first; finished games read in order. */
     newestFirst: boolean;
+    /** Offer the key-plays toggle (rows must carry data-key-play). */
+    keyToggle?: boolean;
 }
-const { target, periods, newestFirst } = Astro.props;
+const { target, periods, newestFirst, keyToggle = false } = Astro.props;
 
 const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
 ---
@@ -31,9 +33,16 @@ const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
             ))}
         </Fragment>
     </FilterGroup>
-    <button type="button" class="btn btn-sm btn-outline-secondary" data-order-toggle="1" aria-pressed={newestFirst}>
-        {newestFirst ? "Newest first" : "Oldest first"}
-    </button>
+    <div class="d-flex gap-2">
+        {keyToggle && (
+            <button type="button" class="btn btn-sm btn-outline-secondary" data-key-toggle="1" aria-pressed="false" title="Scoring plays and the biggest win-probability swings">
+                Key plays
+            </button>
+        )}
+        <button type="button" class="btn btn-sm btn-outline-secondary" data-order-toggle="1" aria-pressed={newestFirst}>
+            {newestFirst ? "Newest first" : "Oldest first"}
+        </button>
+    </div>
 </div>
 
 <script>
@@ -52,9 +61,12 @@ const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
         const pairs = pairRows([...body.children], isDetail);
 
         let period = "all";
+        let keyOnly = false;
         const apply = () => {
             for (const pair of pairs) {
-                const match = period === "all" || String((pair[0] as HTMLElement).dataset.period) === period;
+                const first = pair[0] as HTMLElement;
+                const match = (period === "all" || String(first.dataset.period) === period)
+                    && (!keyOnly || first.dataset.keyPlay === "1");
                 // A filtered-in detail row is un-hidden but stays collapsed:
                 // Bootstrap's .collapse still governs whether it is on screen.
                 for (const row of pair) (row as HTMLElement).hidden = !match;
@@ -71,6 +83,11 @@ const label = (p: number) => (p <= 4 ? `Q${p}` : p === 5 ? "OT" : `${p - 4}OT`);
                     other.classList.toggle("active", on);
                     other.setAttribute("aria-pressed", String(on));
                 }
+                apply();
+            } else if (btn.dataset.keyToggle !== undefined) {
+                keyOnly = !keyOnly;
+                btn.classList.toggle("active", keyOnly);
+                btn.setAttribute("aria-pressed", String(keyOnly));
                 apply();
             } else if (btn.dataset.orderToggle !== undefined) {
                 pairs.reverse();

--- a/astro/src/components/game/plays/PlayRow.astro
+++ b/astro/src/components/game/plays/PlayRow.astro
@@ -39,7 +39,7 @@ const defense = (play.start.pos_team.id == homeTeam.id) ? awayTeam : homeTeam;
 const downText = (play.penalty_assessed_on_kickoff && play.penalty_assessed_on_kickoff == true) ? "Assessed on Kickoff" : `${formatDistance(play.period, play.start.down, play.type.text, play.start.distance, play.start.yardsToEndzone)} at ${ formatYardline(play.start.yardsToEndzone, cleanAbbreviation(offense), cleanAbbreviation(defense), play.type.text) }`;
 ---
 
-<tr data-period={play.period} data-play-row="1" data-bs-toggle={expandable ? "collapse" : ""} href={expandable ? `#play-${prefix}-${play.game_play_number}` : ''} class=`accordion-toggle ${classText}`>
+<tr data-period={play.period} data-play-row="1" data-key-play={(play as any).key_play ? "1" : undefined} data-bs-toggle={expandable ? "collapse" : ""} href={expandable ? `#play-${prefix}-${play.game_play_number}` : ''} class=`accordion-toggle ${classText}`>
     <td style="text-align: left;">{gameClock}</td>
     <td class="play-offense-cell"><a href={`/year/${play.season}/team/${play.start.pos_team.id}`}><img class={`img-fluid team-logo-${play.start.pos_team.id}`} width="35px" src={`https://a.espncdn.com/i/teamlogos/ncaa/500/${play.pos_team}.png`} alt={`ESPN team id ${play.start.pos_team.id}`}/></a><PlayMarks play={play} beside /></td>
     <td style="text-align: left;">({downText}) {play.text} - {play.scoringPlay ? (<strong>{cleanAbbreviation(awayTeam)} {play.awayScore}, {cleanAbbreviation(homeTeam)} {play.homeScore}</strong>) : (<span>{cleanAbbreviation(awayTeam)} {play.awayScore}, {cleanAbbreviation(homeTeam)} {play.homeScore}</span>)}</td>


### PR DESCRIPTION
Two additions to the (v2) game page that answer "what did I miss?" in one glance:

## Catch me up

A collapsible block at the top of the page: the status line, the last score, and the three plays that most changed the game (by absolute WPA). Open by default while the game is live — a mid-game visitor reads this before any chart — and collapsed on finals, where the whole page is the recap.

## Key plays filter

A "Key plays" toggle on the All Plays filter bar showing only scoring plays and the top win-probability swings. Rows carry `data-key-play` server-side (same mutation pattern as `three_and_out`), so the toggle composes cleanly with the existing quarter filter and reading-order controls — and with PlayFocus, which hides via `style.display` on a different axis.

## Previews

Real COLO @ TCU data. The recap surfaces exactly the game's story: the muffed punt (34% swing), the goal-line penalty stand (33%), and the DPI (18%).

**Catch me up + All Plays (toggle off):**
![off](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/recap-off.png)

**Key plays toggle on — only scoring plays + top swings remain:**
![on](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/recap-on.png)

(Harness renders the markup with the game's real play data; the shipped PlayRow adds logos, marks, and expandable detail rows as on every other table.)

Tests: 209 astro tests pass. Scope: v2 GamePage only — classic/ is slated for deletion when `game-page-v2` promotes.

## Summary by Sourcery

Add at-a-glance game recaps and key-play filtering to the v2 game page.

New Features:
- Add a collapsible “Catch me up” recap showing the current status, latest score, and three highest-impact plays.
- Add a Key plays filter that surfaces scoring plays and the largest win-probability swings.

Enhancements:
- Allow key-play filtering to compose with quarter selection, play ordering, and PlayFocus controls.