### PR TITLE
ci: run the Flask processor's pytest on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,21 @@ jobs:
       # shipping as an empty 200 -- which is exactly what happened on 2026-08-31.
       - run: npx vitest run
         working-directory: astro
+  pytest:
+    # The Flask processor. This job did not exist when #224's merge commit
+    # landed with unresolved conflict markers in python/app.py: vitest was green,
+    # the module did not parse, and the API deploy failed on restart. A syntax or
+    # import error here blocks the merge instead.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: python/uv.lock
+      - run: uv sync --locked
+        working-directory: python
+      - run: uv run pytest -q
+        working-directory: python
+        env:
+          PYTHON_HTTP_TOKEN: test


### PR DESCRIPTION
Follow-up to #239. `test.yml` ran vitest only, so #224's merge commit — `python/app.py` with unresolved conflict markers — went green, merged, and the API deploy failed on `Restart Docker Compose`.

Adds a `pytest` job: `astral-sh/setup-uv` + `uv sync --locked` (the lockfile pins sdv-py to a git commit, so `--locked` also catches a stale lock) + `uv run pytest -q` with the test token. Same commands as the local gate in `CLAUDE.md`. Verified locally: 45 passed.

## Summary by Sourcery

Run the Flask processor's pytest suite in pull-request CI to catch Python failures before they reach deployment.

Enhancements:
- Add a dedicated Flask processor test job to the pull-request CI workflow so Python syntax, import, and regression failures block merges.

CI:
- Set up the Python environment from the locked uv dependency file and run the Flask processor's pytest suite with the test HTTP token on every pull request.