### PR TITLE
feat(live): visibility-aware auto-refresh + page-age stamp

### DIFF
--- a/astro/public/assets/js/auto-update.js
+++ b/astro/public/assets/js/auto-update.js
@@ -1,1 +1,22 @@
-setTimeout("location.reload(true);", 60 * 1000);
+// Auto-refresh for live pages, visibility-aware: a visible tab reloads on the
+// usual cadence (with jitter so a stadium of open tabs doesn't stampede the
+// edge in the same second); a hidden tab never reloads on a timer -- its
+// refresh is deferred to the moment it is next seen, so backgrounded tabs stop
+// re-fetching a page nobody is reading.
+(function () {
+    var INTERVAL_MS = 60 * 1000;
+    var JITTER_MS = Math.random() * 6000;
+    var due = false;
+    setTimeout(function () {
+        if (document.visibilityState === "visible") {
+            location.reload();
+        } else {
+            due = true;
+        }
+    }, INTERVAL_MS + JITTER_MS);
+    document.addEventListener("visibilitychange", function () {
+        if (due && document.visibilityState === "visible") {
+            location.reload();
+        }
+    });
+})();

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -199,7 +199,10 @@ if (compactRows) {
             </div>
             <div class="row mb-3" hidden={!hasActiveGames}>
                 <div class="col-12">
-                    <p class="text-small text-muted">Because there are active games, page will auto-refresh every minute.</p>
+                    <p class="text-small text-muted">
+                        Because there are active games, this page auto-refreshes every minute while you're watching it.
+                        <span data-rendered-at={new Date().toISOString()}></span>
+                    </p>
                 </div>
             </div>
             <div class="row text-muted">
@@ -232,5 +235,20 @@ if (compactRows) {
                 )
             }
         </div>
-    </body>
+    <script>
+    // "Updated Ns ago" beside the auto-refresh note: honest about page age,
+    // cheap to keep current, and it makes a deferred (hidden-tab) refresh
+    // legible -- the reader sees the age climb, then the reload catch up.
+    const stamp = document.querySelector<HTMLElement>("[data-rendered-at]");
+    if (stamp?.dataset.renderedAt) {
+        const at = Date.parse(stamp.dataset.renderedAt);
+        const render = () => {
+            const s = Math.max(0, Math.round((Date.now() - at) / 1000));
+            stamp.textContent = s < 10 ? "Updated just now." : s < 90 ? `Updated ${s}s ago.` : `Updated ${Math.round(s / 60)}m ago.`;
+        };
+        render();
+        setInterval(render, 10_000);
+    }
+</script>
+</body>
 </html>

--- a/astro/src/components/schedule/SchedulePage.astro
+++ b/astro/src/components/schedule/SchedulePage.astro
@@ -201,7 +201,7 @@ if (compactRows) {
                 <div class="col-12">
                     <p class="text-small text-muted">
                         Because there are active games, this page auto-refreshes every minute while you're watching it.
-                        <span data-rendered-at={new Date().toISOString()}></span>
+                        {hasActiveGames && <span data-rendered-at={new Date().toISOString()}></span>}
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Makes the live-page auto-refresh visibility-aware and page age legible.

## The problem

`auto-update.js` was one line: `setTimeout("location.reload(true);", 60 * 1000)`. Every open tab — including hidden background tabs — re-fetched the page every minute for as long as it stayed open. On a Saturday, that's a large share of edge traffic serving pages nobody is reading, all synchronized to the minute they loaded.

## The change

- **Hidden tabs never reload on a timer.** The reload is deferred and fires the moment the tab is next seen (`visibilitychange`), so a returning reader still gets a fresh page immediately.
- **Visible tabs reload with up to 6s of jitter**, desynchronizing simultaneous open tabs instead of stampeding the edge in the same second.
- **The scoreboard's auto-refresh note now carries an "Updated Ns ago" stamp** (server-stamped render time, client-ticked every 10s) — page age is honest, and a deferred refresh visibly catches up when you return to the tab.
- Copy updated to match the behavior: "auto-refreshes every minute *while you're watching it*". (Also drops the deprecated `reload(true)` forceGet argument, a no-op in modern browsers.)

Same script serves all three include sites (scoreboard + both game pages) unchanged.

## Preview

![before/after](https://raw.githubusercontent.com/saiemgilani/game-on-paper-app/pr-assets/pr-previews/2026-09-07/refresh-note.png)

Tests: 209 astro tests pass.

## Summary by Sourcery

Make live-page refreshing visibility-aware and show readers when the page was last rendered.

New Features:
- Make live-page auto-refresh defer hidden-tab reloads until the tab becomes visible and add jitter to visible-tab refreshes.
- Display a live page-age stamp beside the scoreboard auto-refresh notice.

Bug Fixes:
- Prevent background tabs from repeatedly fetching live pages while they are not being viewed.
- Ensure returning to a hidden live page triggers its deferred refresh immediately.

Enhancements:
- Update auto-refresh messaging to clarify that refreshing occurs while the page is being watched.