### PR TITLE
fix(standings): NFL names by short name; trust ESPN's seed only for a whole group

### DIFF
--- a/astro/src/resources/espn.ts
+++ b/astro/src/resources/espn.ts
@@ -717,6 +717,8 @@ export interface ESPNStandingsEntry {
     team?: {
         id?: string
         location?: string
+        displayName?: string
+        shortDisplayName?: string
         abbreviation?: string
         logos?: { href: string }[]
     }

--- a/astro/src/utils/standings.ts
+++ b/astro/src/utils/standings.ts
@@ -128,9 +128,11 @@ export function parseStandingsEntry(entry: ESPNStandingsEntry, league: League = 
  * conference for CFB -- and ESPN's own order after that (the sort is stable).
  */
 export function sortStandings(rows: StandingsRow[], league: League = 'cfb'): StandingsRow[] {
+    // "W-L" or, in the NFL, "W-L-T": a tie is half a win, the league's own rule
     const winPct = (rec: string) => {
-        const [w, l] = rec.split("-").map(Number);
-        return Number.isFinite(w) && Number.isFinite(l) && w + l > 0 ? w / (w + l) : 0;
+        const [w, l, t = 0] = rec.split("-").map(Number);
+        const games = w + l + t;
+        return Number.isFinite(games) && games > 0 ? (w + t / 2) / games : 0;
     };
     const fullySeeded = rows.length > 0 && rows.every((r) => r.seed !== 999);
     if (fullySeeded) return rows.toSorted((a, b) => a.seed - b.seed);

--- a/astro/src/utils/standings.ts
+++ b/astro/src/utils/standings.ts
@@ -117,7 +117,6 @@ export function parseStandingsEntry(entry: ESPNStandingsEntry, league: League = 
     };
 }
 
-/** Conference order: seed when ESPN provides it, else conference win rate. */
 /**
  * ESPN's `playoffSeed` encodes the league's own tiebreak order, which is the
  * right primary key -- but only once ESPN has seeded the WHOLE group. Early in

--- a/astro/src/utils/standings.ts
+++ b/astro/src/utils/standings.ts
@@ -25,6 +25,7 @@ export interface StandingsGroup {
 function toGroup(
     c: ESPNConferenceStandings | null | undefined,
     fallbackId: string,
+    league: League,
     // ESPN abbreviates an NFL division to EAST/NORTH/SOUTH/WEST, which collides
     // across the two conferences -- the dropdown would list EAST twice. The full
     // name ("AFC East") is already short, so the NFL keeps it.
@@ -38,7 +39,7 @@ function toGroup(
         name,
         // the dropdown uses ESPN's short form, the standard the chart builder set
         shortName: preferFullName ? name : (c.shortName ?? c.abbreviation ?? name),
-        rows: sortStandings(entries.map(parseStandingsEntry)),
+        rows: sortStandings(entries.map((e) => parseStandingsEntry(e, league)), league),
     };
 }
 
@@ -55,8 +56,8 @@ export async function loadStandings(league: League): Promise<StandingsGroup[]> {
     const results = await Promise.all(ids.map((g) => retrieveConferenceStandings(g, league)));
     return results.flatMap((c, i) =>
         league === 'nfl'
-            ? (c?.children ?? []).map((d) => toGroup(d, `${ids[i]}-${d.id ?? ""}`, true))
-            : [toGroup(c, ids[i])],
+            ? (c?.children ?? []).map((d) => toGroup(d, `${ids[i]}-${d.id ?? ""}`, league, true))
+            : [toGroup(c, ids[i], league)],
     ).filter((g): g is StandingsGroup => !!g);
 }
 
@@ -67,6 +68,8 @@ export interface StandingsRow {
     logo?: string
     overall: string
     conference: string
+    /** "vs. Div." -- the NFL's tiebreak record; empty for CFB */
+    division: string
     pointsFor: number
     pointsAgainst: number
     pointDifferential: string
@@ -80,23 +83,32 @@ export interface StandingsRow {
  * streak, etc. with block-local values. The FIRST occurrence of each scalar is
  * the overall one; the records are addressed by their exact display names.
  */
-export function parseStandingsEntry(entry: ESPNStandingsEntry): StandingsRow {
+export function parseStandingsEntry(entry: ESPNStandingsEntry, league: League = 'cfb'): StandingsRow {
     const first: Record<string, string> = {};
     let overall = "";
     let conference = "";
+    let division = "";
     for (const s of entry.stats ?? []) {
         const name = s.name ?? "";
         if (name === "overall" && !overall) overall = s.displayValue ?? "";
         else if (name === "vs. Conf." && !conference) conference = s.displayValue ?? "";
+        else if (name === "vs. Div." && !division) division = s.displayValue ?? "";
         else if (!(name in first)) first[name] = s.displayValue ?? "";
     }
+    // CFB reads as the location ("Ohio State"). The NFL cannot: two New Yorks
+    // and two Los Angeleses share a city, so it takes ESPN's short name
+    // ("Jets", "Giants"), which is what every NFL standings table prints.
+    const name = league === 'nfl'
+        ? (entry.team?.shortDisplayName ?? entry.team?.displayName ?? entry.team?.abbreviation ?? "")
+        : (entry.team?.location ?? entry.team?.abbreviation ?? "");
     return {
         teamId: String(entry.team?.id ?? ""),
-        name: entry.team?.location ?? entry.team?.abbreviation ?? "",
+        name,
         abbreviation: entry.team?.abbreviation,
         logo: entry.team?.logos?.[0]?.href,
         overall,
         conference,
+        division,
         pointsFor: Number(first["pointsFor"] ?? 0),
         pointsAgainst: Number(first["pointsAgainst"] ?? 0),
         pointDifferential: first["pointDifferential"] ?? "0",
@@ -106,12 +118,24 @@ export function parseStandingsEntry(entry: ESPNStandingsEntry): StandingsRow {
 }
 
 /** Conference order: seed when ESPN provides it, else conference win rate. */
-export function sortStandings(rows: StandingsRow[]): StandingsRow[] {
+/**
+ * ESPN's `playoffSeed` encodes the league's own tiebreak order, which is the
+ * right primary key -- but only once ESPN has seeded the WHOLE group. Early in
+ * a season it seeds the teams that have played and leaves the rest at 0, so a
+ * 0-1 team arrives as "seed 1" above three 0-0 teams (AFC East, week 2 2026).
+ * A partially seeded group therefore falls back to the record: overall win
+ * percentage, then the league's tiebreak record -- division for the NFL,
+ * conference for CFB -- and ESPN's own order after that (the sort is stable).
+ */
+export function sortStandings(rows: StandingsRow[], league: League = 'cfb'): StandingsRow[] {
     const winPct = (rec: string) => {
         const [w, l] = rec.split("-").map(Number);
         return Number.isFinite(w) && Number.isFinite(l) && w + l > 0 ? w / (w + l) : 0;
     };
-    return rows.toSorted((a, b) =>
-        a.seed !== b.seed ? a.seed - b.seed : winPct(b.conference) - winPct(a.conference)
+    const fullySeeded = rows.length > 0 && rows.every((r) => r.seed !== 999);
+    if (fullySeeded) return rows.toSorted((a, b) => a.seed - b.seed);
+    const tiebreak = (r: StandingsRow) => (league === 'nfl' ? r.division : r.conference);
+    return rows.toSorted(
+        (a, b) => winPct(b.overall) - winPct(a.overall) || winPct(tiebreak(b)) - winPct(tiebreak(a)),
     );
 }

--- a/astro/test/standings.test.ts
+++ b/astro/test/standings.test.ts
@@ -28,6 +28,7 @@ describe("parseStandingsEntry", () => {
             logo: "x.png",
             overall: "1-0",
             conference: "0-0",
+            division: "",
             pointsFor: 48,
             pointsAgainst: 10,
             pointDifferential: "+38",
@@ -35,15 +36,41 @@ describe("parseStandingsEntry", () => {
             seed: 1,
         });
     });
+
+    it("names an NFL team by its short name, since two share a city", () => {
+        const jets = { ...entry, team: { id: "2", location: "New York", shortDisplayName: "Jets", abbreviation: "NYJ" } };
+        expect(parseStandingsEntry(jets, "nfl").name).toBe("Jets");
+        expect(parseStandingsEntry(jets, "cfb").name).toBe("New York");
+    });
 });
 
 describe("sortStandings", () => {
-    it("orders by seed, then conference win rate", () => {
+    it("uses ESPN's seed only once the whole group is seeded", () => {
         const rows = [
-            { seed: 999, conference: "1-1", name: "B" },
-            { seed: 1, conference: "0-0", name: "A" },
-            { seed: 999, conference: "2-0", name: "C" },
-        ] as any;
-        expect(sortStandings(rows).map((r: any) => r.name)).toEqual(["A", "C", "B"]);
+            { seed: 2, overall: "1-0", conference: "0-0", division: "", name: "B" },
+            { seed: 1, overall: "1-0", conference: "0-0", division: "", name: "A" },
+            { seed: 3, overall: "0-1", conference: "0-0", division: "", name: "C" },
+        ] as any[];
+        expect(sortStandings(rows).map((r: any) => r.name)).toEqual(["A", "B", "C"]);
+    });
+
+    it("a partially seeded group falls back to the record, not the lone seed", () => {
+        // AFC East, week 2 2026: ESPN seeded the only team that had played --
+        // at 0-1 -- and left the 0-0 teams at 0. Seed-first put the loser on top.
+        const rows = [
+            { seed: 999, overall: "0-0", conference: "0-0", division: "0-0", name: "Bills" },
+            { seed: 999, overall: "0-0", conference: "0-0", division: "0-0", name: "Dolphins" },
+            { seed: 1, overall: "0-1", conference: "0-0", division: "0-0", name: "Patriots" },
+        ] as any[];
+        expect(sortStandings(rows, "nfl").map((r: any) => r.name)).toEqual(["Bills", "Dolphins", "Patriots"]);
+    });
+
+    it("breaks ties on the league's own record: division for the NFL, conference for CFB", () => {
+        const rows = [
+            { seed: 999, overall: "2-1", conference: "1-1", division: "0-1", name: "confStrong" },
+            { seed: 999, overall: "2-1", conference: "0-1", division: "1-0", name: "divStrong" },
+        ] as any[];
+        expect(sortStandings(rows, "nfl").map((r: any) => r.name)).toEqual(["divStrong", "confStrong"]);
+        expect(sortStandings(rows, "cfb").map((r: any) => r.name)).toEqual(["confStrong", "divStrong"]);
     });
 });

--- a/astro/test/standings.test.ts
+++ b/astro/test/standings.test.ts
@@ -65,6 +65,16 @@ describe("sortStandings", () => {
         expect(sortStandings(rows, "nfl").map((r: any) => r.name)).toEqual(["Bills", "Dolphins", "Patriots"]);
     });
 
+    it("counts an NFL tie as half a win in the fallback", () => {
+        const rows = [
+            { seed: 999, overall: "1-0-1", conference: "0-0", division: "0-0", name: "tied" },   // .750
+            { seed: 999, overall: "1-1", conference: "0-0", division: "0-0", name: "even" },     // .500
+            { seed: 999, overall: "0-0-1", conference: "0-0", division: "0-0", name: "onlyTie" }, // .500, not .000
+            { seed: 999, overall: "0-1", conference: "0-0", division: "0-0", name: "lost" },     // .000
+        ] as any[];
+        expect(sortStandings(rows, "nfl").map((r: any) => r.name)).toEqual(["tied", "even", "onlyTie", "lost"]);
+    });
+
     it("breaks ties on the league's own record: division for the NFL, conference for CFB", () => {
         const rows = [
             { seed: 999, overall: "2-1", conference: "1-1", division: "0-1", name: "confStrong" },


### PR DESCRIPTION
Cherry-pick of `1585c84`, which I pushed to `feat/rankings-page` a few minutes after #228 had already merged, so it never reached main. Both defects showed on the first real render of `/nfl/standings` (preview-gated, so not public — but deployed).

**"New York" and "Los Angeles" each appeared twice.** CFB's `team.location` convention cannot name a league where two teams share a city. NFL rows now take ESPN's `shortDisplayName` ("Jets", "Giants"), which is what every NFL standings table prints; CFB keeps the location.

**New England sat 0-1 above three 0-0 teams.** ESPN's `playoffSeed` is the right primary key — it encodes the league's own tiebreak order — but early in a season ESPN seeds only the teams that have played and leaves the rest at 0, so the lone loser arrived as "seed 1" (live AFC East payload: BUF/MIA/NYJ seed 0, NE seed 1 at 0-1). A group is now sorted by seed only when **every** team in it is seeded; otherwise by overall win%, then the league's tiebreak record — `vs. Div.` for the NFL (newly parsed into the row), `vs. Conf.` for CFB — with ESPN's order after that.

The prior sort test encoded the bug (a lone seed hoisted) and is replaced by the three cases of the rule; `ESPNStandingsEntry.team` gains `shortDisplayName`/`displayName` so the Cloudflare build type-checks. 259 tests pass. Verified live against the dev server: `Jets`/`Giants` render, "New York" does not, and the AFC East lists Bills/Dolphins ahead of the Patriots.

## Summary by Sourcery

Correct NFL standings team names and ordering by using unambiguous team labels and reliable league-aware sorting rules.

Bug Fixes:
- Use NFL team short names to prevent duplicate city labels in standings.
- Prevent partially populated ESPN playoff seeds from incorrectly placing teams above others, while preserving seed ordering for fully seeded groups.
- Apply league-specific tiebreak records and NFL tie-aware winning percentages when sorting standings.

Enhancements:
- Extend standings data to include NFL division records and team display-name fields.

Tests:
- Replace the seed-ordering regression test with coverage for complete and partial seeding, NFL ties, and league-specific tiebreakers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved standings ordering when teams have incomplete seeding information.
  - Added league-specific tiebreakers for tied records, using division performance for NFL and conference performance for college football.
  - NFL standings now display teams using their shorter names and include division records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->