### PR TITLE
docs: require the desktop/mobile × light/dark screenshot matrix for UI changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# game-on-paper-app — working notes
+
+Astro 5 SSR on Cloudflare Workers (Svelte 5 islands) in `astro/`; a Flask
+processor (`sportsdataverse` play-by-play) in `python/`. The site renders two
+leagues: `cfb` (unprefixed, the default) and `nfl` (explicit pages under
+`astro/src/pages/nfl/**`; see `astro/src/utils/league.ts`).
+
+## Local gates
+- Node here is often < 22.12, so `astro check` / `astro build` / `astro dev`
+  can't run locally — **CI covers the templates**. What runs locally:
+  `cd astro && npx vitest run` and `cd python && pytest`. Run both before a PR.
+- Never claim a rendered change works from the code alone. Exercise it: vitest
+  for logic, and a **visual check** (below) for anything a person sees.
+
+## Visual verification — REQUIRED for any UI change
+Any change that touches a rendered page, an Astro/Svelte component, or CSS —
+including "just a copy/colour tweak" — is not done until it has been seen in
+**all four combinations**, because each is a different code path or layout:
+
+|          | light | dark |
+|----------|-------|------|
+| desktop (1280×800) | ✓ | ✓ |
+| mobile (390×844)   | ✓ | ✓ |
+
+Dark mode is driven by `prefers-color-scheme` (see `public/assets/css/dark-*.css`),
+so it must be **emulated**, not faked by resizing a window or toggling a class —
+a real dark-mode viewer hits the media query. Mobile is a real narrow viewport,
+not a scaled-down desktop. So: two viewports × two schemes, every time.
+
+Capture the matrix with the committed helper (it emulates both axes and shoots
+full-page at 2× density):
+
+```bash
+cd astro
+# against the deployed site (or a local `npm run preview` on :4321):
+BASE=https://gameonpaper.com npm run visual-check -- /nfl /nfl/year/2025/teams/tendencies
+# writes astro/img/visual/<route>-<device>-<scheme>.png (4 per route)
+```
+
+`scripts/visual-check.mjs` uses `playwright-core` (resolve it with
+`npm i -g playwright-core`; it downloads **no** browser) driving your installed
+Google Chrome, or the chromium at `$VISUAL_CHECK_EXECUTABLE`. It is deliberately
+not a repo dependency, so `npm ci` stays lean.
+
+Attach the four (or the relevant subset) to the PR, or send them to reviewers.
+When a change is league-specific, shoot the `/nfl` route **and** its `cfb` twin —
+the two share components, so a regression usually hits both. `img/visual/` is
+git-ignored; don't commit the PNGs.
+
+## Guardrails
+- Branch + PR, never push `main`. Stage explicit paths. One logical change per PR.
+- After merging a GOP PR, the deploy runs on push to `main`; smoke the deployed
+  URL (status, and grep the HTML) before calling it shipped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,13 @@ BASE=https://gameonpaper.com npm run visual-check -- /nfl /nfl/year/2025/teams/t
 # writes astro/img/visual/<route>-<device>-<scheme>.png (4 per route)
 ```
 
-`scripts/visual-check.mjs` uses `playwright-core` (resolve it with
-`npm i -g playwright-core`; it downloads **no** browser) driving your installed
-Google Chrome, or the chromium at `$VISUAL_CHECK_EXECUTABLE`. It is deliberately
-not a repo dependency, so `npm ci` stays lean.
+`scripts/visual-check.mjs` uses `playwright-core` (install it once with
+`npm i -g playwright-core` or `npm i -D playwright-core`; it downloads **no**
+browser) driving your installed Google Chrome, or the chromium at
+`$VISUAL_CHECK_EXECUTABLE`. It is deliberately not a repo dependency, so
+`npm ci` stays lean, and it exits non-zero if a route fails to load so an error
+page never passes as a valid shot. (Isolated root container that needs the
+Chrome sandbox off: set `VISUAL_CHECK_NO_SANDBOX=1`.)
 
 Attach the four (or the relevant subset) to the PR, or send them to reviewers.
 When a change is league-specific, shoot the `/nfl` route **and** its `cfb` twin —

--- a/astro/.gitignore
+++ b/astro/.gitignore
@@ -24,3 +24,6 @@ pnpm-debug.log*
 .idea/
 
 .omc
+
+# visual-check.mjs output (screenshots are shared on the PR, not committed)
+img/visual/

--- a/astro/package.json
+++ b/astro/package.json
@@ -12,7 +12,8 @@
     "astro": "astro",
     "server": "node dist/server/entry.mjs",
     "generate-types": "wrangler types",
-    "test": "vitest run"
+    "test": "vitest run",
+    "visual-check": "node scripts/visual-check.mjs"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",

--- a/astro/scripts/visual-check.mjs
+++ b/astro/scripts/visual-check.mjs
@@ -1,0 +1,82 @@
+// Visual verification: shoot the {desktop, mobile} x {light, dark} matrix for a
+// set of routes, so a change to any rendered page/component/CSS is reviewed the
+// way people actually see it. See ../../CLAUDE.md "Visual verification".
+//
+//   BASE=https://gameonpaper.com node scripts/visual-check.mjs /nfl /nfl/year/2025/teams/tendencies
+//   node scripts/visual-check.mjs                 # BASE defaults to localhost:4321, default routes
+//
+// Deliberately NOT a repo dependency (keeps npm ci lean): the driver is
+// playwright-core, resolved from wherever it is installed. If it is missing:
+//   npm i -g playwright-core          # or -D in astro/, or `npx playwright-core`
+// and a Chrome/Chromium: $VISUAL_CHECK_EXECUTABLE (a chrome binary path) or the
+// developer's installed Google Chrome (channel). playwright-core pulls no
+// browser on install, so this never downloads one.
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+async function loadChromium() {
+  // try a normal resolve first (astro devDep / global), then NODE_PATH entries
+  try { return (await import('playwright-core')).chromium; } catch {}
+  const req = createRequire(import.meta.url);
+  for (const base of (process.env.NODE_PATH ?? '').split(':').filter(Boolean)) {
+    try { return req(join(base, 'playwright-core')).chromium; } catch {}
+  }
+  console.error('playwright-core not found. Install it: `npm i -g playwright-core` '
+    + '(or `npm i -D playwright-core` in astro/), then re-run. It pulls no browser.');
+  process.exit(2);
+}
+
+const BASE = process.env.BASE ?? 'http://localhost:4321';
+const OUT = process.env.OUT ?? 'img/visual';
+// pass routes as args; the default set is one scoreboard, one leaderboard, one
+// team page -- enough surfaces that a layout/theme regression shows up.
+const passed = process.argv.slice(2);
+const routes = passed.length ? passed : ['/', '/nfl', '/nfl/year/2025/teams/tendencies'];
+
+// the review matrix -- never fewer than these four per route
+const DEVICES = [
+  { name: 'desktop', width: 1280, height: 800 },
+  { name: 'mobile', width: 390, height: 844 },
+];
+const SCHEMES = ['light', 'dark'];
+
+const slug = (r) => (r === '/' ? 'home' : r.replace(/^\/+|\/+$/g, '').replace(/[^\w-]+/g, '-'));
+
+const chromium = await loadChromium();
+const launch = process.env.VISUAL_CHECK_EXECUTABLE
+  ? { executablePath: process.env.VISUAL_CHECK_EXECUTABLE, args: ['--no-sandbox'] }
+  : { channel: 'chrome', args: ['--no-sandbox'] };
+
+await mkdir(OUT, { recursive: true });
+const browser = await chromium.launch(launch);
+const shots = [];
+try {
+  for (const device of DEVICES) {
+    for (const colorScheme of SCHEMES) {
+      const ctx = await browser.newContext({
+        viewport: { width: device.width, height: device.height },
+        colorScheme,
+        deviceScaleFactor: 2,
+      });
+      const page = await ctx.newPage();
+      for (const route of routes) {
+        const url = BASE + route;
+        try {
+          await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 });
+          await page.waitForTimeout(1200); // let islands hydrate + charts draw
+        } catch (e) {
+          console.error(`WARN ${url} (${device.name}/${colorScheme}): ${e.message}`);
+        }
+        const path = join(OUT, `${slug(route)}-${device.name}-${colorScheme}.png`);
+        await page.screenshot({ path, fullPage: true });
+        shots.push(path);
+      }
+      await ctx.close();
+    }
+  }
+} finally {
+  await browser.close();
+}
+console.log(`${shots.length} screenshots -> ${OUT}/`);
+for (const s of shots) console.log('  ' + s);

--- a/astro/scripts/visual-check.mjs
+++ b/astro/scripts/visual-check.mjs
@@ -6,24 +6,29 @@
 //   node scripts/visual-check.mjs                 # BASE defaults to localhost:4321, default routes
 //
 // Deliberately NOT a repo dependency (keeps npm ci lean): the driver is
-// playwright-core, resolved from wherever it is installed. If it is missing:
-//   npm i -g playwright-core          # or -D in astro/, or `npx playwright-core`
-// and a Chrome/Chromium: $VISUAL_CHECK_EXECUTABLE (a chrome binary path) or the
-// developer's installed Google Chrome (channel). playwright-core pulls no
-// browser on install, so this never downloads one.
+// playwright-core, resolved from a local (`npm i -D playwright-core`) OR global
+// (`npm i -g playwright-core`) install. It pulls NO browser on install; it
+// drives the developer's installed Google Chrome, or the chromium at
+// $VISUAL_CHECK_EXECUTABLE. Exits non-zero if any route fails to load, so a dead
+// server or a 404 can't pass off an error-page screenshot as valid.
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
+import { execSync } from 'node:child_process';
 
 async function loadChromium() {
-  // try a normal resolve first (astro devDep / global), then NODE_PATH entries
+  // 1) a normal resolve (local devDep) 2) the global npm root (npm i -g)
+  // 3) any NODE_PATH entry
   try { return (await import('playwright-core')).chromium; } catch {}
   const req = createRequire(import.meta.url);
-  for (const base of (process.env.NODE_PATH ?? '').split(':').filter(Boolean)) {
+  const roots = [];
+  try { roots.push(execSync('npm root -g', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim()); } catch {}
+  roots.push(...(process.env.NODE_PATH ?? '').split(':').filter(Boolean));
+  for (const base of roots) {
     try { return req(join(base, 'playwright-core')).chromium; } catch {}
   }
-  console.error('playwright-core not found. Install it: `npm i -g playwright-core` '
-    + '(or `npm i -D playwright-core` in astro/), then re-run. It pulls no browser.');
+  console.error('playwright-core not found. Install it (it downloads no browser): '
+    + '`npm i -g playwright-core` or `npm i -D playwright-core` in astro/, then re-run.');
   process.exit(2);
 }
 
@@ -44,13 +49,17 @@ const SCHEMES = ['light', 'dark'];
 const slug = (r) => (r === '/' ? 'home' : r.replace(/^\/+|\/+$/g, '').replace(/[^\w-]+/g, '-'));
 
 const chromium = await loadChromium();
+// The Chrome sandbox stays ON for a developer's Chrome; only an isolated
+// container running as root needs it off (opt in with VISUAL_CHECK_NO_SANDBOX=1).
+const args = process.env.VISUAL_CHECK_NO_SANDBOX ? ['--no-sandbox'] : [];
 const launch = process.env.VISUAL_CHECK_EXECUTABLE
-  ? { executablePath: process.env.VISUAL_CHECK_EXECUTABLE, args: ['--no-sandbox'] }
-  : { channel: 'chrome', args: ['--no-sandbox'] };
+  ? { executablePath: process.env.VISUAL_CHECK_EXECUTABLE, args }
+  : { channel: 'chrome', args };
 
 await mkdir(OUT, { recursive: true });
 const browser = await chromium.launch(launch);
 const shots = [];
+const failures = [];
 try {
   for (const device of DEVICES) {
     for (const colorScheme of SCHEMES) {
@@ -62,11 +71,13 @@ try {
       const page = await ctx.newPage();
       for (const route of routes) {
         const url = BASE + route;
+        const where = `${route} (${device.name}/${colorScheme})`;
         try {
-          await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 });
+          const res = await page.goto(url, { waitUntil: 'networkidle', timeout: 60_000 });
+          if (res && res.status() >= 400) failures.push(`${where}: HTTP ${res.status()}`);
           await page.waitForTimeout(1200); // let islands hydrate + charts draw
         } catch (e) {
-          console.error(`WARN ${url} (${device.name}/${colorScheme}): ${e.message}`);
+          failures.push(`${where}: ${e.message}`);
         }
         const path = join(OUT, `${slug(route)}-${device.name}-${colorScheme}.png`);
         await page.screenshot({ path, fullPage: true });
@@ -80,3 +91,8 @@ try {
 }
 console.log(`${shots.length} screenshots -> ${OUT}/`);
 for (const s of shots) console.log('  ' + s);
+if (failures.length) {
+  console.error(`\n${failures.length} route(s) failed to load — screenshots may be error pages:`);
+  for (const f of failures) console.error('  ' + f);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
akeaswaran flagged dark mode as an unchecked case on the NFL PR — so this makes visual review a rule instead of an ad-hoc thing.

- **`CLAUDE.md`** (new; the repo had none): any change touching a rendered page, an Astro/Svelte component, or CSS is not done until it's been seen in **{desktop 1280×800, mobile 390×844} × {light, dark}** — four shots. It spells out *why* each axis matters (dark mode is `prefers-color-scheme`, so it must be emulated, not faked by resizing or a class toggle; mobile is a real narrow viewport), and to shoot a `/nfl` route together with its `cfb` twin since they share components. Also records the local-gates reality (node < 22.12 → `astro build` can't run locally; vitest + pytest do).
- **`astro/scripts/visual-check.mjs`** + `npm run visual-check`: shoots the matrix full-page at 2× density with `playwright-core` driving the developer's installed Chrome. Deliberately **not** a repo dependency (resolved at runtime; `playwright-core` downloads no browser), so `npm ci` and the lockfile are untouched. Verified end-to-end against production — dark contexts render `rgb(24,26,27)`, light `rgb(255,255,255)`; desktop 2×1280, mobile 2×390.
- `img/visual/` git-ignored — screenshots ride on the PR, not the repo.

No app code changes; vitest/pytest unaffected (package.json gains one script key, lockfile untouched).

## Summary by Sourcery

Require and streamline four-way visual verification for all rendered UI changes.

New Features:
- Add a visual verification command that captures full-page screenshots across desktop and mobile viewports in both light and dark modes for specified routes.
- Document a required four-state visual review process for rendered UI changes, including reviewing shared league routes and attaching screenshots to pull requests.

Enhancements:
- Use the developer’s installed Chrome through an optional runtime-only Playwright Core setup, without adding browser dependencies to the repository.

Build:
- Add the `visual-check` npm script for running the screenshot workflow.

Documentation:
- Add repository working notes covering local test gates, visual verification requirements, route coverage, and deployment smoke checks.

Chores:
- Ignore generated visual verification screenshots so review artifacts remain attached to pull requests rather than committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual-check tool that captures full-page screenshots across desktop and mobile layouts, with light and dark color schemes.
  * Added configurable routes, output locations, and application URL settings for visual checks.

* **Documentation**
  * Added project guidance covering architecture, local development, visual verification, branching, and deployment checks.

* **Chores**
  * Excluded generated visual-check screenshots from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->