### PR TITLE
fix(leaderboards): malformed season year is a 404 on the index pages too

### DIFF
--- a/astro/src/pages/nfl/year/[year]/players.astro
+++ b/astro/src/pages/nfl/year/[year]/players.astro
@@ -3,6 +3,9 @@ import PlayerLeaderboardPage from "../../../../components/leaderboards/PlayerLea
 import { prepareLeaderboard } from "../../../../routes/leaderboards";
 
 const r = prepareLeaderboard(Astro, 'nfl', 'players');
+if ('notFound' in r) {
+    return Astro.rewrite("/404");
+}
 if ('redirect' in r) {
     return Astro.redirect(r.redirect);
 }

--- a/astro/src/pages/nfl/year/[year]/teams.astro
+++ b/astro/src/pages/nfl/year/[year]/teams.astro
@@ -3,6 +3,9 @@ import TeamLeaderboardPage from "../../../../components/leaderboards/TeamLeaderb
 import { prepareLeaderboard } from "../../../../routes/leaderboards";
 
 const r = prepareLeaderboard(Astro, 'nfl', 'teams');
+if ('notFound' in r) {
+    return Astro.rewrite("/404");
+}
 if ('redirect' in r) {
     return Astro.redirect(r.redirect);
 }

--- a/astro/src/pages/year/[year]/players.astro
+++ b/astro/src/pages/year/[year]/players.astro
@@ -3,6 +3,9 @@ import PlayerLeaderboardPage from "../../../components/leaderboards/PlayerLeader
 import { prepareLeaderboard } from "../../../routes/leaderboards";
 
 const r = prepareLeaderboard(Astro, 'cfb', 'players');
+if ('notFound' in r) {
+    return Astro.rewrite("/404");
+}
 if ('redirect' in r) {
     return Astro.redirect(r.redirect);
 }

--- a/astro/src/pages/year/[year]/teams.astro
+++ b/astro/src/pages/year/[year]/teams.astro
@@ -3,6 +3,9 @@ import TeamLeaderboardPage from "../../../components/leaderboards/TeamLeaderboar
 import { prepareLeaderboard } from "../../../routes/leaderboards";
 
 const r = prepareLeaderboard(Astro, 'cfb', 'teams');
+if ('notFound' in r) {
+    return Astro.rewrite("/404");
+}
 if ('redirect' in r) {
     return Astro.redirect(r.redirect);
 }

--- a/astro/test/explicitRoutes.test.ts
+++ b/astro/test/explicitRoutes.test.ts
@@ -36,6 +36,26 @@ describe('explicit /nfl pages', () => {
         expect(nfl).toEqual(cfb);
     });
 
+    test('a page handles every variant its loader can return', () => {
+        // routes/*.ts loaders return {redirect}/{notFound} unions; a page that
+        // forgets a branch spreads the marker object into the component and
+        // ships an "undefined" page as HTTP 200 (seen on /year/2025junk/teams).
+        const loaders = ['leaderboards', 'matchup', 'seasonTeam', 'game']
+            .map((f) => readFileSync(new URL(`../src/routes/${f}.ts`, import.meta.url)).toString()).join('\n');
+        const variants: Record<string, string[]> = {};
+        for (const m of loaders.matchAll(/export (?:async )?function (\w+)\([\s\S]*?\n\}/g)) {
+            variants[m[1]] = ['notFound', 'redirect'].filter((k) => m[0].includes(`{ ${k}`));
+        }
+        expect(variants.prepareLeaderboard).toEqual(['notFound', 'redirect']);
+        for (const p of walk(PAGES)) {
+            const src = readFileSync(join(PAGES, p)).toString();
+            for (const [fn, keys] of Object.entries(variants)) {
+                if (!src.includes(`${fn}(`)) continue;
+                for (const k of keys) expect(src, `${p} handles '${k}' from ${fn}`).toContain(`'${k}' in r`);
+            }
+        }
+    });
+
     test('an nfl page sets the league itself (no middleware)', () => {
         for (const p of walk(join(PAGES, 'nfl'))) {
             const src = readFileSync(join(PAGES, 'nfl', p)).toString();


### PR DESCRIPTION
Follow-up to #229, found on the production smoke after deploy.

`prepareLeaderboard` returns `{ notFound }` for a year that is not four digits, but the four `year/[year]/{teams,players}.astro` pages (cfb + nfl) only branched on `redirect`, so `/year/2025junk/teams` rendered an "undefined … Team Rankings" page as HTTP 200 — an indexable thin page, the exact class the category 404 was added for.

- The four pages rewrite to `/404` on `notFound`.
- `test/explicitRoutes.test.ts` now derives each loader's return variants from `src/routes/*.ts` and asserts every page that calls a loader branches on all of them (fails without the page fix — verified).

vitest: 237 passed, 1 skipped.

## Summary by Sourcery

Handle malformed season years consistently as not-found responses across leaderboard index pages and guard against unhandled loader results.

Bug Fixes:
- Return a 404 for malformed season-year leaderboard URLs across CFB and NFL team and player index pages instead of rendering invalid ranking pages.

Enhancements:
- Add coverage that verifies pages branch on every response variant exposed by their route loaders.

Tests:
- Extend explicit route tests to detect pages that fail to handle loader redirect and not-found responses.