### PR TITLE
fix(api): resolve the conflict markers merged into python/app.py by #224

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -16,12 +16,9 @@ from telemetry import TEL, stage, init_flask
 import gop_routes
 import espn_proxy
 import dq
-<<<<<<< HEAD
 import paper_index
-=======
 from sportsdataverse.cfb import cfb_drive_summary as drive_summary
 from sportsdataverse.cfb import cfb_situational_stats as situational_stats
->>>>>>> origin/main
 import span_box
 
 # span key -> drive-summary period windows (drives book to their start quarter)
@@ -346,11 +343,6 @@ def _process_game(league: str, game_id: int):
         # processed_game, and everything after `return` is dead code -- which is
         # exactly where the DQ emit sat unnoticed until CodeRabbit flagged the
         # ordering (gop.dq_boxscore had zero rows since #192 merged).
-<<<<<<< HEAD
-        # Every standard window's box ships on every response
-        # (advBoxScoreSpans), so the frontend switches spans in place without
-        # a reload. The singular ?span= swap below stays for deep links.
-=======
         # StatBroadcast-style drive summary/chart. Cheap (one pass over ~25
         # drives + a few frame aggregations), so it ships on every response;
         # fail-open like everything else on this route.
@@ -391,7 +383,6 @@ def _process_game(league: str, game_id: int):
         # without a reload. Window-inherent sections (two-minute, middle-8,
         # pace, non-garbage, 4th-down report) stay on the full-game objects
         # only. The singular ?span= swap below stays for deep links.
->>>>>>> origin/main
         try:
             boxes = span_box.all_span_boxes(game)
             if boxes:
@@ -400,7 +391,6 @@ def _process_game(league: str, game_id: int):
             logging.getLogger("root").warning(
                 f"all-span boxes failed for {game_id}: {e}"
             )
-<<<<<<< HEAD
 
         # Paper Index: one who-won-on-paper share from six fitted margins
         # (python/paper_index.py; trained by tools/fit_paper_index.py).
@@ -417,7 +407,8 @@ def _process_game(league: str, game_id: int):
         except Exception as e:  # the index must never cost the page
             logging.getLogger("root").warning(
                 f"paper index failed for {game_id}: {e}"
-=======
+            )
+
         try:
             frame = getattr(game, "plays_frame", None)
             drv_all = (processed_game.get("drives") or {}).get("previous") or []
@@ -455,7 +446,6 @@ def _process_game(league: str, game_id: int):
         except Exception as e:  # a bad window must never cost the page
             logging.getLogger("root").warning(
                 f"all-span summaries failed for {game_id}: {e}"
->>>>>>> origin/main
             )
 
         raw_span = request.args.get("span")


### PR DESCRIPTION
**Broken main.** #224's merge commit landed with three unresolved conflict hunks in `python/app.py` (imports; the span-box comment vs the drive-summary/situational block; the paper-index block vs the all-span summaries block). CI runs vitest only, so the syntactically invalid module reached `main` and a deploy.

Both sides kept everywhere: `import paper_index` + the two sdv imports; the drive-summary + situational blocks with the longer closing comment; the paper-index block *and* the all-span summaries block. The file parses (`ast.parse`) and pytest passes 45/45 with the current sdv-py pin.

Root cause on my side: the resolution script's assertion failed and the shell chain did not gate on it. Follow-up worth doing: run pytest in CI (`test.yml` only runs vitest today), which would have blocked this.

## Summary by Sourcery

Bug Fixes:
- Remove unresolved Git conflict markers from `python/app.py` and restore the combined paper-index, drive-summary, situational-statistics, and all-span response processing so the application parses and runs correctly.