### PR TITLE
feat(nfl): put the NFL surface behind the 'nfl' feature flag (preview)

### DIFF
--- a/astro/src/components/Header.astro
+++ b/astro/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import { LAST_YEAR } from "../utils/constants";
 import { LEAGUES, leaguePath, type League } from "../utils/league";
+import { isFeatureEnabled } from "../utils/features";
 
 const league: League = Astro.locals.league ?? 'cfb';
 const cfg = LEAGUES[league];
@@ -67,9 +68,15 @@ const METRIC_YEAR = LAST_YEAR;
                 </li>
             </ul>
 
-            <form class="col-auto mb-3 mt-1 mb-lg-0 me-lg-3">
-                <a href={leaguePath(other, "/")} class="btn btn-md btn-outline-primary league-switch" title={`Switch to ${LEAGUES[other].name}`}>{cfg.shortName} <i class="bi bi-arrow-right" aria-hidden="true"></i> {LEAGUES[other].shortName}</a>
-            </form>
+            {
+                /* the switch INTO the NFL is offered only to a viewer the 'nfl'
+                   flag admits (utils/features.ts); the switch back to CFB always */
+                (other !== 'nfl' || isFeatureEnabled('nfl', Astro.locals)) && (
+                <form class="col-auto mb-3 mt-1 mb-lg-0 me-lg-3">
+                    <a href={leaguePath(other, "/")} class="btn btn-md btn-outline-primary league-switch" title={`Switch to ${LEAGUES[other].name}`}>{cfg.shortName} <i class="bi bi-arrow-right" aria-hidden="true"></i> {LEAGUES[other].shortName}</a>
+                </form>
+                )
+            }
         </div>
     </div>
 </header>

--- a/astro/src/middleware.ts
+++ b/astro/src/middleware.ts
@@ -10,7 +10,7 @@ import {
 } from './utils/preview';
 import { ADMIN_COOKIE, verifyAdminCookie } from './utils/adminSession';
 import { legacyCfbTarget, staleRedirectTarget } from './utils/legacyCfb';
-import { FLAGS } from './utils/features';
+import { FLAGS, isFeatureEnabled } from './utils/features';
 
 const GAME_ID_RE = /\/game\/(\d+)/;
 
@@ -100,6 +100,18 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const previewCookie = readCookie(context.request.headers.get('cookie'), PREVIEW_COOKIE);
   if (previewCookie) {
     context.locals.preview = await verifyPreviewCookie(previewCookie, getSecret('ADMIN_PASS'));
+  }
+
+  // The NFL surface is a 'preview' feature (utils/features.ts). The explicit
+  // pages/nfl/** tree is reached only by a viewer holding the preview cookie --
+  // via /preview/nfl/... (previewRewrite) or the cookie on the public URL, which
+  // withPreviewCacheGuard keeps out of Workers Caching. Everyone else gets the
+  // site's 404, cacheable like any other. An access gate on a namespace, the
+  // same job the /admin block does below -- not a route rewrite: the URL and
+  // the page file stay one-to-one.
+  const effectivePath = previewRewrite ? new URL(previewRewrite, url).pathname : url.pathname;
+  if ((effectivePath === '/nfl' || effectivePath.startsWith('/nfl/')) && !isFeatureEnabled('nfl', context.locals)) {
+    previewRewrite = '/404';
   }
 
   if (url.pathname === '/admin' || url.pathname.startsWith('/admin/')) {

--- a/astro/src/pages/sitemap.xml.ts
+++ b/astro/src/pages/sitemap.xml.ts
@@ -3,6 +3,7 @@ import { retrieveAllTeams } from '../utils/teams';
 import { AVAILABLE_SEASONS, CURRENT_YEAR } from '../utils/constants';
 import { LEAGUES, teamCategoriesFor } from '../utils/league';
 import { LEADERBOARD_CATEGORIES, PLAYER_LEADERBOARD_CATEGORIES } from '../utils/seo';
+import { FLAGS } from '../utils/features';
 
 // Prerendered: this is built once at deploy time from local data (teams.json +
 // the season list) and costs nothing to serve. Deliberately makes no network
@@ -31,12 +32,17 @@ type Entry = { loc: string; lastmod: string; changefreq: string; priority: strin
 
 function buildEntries(): Entry[] {
     const today = new Date().toISOString().slice(0, 10);
+    // This file is prerendered -- there is no viewer to hold a preview cookie --
+    // so the NFL is advertised only once the 'nfl' flag is public; until then
+    // every /nfl URL is a 404 and a sitemap must never list one.
+    const nflPublic = FLAGS['nfl'] === 'on';
     const out: Entry[] = [
         { loc: '/', lastmod: today, changefreq: 'hourly', priority: '1.0' },
-        // the NFL scoreboard; its season/team URLs follow once the NFL tables exist
-        { loc: '/nfl', lastmod: today, changefreq: 'hourly', priority: '0.8' },
-        { loc: '/nfl/charts/trends', lastmod: today, changefreq: 'weekly', priority: '0.5' },
-        { loc: '/nfl/charts/builder', lastmod: today, changefreq: 'weekly', priority: '0.5' },
+        ...(nflPublic ? [
+            { loc: '/nfl', lastmod: today, changefreq: 'hourly', priority: '0.8' },
+            { loc: '/nfl/charts/trends', lastmod: today, changefreq: 'weekly', priority: '0.5' },
+            { loc: '/nfl/charts/builder', lastmod: today, changefreq: 'weekly', priority: '0.5' },
+        ] : []),
         // Trailing slashes are load-bearing: prerendered routes 307 to the
         // slashed form, and advertising a redirect wastes the crawl budget this
         // file exists to protect. Verified per-URL against production.
@@ -50,7 +56,7 @@ function buildEntries(): Entry[] {
     // the NFL mirrors the cfb season/leaderboard/team blocks below, prefixed;
     // its week schedules are listed too (the cfb ones are reached from /year/N)
     const nfl = LEAGUES.nfl;
-    for (const year of nfl.seasons) {
+    for (const year of nflPublic ? nfl.seasons : []) {
         const lastmod = seasonLastmod(year);
         const freq = year < CURRENT_YEAR ? 'yearly' : 'daily';
         out.push({ loc: `/nfl/year/${year}`, lastmod, changefreq: freq, priority: '0.6' });
@@ -82,7 +88,7 @@ function buildEntries(): Entry[] {
         for (const c of PLAYER_LEADERBOARD_CATEGORIES) out.push({ loc: `/year/${year}/players/${c}`, lastmod, changefreq: freq, priority: '0.6' });
     }
 
-    for (const league of ['cfb', 'nfl'] as const) {
+    for (const league of (nflPublic ? ['cfb', 'nfl'] : ['cfb']) as readonly ('cfb' | 'nfl')[]) {
         const lp = (p: string) => (league === 'cfb' ? p : `/nfl${p}`);
         if (league === 'nfl') out.push({ loc: '/nfl/teams', lastmod: today, changefreq: 'weekly', priority: '0.7' });
         for (const team of retrieveAllTeams(league)) {

--- a/astro/src/utils/features.ts
+++ b/astro/src/utils/features.ts
@@ -24,6 +24,11 @@ export const FLAGS: Record<string, FeatureState> = {
     // Mobile scoreboard: one-line rows (GameCompactRow) instead of cards under
     // 768px. Desktop keeps the card grid either way.
     'scoreboard-compact': 'preview',
+    // The whole NFL surface (pages/nfl/**, the header's league switch, the
+    // sitemap's /nfl URLs). Gated once in middleware: a viewer without the
+    // preview cookie gets the site's 404 for any /nfl path. Promote to 'on'
+    // when the NFL launches -- nothing else changes.
+    'nfl': 'preview',
 };
 
 export function isFeatureEnabled(name: string, locals: { preview?: boolean } | undefined): boolean {

--- a/astro/test/nflFlag.test.ts
+++ b/astro/test/nflFlag.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from 'vitest';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+
+// The NFL surface sits behind the 'nfl' feature flag (utils/features.ts):
+// middleware turns any /nfl path into the site's 404 unless the viewer holds
+// the preview cookie; the header offers the switch into the NFL only to such a
+// viewer. Promotion is 'preview' -> 'on' and nothing else.
+vi.mock('astro:env/server', () => ({ getSecret: (k: string) => (k === 'ADMIN_PASS' ? 'test-secret' : undefined) }));
+vi.mock('astro:middleware', () => ({ defineMiddleware: (fn: unknown) => fn }));
+
+import { onRequest } from '../src/middleware';
+import { mintPreviewCookie, PREVIEW_COOKIE } from '../src/utils/preview';
+import { FLAGS, isFeatureEnabled } from '../src/utils/features';
+
+async function run(path: string, cookie: string | null) {
+    const locals: Record<string, unknown> = {};
+    let rewrittenTo: string | undefined = 'never-called';
+    const ctx: any = {
+        request: new Request(`https://gameonpaper.com${path}`, {
+            headers: cookie ? { cookie: `${PREVIEW_COOKIE}=${cookie}` } : {},
+        }),
+        locals,
+        cache: { set: () => {} },
+        redirect: (l: string, status = 302) => new Response(null, { status, headers: { Location: l } }),
+    };
+    const res = await (onRequest as any)(ctx, async (to?: string) => { rewrittenTo = to; return new Response('ok'); });
+    return { locals, res, rewrittenTo };
+}
+
+describe('the nfl flag', () => {
+    test('is a preview feature until launch', () => {
+        expect(FLAGS['nfl']).toBe('preview');
+        expect(isFeatureEnabled('nfl', {})).toBe(false);
+        expect(isFeatureEnabled('nfl', { preview: true })).toBe(true);
+    });
+
+    test('a public viewer gets the 404 for every /nfl path, and only those', async () => {
+        for (const p of ['/nfl', '/nfl/', '/nfl/year/2025/teams/tendencies', '/nfl/game/401772944?span=q3']) {
+            expect((await run(p, null)).rewrittenTo, p).toBe('/404');
+        }
+        // the cfb site is untouched, and a path that merely starts with the letters is not the namespace
+        for (const p of ['/', '/year/2025/teams/differential', '/game/401752746', '/nflx']) {
+            expect((await run(p, null)).rewrittenTo, p).toBeUndefined();
+        }
+    });
+
+    test('the preview cookie on the public URL renders the NFL, uncacheable', async () => {
+        const { locals, res, rewrittenTo } = await run('/nfl/year/2025/teams/tendencies', await mintPreviewCookie('test-secret'));
+        expect(locals.preview).toBe(true);
+        expect(rewrittenTo).toBeUndefined();
+        expect(res.headers.get('Cache-Control')).toBe('no-store');
+    });
+
+    test('/preview/nfl/... composes: the strip happens first, then the gate admits the cookie holder', async () => {
+        const { rewrittenTo } = await run('/preview/nfl/year/2025/teams/luck?sort=x', await mintPreviewCookie('test-secret'));
+        expect(rewrittenTo).toBe('/nfl/year/2025/teams/luck?sort=x');
+        // without the cookie the preview surface bounces to the public path (which then 404s)
+        const bounced = await run('/preview/nfl', null);
+        expect(bounced.res.status).toBe(302);
+        expect(bounced.res.headers.get('Location')).toBe('/nfl');
+    });
+
+    test('the header offers the switch into the NFL only to a viewer the flag admits', async () => {
+        const container = await AstroContainer.create();
+        const { default: Header } = await import('../src/components/Header.astro');
+        const req = new Request('https://gameonpaper.com/');
+        const pub = await container.renderToString(Header, { request: req, locals: {} });
+        expect(pub).not.toContain('league-switch');
+        expect(pub).not.toContain('href="/nfl"');
+        const prev = await container.renderToString(Header, { request: req, locals: { preview: true } });
+        expect(prev).toContain('league-switch');
+        expect(prev).toContain('href="/nfl"');
+        // on the NFL side (already admitted) the switch back to CFB is always there
+        const nfl = await container.renderToString(Header, { request: new Request('https://gameonpaper.com/nfl'), locals: { league: 'nfl' } });
+        expect(nfl).toMatch(/league-switch[^>]*href="\/"|href="\/"[^>]*league-switch/);
+    }, 30_000);
+});

--- a/astro/test/sitemap.test.ts
+++ b/astro/test/sitemap.test.ts
@@ -48,21 +48,8 @@ describe('sitemap.xml', () => {
     expect(xml).not.toContain(`/year/${CURRENT_YEAR}/players`);
   });
 
-  test('the NFL mirrors the season, leaderboard and team blocks under /nfl', () => {
-    for (const c of ['differential', 'offensive', 'defensive', 'tendencies', 'fourth-downs', 'luck']) {
-      expect(xml).toContain(`<loc>https://gameonpaper.com/nfl/year/2025/teams/${c}</loc>`);
-    }
-    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/year/2025/players/passing</loc>');
-    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/teams</loc>');
-    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/team/12</loc>');
-    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/year/2002/team/12</loc>');
-    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/year/2020/type/2/week/17</loc>');
-    expect(xml).not.toContain('/nfl/year/2020/type/2/week/18');
-    // 2026 has no season table yet: no team-season page, and the leaderboards redirect
-    expect(xml).not.toContain(`/nfl/year/${CURRENT_YEAR}/team/`);
-    expect(xml).not.toContain(`/nfl/year/${CURRENT_YEAR}/teams`);
-    // the rbsdm extras are NFL-only
-    expect(xml).not.toContain('gameonpaper.com/year/2025/teams/tendencies</loc>');
+  test('no /nfl URL while the nfl flag is not public (they are 404s)', () => {
+    expect(xml).not.toContain('gameonpaper.com/nfl');
   });
 
   test('no doubled slashes or undefined leaked into a URL', () => {

--- a/astro/test/sitemapNflOn.test.ts
+++ b/astro/test/sitemapNflOn.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test, vi } from 'vitest';
+
+// The sitemap once the NFL is promoted ('nfl': 'on'): the /nfl season,
+// leaderboard and team blocks mirror the cfb ones. Kept as its own file so the
+// promotion path stays tested while the flag is still 'preview'.
+vi.mock('../src/utils/features', async (orig) => {
+    const real = await orig<typeof import('../src/utils/features')>();
+    return { ...real, FLAGS: { ...real.FLAGS, nfl: 'on' } };
+});
+
+import { GET } from '../src/pages/sitemap.xml';
+import { CURRENT_YEAR } from '../src/utils/constants';
+
+const xml: string = await ((GET as any)({} as any) as Response).text();
+
+describe('sitemap.xml with the nfl flag on', () => {
+  test('the NFL mirrors the season, leaderboard and team blocks under /nfl', () => {
+    expect(xml).toContain('<loc>https://gameonpaper.com/nfl</loc>');
+    for (const c of ['differential', 'offensive', 'defensive', 'tendencies', 'fourth-downs', 'luck']) {
+      expect(xml).toContain(`<loc>https://gameonpaper.com/nfl/year/2025/teams/${c}</loc>`);
+    }
+    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/year/2025/players/passing</loc>');
+    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/teams</loc>');
+    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/team/12</loc>');
+    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/year/2002/team/12</loc>');
+    expect(xml).toContain('<loc>https://gameonpaper.com/nfl/year/2020/type/2/week/17</loc>');
+    expect(xml).not.toContain('/nfl/year/2020/type/2/week/18');
+    // 2026 has no season table yet: no team-season page, and the leaderboards redirect
+    expect(xml).not.toContain(`/nfl/year/${CURRENT_YEAR}/team/`);
+    expect(xml).not.toContain(`/nfl/year/${CURRENT_YEAR}/teams`);
+    // the rbsdm extras are NFL-only
+    expect(xml).not.toContain('gameonpaper.com/year/2025/teams/tendencies</loc>');
+  });
+
+});


### PR DESCRIPTION
Per akeaswaran: *"we should put the NFL pages behind a feature flag for now."*

`FLAGS.nfl = 'preview'` — the existing admin-preview machinery in `utils/features.ts`. The NFL renders only for a viewer holding the preview cookie; everyone else gets the site's 404. Launch is a one-line `'preview' → 'on'`.

**How**
- **Middleware gate:** any `/nfl` effective path (after the `/preview` strip, so `/preview/nfl/...` composes) without the flag rewrites to `/404`. This is an access gate on a namespace — the same job the `/admin` block does — *not* the URL-routing rewrite from #229: the URL and page file stay one-to-one and `pages/nfl/**` is untouched. A cookie holder on the public URL renders the NFL and `withPreviewCacheGuard` keeps that response out of Workers Caching, so nothing preview-only can be served to the public.
- **Header:** the CFB → NFL switch is offered only to an admitted viewer; the switch back to CFB always renders.
- **Sitemap** (prerendered, no viewer): `/nfl` URLs listed only once the flag is `'on'` — a 404 must never be advertised.

**How to look at it:** `/preview/nfl/...` with the admin preview cookie (or the magic link from `/admin`), as with every other preview feature. Note the documented preview limitation applies: a publicly-cached `/nfl` 404 can be a cache HIT for a cookie holder on the *public* URL — use `/preview/nfl/...`.

**Tests** (245 passed, +2 files): flag pinned `'preview'`; the gate for `/nfl`, `/nfl/`, deep paths and query strings, with `/`, cfb routes and `/nflx` untouched; cookie on the public URL → renders + `no-store`; `/preview/nfl` composes and bounces without a cookie; header both ways; the promoted sitemap has its own test file (`sitemapNflOn.test.ts`) so the launch path stays covered while the flag is preview.

## Summary by Sourcery

Gate the NFL surface behind the existing preview feature flag until it is publicly launched.

New Features:
- Add preview feature-flag support for the NFL surface, allowing admitted preview viewers to access NFL pages and navigation.

Bug Fixes:
- Prevent non-admitted viewers from accessing NFL routes by serving the site's 404 response.
- Prevent preview-only NFL responses from being cached for public URL requests.
- Avoid advertising unavailable NFL routes in the sitemap.

Tests:
- Cover NFL flag behavior, route gating, preview access, header navigation, and sitemap output before and after launch promotion.