### PR TITLE
fix(leaderboards): an NFL-only category sorts by its own first column

### DIFF
--- a/astro/src/components/leaderboards/TeamLeaderboardTable.astro
+++ b/astro/src/components/leaderboards/TeamLeaderboardTable.astro
@@ -77,7 +77,7 @@ function generateMetricRow(team: any): string {
     <tr>
         <td class="text-right" colspan="1">${rankStr}</td>
         <td class="text-left" colspan="1">
-            <a href="${leaguePath(Astro.locals.league, `/year/${season}/team/${team.team_id}`)}"><img class="img-fluid team-logo-${team.team_id} me-2" width="20px" src="https://a.espncdn.com/i/teamlogos/${espnLogoLeague(Astro.locals.league)}/500/${team.team_id}.png" alt="ESPN team id ${team.team_id} ${cleanField(team, "pos_team")}" title="${team.team}"/><span class="visually-hidden">${cleanField(team, "pos_team")}</span><strong>${cleanField(team, "pos_team")}</strong></a>
+            <a href="${leaguePath(Astro.locals.league, `/year/${season}/team/${team.team_id}`)}"><img class="img-fluid team-logo-${team.team_id} me-2" width="20px" src="https://a.espncdn.com/i/teamlogos/${espnLogoLeague(Astro.locals.league)}/500/${team.team_id}.png" alt="ESPN team id ${team.team_id} ${cleanField(team, "pos_team")}" title="${cleanField(team, "pos_team")}"/><span class="visually-hidden">${cleanField(team, "pos_team")}</span><strong>${cleanField(team, "pos_team")}</strong></a>
         </td>
         ${colContent}
     </tr>`;

--- a/astro/src/utils/misc.ts
+++ b/astro/src/utils/misc.ts
@@ -1,5 +1,5 @@
 import type { ESPNCompetition, ESPNScheduleEvent, ESPNTeam, ESPNCompetitor, ESPNStatus } from "../resources/espn";
-import { MEME_LIST, SDV_BASE_METRIC_TITLES, FBS_CONFERENCES } from "./constants";
+import { MEME_LIST, SDV_BASE_METRIC_TITLES, FBS_CONFERENCES, SDV_TEAM_METRIC_CATEGORIES } from "./constants";
 import { espnLogoLeague, leaguePath, type League } from "./league";
 import { GLOBAL_GROUP_LIST } from "../resources/schedule"
 
@@ -559,6 +559,13 @@ export function generateCategoryForMetric(metric: string): string {
 }
 
 export function modifyMetricForCategory(category: string, metric: string) {
+    // an NFL-only category (tendencies / fourth-downs / luck) shares no column
+    // with the cfb grid: a metric it does not carry sorts by its first column
+    // (the leaderboard showed N/A ranks when the default net_adj_epa carried over)
+    const own = SDV_TEAM_METRIC_CATEGORIES[category];
+    if (own && !["offensive", "defensive", "differential"].includes(category)) {
+        return metric in own ? metric : Object.keys(own)[0];
+    }
     if (category == "offensive" && ["adj_def_epa", "net_adj_epa"].includes(metric)) {
         return "adj_off_epa"
     } else if (category == "defensive" && ["adj_off_epa", "net_adj_epa"].includes(metric)) {

--- a/astro/test/explicitRoutes.test.ts
+++ b/astro/test/explicitRoutes.test.ts
@@ -80,6 +80,11 @@ describe('leaderboard loaders', () => {
         expect(a.locals.league).toBe('nfl');
         expect(prepareTeamCategory(fakeAstro('/nfl/year/2025/teams/tendencies?sort=proe', { year: '2025', category: 'tendencies' }), 'nfl'))
             .toEqual({ season: 2025, category: 'tendencies', metric: 'proe' });
+        // no ?sort: an NFL-only category defaults to its own first column, not net_adj_epa
+        expect(prepareTeamCategory(fakeAstro('/nfl/year/2025/teams/tendencies', { year: '2025', category: 'tendencies' }), 'nfl'))
+            .toEqual({ season: 2025, category: 'tendencies', metric: 'pass_rate_off' });
+        expect(prepareTeamCategory(fakeAstro('/year/2025/teams/offensive', { year: '2025', category: 'offensive' }), 'cfb'))
+            .toEqual({ season: 2025, category: 'offensive', metric: 'adj_off_epa' });
     });
 
     test('player category and the index pages', async () => {

--- a/astro/test/nflLeaderboards.render.test.ts
+++ b/astro/test/nflLeaderboards.render.test.ts
@@ -3,6 +3,7 @@ import { experimental_AstroContainer as AstroContainer } from 'astro/container';
 import { loadRenderers } from 'astro:container';
 import { getContainerRenderer as svelteRenderer } from '@astrojs/svelte/container-renderer';
 import { beforeAll, describe, expect, test, vi } from 'vitest';
+import { modifyMetricForCategory } from '../src/utils/misc';
 
 // The season surfaces (team + player leaderboards) rendered for the NFL with
 // real rows from the nfl-data producer's 2025 build (tests/fixtures/
@@ -27,7 +28,7 @@ beforeAll(async () => {
 async function renderTeams(category: string) {
     const { default: Page } = await import('../src/components/leaderboards/TeamLeaderboardPage.astro');
     return container.renderToString(Page, {
-        props: { season: 2025, category, metric: category === 'differential' ? 'net_adj_epa' : undefined },
+        props: { season: 2025, category, metric: modifyMetricForCategory(category, 'net_adj_epa') },
         request: new Request(`https://gameonpaper.com/nfl/year/2025/teams/${category}`),
         locals: { league: 'nfl' },
     });
@@ -53,6 +54,9 @@ describe('NFL team leaderboard', () => {
         // rbsdm's Series Conv % (nflfastR series_success) joined the grid with the
         // 2002-2025 rebuild; the defense column ranks lowest-first
         expect(html).toContain('Series Conv %');
+        // sorted by a column the category has (pass_oe_off), so every row carries a rank
+        expect(html).not.toContain('>N/A<');
+        expect(html).not.toContain('title="undefined"');
         expect(html).toContain('Opp Series Conv %');
         // canonical + JSON-LD dataset url carry the league prefix
         expect(html).toContain('gameonpaper.com/nfl/year/2025/teams/tendencies');


### PR DESCRIPTION
Found on the post-deploy smoke of #234.

- `/nfl/year/2025/teams/{tendencies,fourth-downs,luck}` without `?sort` kept the differential default (`net_adj_epa`), a column those grids do not show, so every row's rank cell read **N/A**. `modifyMetricForCategory` now maps a metric the category does not carry to the category's first column — the same function the category dropdowns use when switching, so the dropdown path is fixed too.
- The team logo `title` read `undefined` on both leagues (`team.team` is not a field): now the team abbreviation.
- Tests: loader default for an NFL-only category; the tendencies render has no N/A rank cell and no `title="undefined"`.

vitest: 239 passed, 1 skipped.

## Summary by Sourcery

Fix NFL-only team leaderboards so their default sorting and team logo metadata match the columns and teams displayed.

Bug Fixes:
- Ensure NFL-only team leaderboard categories default to a metric they display, preventing missing rank values when no sort parameter is provided.
- Use team abbreviations for leaderboard logo titles instead of undefined values.

Tests:
- Add loader and rendering coverage for NFL-only category defaults, valid rank cells, and populated team logo titles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Team leaderboard image tooltips now display cleaned team names.
  - NFL leaderboard rankings no longer show unavailable “N/A” values when supported metrics are available.
  - NFL tendency and college football offensive leaderboards now load with the appropriate default metrics when no sort option is selected.
- **Tests**
  - Added coverage to verify default leaderboard metrics and prevent undefined values from appearing in NFL leaderboard results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->