### PR TITLE
fix(sdv): a no-category team read selects only its league's columns

### DIFF
--- a/astro/src/resources/sdv.ts
+++ b/astro/src/resources/sdv.ts
@@ -4,7 +4,7 @@ import { SDV_RADAR_COLUMNS, SDV_TEAM_CARD_COLUMNS, SDV_TEAM_METRIC_CATEGORIES } 
 import { env } from "cloudflare:workers";
 import { calculateNormCdf, cleanUpParams, safeCachePut } from "../utils/misc";
 import { wrappedFetch } from "../utils/telemetry"
-import { LEAGUES, type League } from "../utils/league";
+import { LEAGUES, type League, teamCategoriesFor } from '../utils/league';
 
 const SDV_MAX_LOOKBACK_YEAR = 2004;
 
@@ -699,8 +699,10 @@ export async function retrieveTeamSummaries({ season, week, fbs_class, category,
     } else if (category) {
         metric_columns = Object.keys(SDV_TEAM_METRIC_CATEGORIES[category]).concat(SDV_RADAR_COLUMNS[category]).concat(SDV_TEAM_CARD_COLUMNS[category])
     } else if (!category) {
-        // not implemented yet
-        metric_columns = Object.keys(SDV_TEAM_METRIC_CATEGORIES).flatMap((p: string) => Object.keys(SDV_TEAM_METRIC_CATEGORIES[p]).concat(SDV_RADAR_COLUMNS[p]).concat(SDV_TEAM_CARD_COLUMNS[p]))
+        // every column the LEAGUE's categories read: the NFL-only categories name
+        // columns the cfb table does not have, and one unknown column in `select`
+        // is a 400 (every team profile / season team / pregame read went empty)
+        metric_columns = teamCategoriesFor(league).flatMap((p: string) => Object.keys(SDV_TEAM_METRIC_CATEGORIES[p]).concat(SDV_RADAR_COLUMNS[p] ?? []).concat(SDV_TEAM_CARD_COLUMNS[p] ?? []))
     } else {
         throw Error(`Category ${category} not implemented`)
     }

--- a/astro/test/leagueResources.test.ts
+++ b/astro/test/leagueResources.test.ts
@@ -70,4 +70,19 @@ describe('sdv.ts routes each league to its own API base', () => {
         // nfl rows never ask for the college-only FBS filter
         expect(urls.filter(u => u.includes('/v1/nfl/')).every(u => !u.includes('fbs_class='))).toBe(true);
     });
+
+    test('a no-category team read selects only the columns its league has', async () => {
+        const sdv = await import('../src/resources/sdv');
+        await sdv.retrieveTeamSummaries({ team_id: 59 }).catch(() => {});
+        await sdv.retrieveTeamSummaries({ team_id: 12, league: 'nfl' }).catch(() => {});
+        const sel = (u: string) => decodeURIComponent(new URL(u).searchParams.get('select') ?? '').split(',');
+        const cfb = sel(seen.find(u => u.includes('/v1/cfb/team_summaries?'))!);
+        const nfl = sel(seen.find(u => u.includes('/v1/nfl/team_summaries?'))!);
+        // the rbsdm columns exist in nfl.team_summaries only; asking cfb for one is a 400
+        expect(cfb).not.toContain('pass_oe_off');
+        expect(cfb).not.toContain('luck_opp_fg_pct_def_rank');
+        expect(cfb).toContain('net_adj_epa');
+        expect(nfl).toContain('pass_oe_off');
+        expect(nfl).toContain('net_adj_epa');
+    });
 });


### PR DESCRIPTION
Production regression from #229, found on the post-deploy smoke: `/team/59` (and every college team profile / season team page / pregame page / matchup) rendered with an empty season table ("undefined" in the title).

Cause: `retrieveTeamSummaries` without a category selects the union of every category's columns, which since #229 includes the NFL-only rbsdm columns; `cfb.team_summaries` has none of them and one unknown column in `select` is a 400 from the Data API.

Fix: the union is over `teamCategoriesFor(league)`. Test pins that a cfb no-category read never asks for an rbsdm column and an nfl one does.

(The NFL `fourth-downs` leaderboard has a sibling problem — the producer never ranked `fourth_decisions_off` — fixed on the data side in sportsdataverse/nfl-data#37 and republished with the series-conversion rebuild.)

vitest: 239 passed, 1 skipped.

## Summary by Sourcery

Fix league-specific team summary column selection to restore successful college team and season page reads.

Bug Fixes:
- Restrict no-category team summary queries to columns available for the requested league, preventing college team reads from failing on NFL-only fields.

Tests:
- Add coverage verifying league-specific column selection for college and NFL no-category team summary reads.